### PR TITLE
Use oauth secure cookie (__cf_bm, cf_clearance) to login

### DIFF
--- a/core/datastore/src/commonMain/kotlin/me/matsumo/fanbox/core/datastore/FanboxCookieDataStore.kt
+++ b/core/datastore/src/commonMain/kotlin/me/matsumo/fanbox/core/datastore/FanboxCookieDataStore.kt
@@ -39,9 +39,7 @@ class FanboxCookieDataStore(
     }
 
     suspend fun getCookies(): List<String> {
-        return (get()?.split(";")?.filter { it.isNotBlank() } ?: emptyList()).also {
-            Napier.d("CookieDataStore getCookies: ${it.joinToString(";")}")
-        }
+        return (get()?.split(";")?.filter { it.isNotBlank() } ?: emptyList())
     }
 
     private fun List<String>.toCookiesMap(): Map<String, String> {

--- a/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/FanboxRepository.kt
+++ b/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/FanboxRepository.kt
@@ -526,18 +526,7 @@ class FanboxRepositoryImpl(
         header("origin", "https://www.fanbox.cc")
         header("referer", "https://www.fanbox.cc")
         header("user-agent", "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Mobile Safari/537.36")
-        header("accept", "application/json, text/plain, */*")
-        header("accept-language", "ja-JP,ja;q=0.9,en-US;q=0.8,en;q=0.7")
-        header("accept-encoding", "gzip, deflate, br")
-        header("Content-Type", "application/json")
-        header("Sec-Ch-Ua", "\"Not-A.Brand\";v=\"99\",\"Chromium\";v=\"124")
-        header("Sec-Ch-Ua-Mobile", "?1")
-        header("Sec-Ch-Ua-Platform", "\"Android\"")
-        header("Sec-Fetch-Dest", "empty")
-        header("Sec-Fetch-Mode", "cors")
-        header("Sec-Fetch-Site", "same-site")
         header("x-csrf-token", metaData.first().csrfToken)
-        header("Cookie", cookie.first())
     }
 
     companion object {

--- a/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/client/CookiesStorage.kt
+++ b/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/client/CookiesStorage.kt
@@ -1,5 +1,6 @@
 package me.matsumo.fanbox.core.repository.client
 
+import io.github.aakira.napier.Napier
 import io.ktor.client.plugins.cookies.CookiesStorage
 import io.ktor.http.Cookie
 import io.ktor.http.Url
@@ -15,7 +16,9 @@ class CookiesStorage(
     private val mutex = Mutex()
 
     override suspend fun addCookie(requestUrl: Url, cookie: Cookie): Unit = mutex.withLock {
-        cookieDataStore.addCookies(listOf("${cookie.name}=${cookie.value}"))
+        // Napier.d { "addCookie: $requestUrl ${cookie.name}=${cookie.value}" }
+        // if (!listOf("__cf_bm", "cf_clearance", "FANBOXSESSID").contains(cookie.name)) return@withLock
+        // cookieDataStore.addCookies(listOf("${cookie.name}=${cookie.value}"))
     }
 
     override suspend fun get(requestUrl: Url): List<Cookie> = mutex.withLock {

--- a/feature/welcome/src/commonMain/kotlin/me/matsumo/fanbox/feature/welcome/login/WelcomeLoginViewModel.kt
+++ b/feature/welcome/src/commonMain/kotlin/me/matsumo/fanbox/feature/welcome/login/WelcomeLoginViewModel.kt
@@ -38,7 +38,7 @@ class WelcomeLoginViewModel(
     fun setSessionId(sessionId: String) {
         viewModelScope.launch {
             suspendRunCatching {
-                fanboxRepository.updateCookie("FANBOXSESSID=$sessionId;")
+                // fanboxRepository.updateCookie("FANBOXSESSID=$sessionId;")
                 fanboxRepository.updateCsrfToken()
                 fanboxRepository.getNewsLetters()
                 setDefaultHomeTab()

--- a/feature/welcome/src/commonMain/kotlin/me/matsumo/fanbox/feature/welcome/web/WelcomeWebScreen.kt
+++ b/feature/welcome/src/commonMain/kotlin/me/matsumo/fanbox/feature/welcome/web/WelcomeWebScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.ui.Modifier
 import com.multiplatform.webview.web.LoadingState
 import com.multiplatform.webview.web.WebView
 import com.multiplatform.webview.web.rememberWebViewState
-import io.github.aakira.napier.Napier
 import me.matsumo.fanbox.core.ui.Res
 import me.matsumo.fanbox.core.ui.component.PixiViewTopBar
 import me.matsumo.fanbox.core.ui.view.SimpleAlertContents
@@ -52,11 +51,13 @@ internal fun WelcomeWebScreen(
     }
 
     LaunchedEffect(webViewState.lastLoadedUrl) {
-        Napier.d("lastLoadedUrl: ${webViewState.lastLoadedUrl}")
-
         if (webViewState.lastLoadedUrl == fanboxRedirectUrl) {
-            val cookies = webViewState.cookieManager.getCookies("https://www.fanbox.cc")
-            val cookieString = cookies.joinToString(";") { "${it.name}=${it.value}" }
+            val oauthCookies = webViewState.cookieManager.getCookies("https://oauth.secure.pixiv.net").associate { it.name to it.value }
+            val fanboxCookies = webViewState.cookieManager.getCookies("https://www.fanbox.cc").associate { it.name to it.value }
+            val cookieString = (fanboxCookies + oauthCookies)
+                .filterKeys { listOf("__cf_bm", "cf_clearance", "FANBOXSESSID").contains(it) }
+                .map { "${it.key}=${it.value}" }
+                .joinToString(";")
 
             viewModel.saveCookie(cookieString)
             terminate.invoke()


### PR DESCRIPTION
# Related links
- closes #4 

# Why?
- FANBOXとの通信の際のセキュリティ要件が上がり（cloudflare challenge による認証が挟まった）、既存の実装では403となってログインできない状態でした

# How?
- ログインの初回のみ cloudflare challenge を受け、ユーザー自身の手で合格してもらうことで oauth secure cookie (`__cf_bm`, `cf_clearance`) を取得し、以降はそれを使い回すようにします

# Testing :mag:
- 複数アカウントでのログインチェック