### PR TITLE
Fix parsing error in post details screen caused by FANBOX API response type change

### DIFF
--- a/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/FanboxComments.kt
+++ b/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/FanboxComments.kt
@@ -1,0 +1,22 @@
+package me.matsumo.fanbox.core.model.fanbox
+
+import kotlinx.datetime.Instant
+import me.matsumo.fanbox.core.model.fanbox.id.CommentId
+
+data class FanboxComments(
+    val items: List<Item>,
+    val nextUrl: String?,
+) {
+    data class Item(
+        val body: String,
+        val createdDatetime: Instant,
+        val id: CommentId,
+        val isLiked: Boolean,
+        val isOwn: Boolean,
+        val likeCount: Int,
+        val parentCommentId: CommentId,
+        val rootCommentId: CommentId,
+        val replies: List<Item>,
+        val user: FanboxUser,
+    )
+}

--- a/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/FanboxPostDetail.kt
+++ b/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/FanboxPostDetail.kt
@@ -1,8 +1,6 @@
 package me.matsumo.fanbox.core.model.fanbox
 
 import kotlinx.datetime.Instant
-import me.matsumo.fanbox.core.model.PageOffsetInfo
-import me.matsumo.fanbox.core.model.fanbox.id.CommentId
 import me.matsumo.fanbox.core.model.fanbox.id.PostId
 
 data class FanboxPostDetail(
@@ -11,7 +9,6 @@ data class FanboxPostDetail(
     val body: Body,
     val coverImageUrl: String?,
     val commentCount: Int,
-    val commentList: PageOffsetInfo<Comment.CommentItem>,
     val excerpt: String,
     val feeRequired: Int,
     val hasAdultContent: Boolean,
@@ -97,24 +94,6 @@ data class FanboxPostDetail(
         data object Unknown : Body
     }
 
-    data class Comment(
-        val items: List<CommentItem>,
-        val nextUrl: String?,
-    ) {
-        data class CommentItem(
-            val body: String,
-            val createdDatetime: Instant,
-            val id: CommentId,
-            val isLiked: Boolean,
-            val isOwn: Boolean,
-            val likeCount: Int,
-            val parentCommentId: CommentId,
-            val rootCommentId: CommentId,
-            val replies: List<CommentItem>,
-            val user: FanboxUser,
-        )
-    }
-
     data class OtherPost(
         val id: PostId,
         val title: String,
@@ -158,35 +137,6 @@ data class FanboxPostDetail(
             body = Body.Unknown,
             coverImageUrl = null,
             commentCount = 3,
-            commentList = PageOffsetInfo(
-                contents = listOf(
-                    Comment.CommentItem(
-                        body = "かわいい～！",
-                        createdDatetime = Instant.parse("2024-01-01T00:00:00"),
-                        id = CommentId("123"),
-                        isLiked = false,
-                        isOwn = false,
-                        likeCount = 0,
-                        parentCommentId = CommentId(""),
-                        rootCommentId = CommentId(""),
-                        replies = emptyList(),
-                        user = FanboxUser.dummy(),
-                    ),
-                    Comment.CommentItem(
-                        body = "なるほどこれが天才か...",
-                        createdDatetime = Instant.parse("2024-01-01T00:00:00"),
-                        id = CommentId("124"),
-                        isLiked = false,
-                        isOwn = false,
-                        likeCount = 0,
-                        parentCommentId = CommentId(""),
-                        rootCommentId = CommentId(""),
-                        replies = emptyList(),
-                        user = FanboxUser.dummy(),
-                    ),
-                ),
-                offset = null,
-            ),
             excerpt = "リクエストありがとうございました！",
             feeRequired = 0,
             hasAdultContent = true,

--- a/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/entity/FanboxCommentsEntity.kt
+++ b/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/entity/FanboxCommentsEntity.kt
@@ -1,0 +1,46 @@
+package me.matsumo.fanbox.core.model.fanbox.entity
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class FanboxCommentsEntity(
+    @SerialName("items")
+    val items: List<Item>,
+    @SerialName("nextUrl")
+    val nextUrl: String?,
+) {
+    @Serializable
+    data class Item(
+        @SerialName("body")
+        val body: String,
+        @SerialName("createdDatetime")
+        val createdDatetime: String,
+        @SerialName("id")
+        val id: String,
+        @SerialName("isLiked")
+        val isLiked: Boolean,
+        @SerialName("isOwn")
+        val isOwn: Boolean,
+        @SerialName("likeCount")
+        val likeCount: Int,
+        @SerialName("parentCommentId")
+        val parentCommentId: String,
+        @SerialName("rootCommentId")
+        val rootCommentId: String,
+        @SerialName("user")
+        val user: User,
+        @SerialName("replies")
+        val replies: List<Item> = emptyList(),
+    ) {
+        @Serializable
+        data class User(
+            @SerialName("iconUrl")
+            val iconUrl: String?,
+            @SerialName("name")
+            val name: String,
+            @SerialName("userId")
+            val userId: String,
+        )
+    }
+}

--- a/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/entity/FanboxPostCommentItemsEntity.kt
+++ b/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/entity/FanboxPostCommentItemsEntity.kt
@@ -6,5 +6,5 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class FanboxPostCommentItemsEntity(
     @SerialName("body")
-    val body: FanboxPostDetailEntity.Body.CommentList,
+    val body: FanboxCommentsEntity,
 )

--- a/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/entity/FanboxPostDetailEntity.kt
+++ b/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/entity/FanboxPostDetailEntity.kt
@@ -12,7 +12,6 @@ data class FanboxPostDetailEntity(
     data class Body(
         @SerialName("body") val body: Body?,
         @SerialName("commentCount") val commentCount: Int,
-        @SerialName("commentList") val commentList: CommentList,
         @SerialName("creatorId") val creatorId: String,
         @SerialName("excerpt") val excerpt: String,
         @SerialName("feeRequired") val feeRequired: Int,
@@ -97,48 +96,6 @@ data class FanboxPostDetailEntity(
                 @SerialName("postInfo")
                 val postInfo: FanboxPostItemsEntity.Body.Item?,
             )
-        }
-
-        @Serializable
-        data class CommentList(
-            @SerialName("items")
-            val items: List<Item>,
-            @SerialName("nextUrl")
-            val nextUrl: String?,
-        ) {
-            @Serializable
-            data class Item(
-                @SerialName("body")
-                val body: String,
-                @SerialName("createdDatetime")
-                val createdDatetime: String,
-                @SerialName("id")
-                val id: String,
-                @SerialName("isLiked")
-                val isLiked: Boolean,
-                @SerialName("isOwn")
-                val isOwn: Boolean,
-                @SerialName("likeCount")
-                val likeCount: Int,
-                @SerialName("parentCommentId")
-                val parentCommentId: String,
-                @SerialName("rootCommentId")
-                val rootCommentId: String,
-                @SerialName("user")
-                val user: User,
-                @SerialName("replies")
-                val replies: List<Item> = emptyList(),
-            ) {
-                @Serializable
-                data class User(
-                    @SerialName("iconUrl")
-                    val iconUrl: String?,
-                    @SerialName("name")
-                    val name: String,
-                    @SerialName("userId")
-                    val userId: String,
-                )
-            }
         }
 
         @Serializable

--- a/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/FanboxRepository.kt
+++ b/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/FanboxRepository.kt
@@ -44,6 +44,7 @@ import me.matsumo.fanbox.core.model.PageCursorInfo
 import me.matsumo.fanbox.core.model.PageNumberInfo
 import me.matsumo.fanbox.core.model.PageOffsetInfo
 import me.matsumo.fanbox.core.model.fanbox.FanboxBell
+import me.matsumo.fanbox.core.model.fanbox.FanboxComments
 import me.matsumo.fanbox.core.model.fanbox.FanboxCreatorDetail
 import me.matsumo.fanbox.core.model.fanbox.FanboxCreatorPlan
 import me.matsumo.fanbox.core.model.fanbox.FanboxCreatorPlanDetail
@@ -104,7 +105,7 @@ interface FanboxRepository {
     suspend fun getCreatorPostsPaginate(creatorId: CreatorId): List<FanboxCursor>
     suspend fun getPost(postId: PostId): FanboxPostDetail
     suspend fun getPostCached(postId: PostId): FanboxPostDetail
-    suspend fun getPostComment(postId: PostId, offset: Int = 0): PageOffsetInfo<FanboxPostDetail.Comment.CommentItem>
+    suspend fun getPostComment(postId: PostId, offset: Int = 0): PageOffsetInfo<FanboxComments.Item>
     suspend fun getPostFromQuery(query: String, creatorId: CreatorId? = null, page: Int = 0): PageNumberInfo<FanboxPost>
     suspend fun getCreatorFromQuery(query: String, page: Int = 0): PageNumberInfo<FanboxCreatorDetail>
     suspend fun getTagFromQuery(query: String): List<FanboxTag>
@@ -292,7 +293,7 @@ class FanboxRepositoryImpl(
         postCache.getOrPut(postId) { getPost(postId) }
     }
 
-    override suspend fun getPostComment(postId: PostId, offset: Int): PageOffsetInfo<FanboxPostDetail.Comment.CommentItem> =
+    override suspend fun getPostComment(postId: PostId, offset: Int): PageOffsetInfo<FanboxComments.Item> =
         withContext(ioDispatcher) {
             get("post.listComments", mapOf("postId" to postId.value, "offset" to offset.toString(), "limit" to "10")).parse<FanboxPostCommentItemsEntity>()!!.translate()
         }

--- a/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/utils/FanboxTranslator.kt
+++ b/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/utils/FanboxTranslator.kt
@@ -8,6 +8,7 @@ import me.matsumo.fanbox.core.model.PageCursorInfo
 import me.matsumo.fanbox.core.model.PageNumberInfo
 import me.matsumo.fanbox.core.model.PageOffsetInfo
 import me.matsumo.fanbox.core.model.fanbox.FanboxBell
+import me.matsumo.fanbox.core.model.fanbox.FanboxComments
 import me.matsumo.fanbox.core.model.fanbox.FanboxCover
 import me.matsumo.fanbox.core.model.fanbox.FanboxCreator
 import me.matsumo.fanbox.core.model.fanbox.FanboxCreatorDetail
@@ -23,6 +24,7 @@ import me.matsumo.fanbox.core.model.fanbox.FanboxPostDetail
 import me.matsumo.fanbox.core.model.fanbox.FanboxUser
 import me.matsumo.fanbox.core.model.fanbox.PaymentMethod
 import me.matsumo.fanbox.core.model.fanbox.entity.FanboxBellItemsEntity
+import me.matsumo.fanbox.core.model.fanbox.entity.FanboxCommentsEntity
 import me.matsumo.fanbox.core.model.fanbox.entity.FanboxCreatorEntity
 import me.matsumo.fanbox.core.model.fanbox.entity.FanboxCreatorItemsEntity
 import me.matsumo.fanbox.core.model.fanbox.entity.FanboxCreatorPlanEntity
@@ -290,10 +292,6 @@ internal fun FanboxPostDetailEntity.translate(bookmarkedPosts: List<PostId>): Fa
         ),
         body = bodyBlock,
         excerpt = body.excerpt,
-        commentList = PageOffsetInfo(
-            contents = body.commentList.items.map { it.translate() },
-            offset = body.commentList.nextUrl?.let { Url(it).parameters["offset"]?.toIntOrNull() },
-        ),
         nextPost = body.nextPost?.let {
             FanboxPostDetail.OtherPost(
                 id = PostId(it.id),
@@ -312,8 +310,8 @@ internal fun FanboxPostDetailEntity.translate(bookmarkedPosts: List<PostId>): Fa
     )
 }
 
-internal fun FanboxPostDetailEntity.Body.CommentList.Item.translate(): FanboxPostDetail.Comment.CommentItem {
-    return FanboxPostDetail.Comment.CommentItem(
+internal fun FanboxCommentsEntity.Item.translate(): FanboxComments.Item {
+    return FanboxComments.Item(
         body = body,
         createdDatetime = Instant.parse(createdDatetime),
         id = CommentId(id),
@@ -529,10 +527,10 @@ internal fun FanboxPostSearchEntity.translate(bookmarkedPosts: List<PostId>): Pa
     )
 }
 
-internal fun FanboxPostCommentItemsEntity.translate(): PageOffsetInfo<FanboxPostDetail.Comment.CommentItem> {
+internal fun FanboxPostCommentItemsEntity.translate(): PageOffsetInfo<FanboxComments.Item> {
     return PageOffsetInfo(
         contents = body.items.map { it.translate() },
-        offset = body.nextUrl?.let { Url(it).parameters["page"]?.toIntOrNull() },
+        offset = body.nextUrl?.let { Url(it).parameters["offset"]?.toIntOrNull() },
     )
 }
 

--- a/core/ui/src/commonMain/composeResources/values-ja/strings.xml
+++ b/core/ui/src/commonMain/composeResources/values-ja/strings.xml
@@ -58,6 +58,7 @@
     <string name="error_adult_content_test_user">このコンテンツは一時的に制限されています</string>
     <string name="error_adult_content_description">表示する</string>
     <string name="error_ios_gif_support">iOS での GIF のプレビューは\n現在開発中です</string>
+    <string name="error_service_status">サービス稼働状況</string>
 
     <!-- Common Unit -->
     <string name="unit_day_before">%1$d日前</string>

--- a/core/ui/src/commonMain/composeResources/values-ko/strings.xml
+++ b/core/ui/src/commonMain/composeResources/values-ko/strings.xml
@@ -54,6 +54,7 @@
     <string name="error_adult_content">성인 콘텐츠</string>
     <string name="error_adult_content_test_user">이 콘텐츠는 일시적으로 제한되었습니다</string>
     <string name="error_adult_content_description">더보기</string>
+    <string name="error_service_status">서비스 운영 현황</string>
 
     <!-- Common Unit -->
     <string name="unit_day_before">%1$d일 전</string>

--- a/core/ui/src/commonMain/composeResources/values-zh-rCN/strings.xml
+++ b/core/ui/src/commonMain/composeResources/values-zh-rCN/strings.xml
@@ -58,6 +58,7 @@
     <string name="error_adult_content_test_user">此内容已被暂时限制</string>
     <string name="error_adult_content_description">显示</string>
     <string name="error_ios_gif_support">iOS上的GIF预览目前正在开发中</string>
+    <string name="error_service_status">服务可用性</string>
 
     <!-- Common Unit -->
     <string name="unit_day_before">%1$d天前</string>

--- a/core/ui/src/commonMain/composeResources/values/strings.xml
+++ b/core/ui/src/commonMain/composeResources/values/strings.xml
@@ -58,6 +58,7 @@
     <string name="error_adult_content_test_user">This content has been temporarily restricted</string>
     <string name="error_adult_content_description">Show</string>
     <string name="error_ios_gif_support">GIF preview on iOS is currently in development</string>
+    <string name="error_service_status">Service operation status</string>
 
     <!-- Common Unit -->
     <string name="unit_day_before">%1$d days ago</string>

--- a/core/ui/src/commonMain/kotlin/me/matsumo/fanbox/core/ui/view/ErrorView.kt
+++ b/core/ui/src/commonMain/kotlin/me/matsumo/fanbox/core/ui/view/ErrorView.kt
@@ -5,21 +5,30 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import me.matsumo.fanbox.core.model.ScreenState
 import me.matsumo.fanbox.core.ui.Res
 import me.matsumo.fanbox.core.ui.common_reload
 import me.matsumo.fanbox.core.ui.error_executed
+import me.matsumo.fanbox.core.ui.error_service_status
+import me.matsumo.fanbox.core.ui.extensition.NavigatorExtension
 import me.matsumo.fanbox.core.ui.theme.bold
 import me.matsumo.fanbox.core.ui.theme.center
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.koinInject
 
 @Composable
 fun ErrorView(
@@ -29,6 +38,8 @@ fun ErrorView(
     retryTitle: StringResource? = null,
     retryAction: (() -> Unit)? = null,
 ) {
+    val navigatorExtension = koinInject<NavigatorExtension>()
+
     Column(
         modifier = modifier
             .background(MaterialTheme.colorScheme.surface)
@@ -64,6 +75,31 @@ fun ErrorView(
                     color = MaterialTheme.colorScheme.onPrimary,
                 )
             }
+        }
+
+        TextButton(
+            modifier = Modifier.padding(top = 24.dp),
+            onClick = {
+                navigatorExtension.navigateToWebPage(
+                    url = "https://github.com/matsumo0922/PixiView-KMP/blob/master/STATUS.md",
+                    referrer = "ErrorView",
+                )
+            },
+        ) {
+            Icon(
+                modifier = Modifier.size(14.dp),
+                imageVector = Icons.Outlined.Info,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            Text(
+                modifier = Modifier.padding(start = 4.dp),
+                text = stringResource(Res.string.error_service_status),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textDecoration = TextDecoration.Underline,
+            )
         }
     }
 }

--- a/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/detail/PostDetailScreen.kt
+++ b/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/detail/PostDetailScreen.kt
@@ -45,8 +45,10 @@ import kotlinx.coroutines.launch
 import me.matsumo.fanbox.core.common.util.format
 import me.matsumo.fanbox.core.logs.category.PostsLog
 import me.matsumo.fanbox.core.logs.logger.send
+import me.matsumo.fanbox.core.model.PageOffsetInfo
 import me.matsumo.fanbox.core.model.ScreenState
 import me.matsumo.fanbox.core.model.UserData
+import me.matsumo.fanbox.core.model.fanbox.FanboxComments
 import me.matsumo.fanbox.core.model.fanbox.FanboxCreatorDetail
 import me.matsumo.fanbox.core.model.fanbox.FanboxMetaData
 import me.matsumo.fanbox.core.model.fanbox.FanboxPost
@@ -195,6 +197,7 @@ private fun PostDetailView(
         PostDetailScreen(
             modifier = Modifier.fillMaxSize(),
             postDetail = uiState.postDetail,
+            comments = uiState.comments,
             creatorDetail = uiState.creatorDetail,
             userData = uiState.userData,
             metaData = uiState.metaData,
@@ -272,6 +275,7 @@ private fun PostDetailView(
 @Composable
 private fun PostDetailScreen(
     postDetail: FanboxPostDetail,
+    comments: PageOffsetInfo<FanboxComments.Item>,
     creatorDetail: FanboxCreatorDetail,
     userData: UserData,
     metaData: FanboxMetaData,
@@ -304,10 +308,10 @@ private fun PostDetailScreen(
     var isShowCommentEditor by remember { mutableStateOf(false) }
     var latestComment by remember { mutableStateOf("") }
 
-    LaunchedEffect(postDetail.commentList) {
+    LaunchedEffect(comments) {
         if (isShowCommentEditor) {
-            val comments = postDetail.commentList.contents.flatMap { comment -> listOf(comment) + comment.replies }
-            isShowCommentEditor = !comments.any { comment -> comment.user.name == metaData.context.user.name && comment.body == latestComment }
+            val commentItems = comments.contents.flatMap { comment -> listOf(comment) + comment.replies }
+            isShowCommentEditor = !commentItems.any { comment -> comment.user.name == metaData.context.user.name && comment.body == latestComment }
         }
     }
 
@@ -407,6 +411,7 @@ private fun PostDetailScreen(
 
             postDetailCommentItems(
                 postDetail = postDetail,
+                comments = comments,
                 metaData = metaData,
                 isShowCommentEditor = isShowCommentEditor,
                 onClickLoadMore = onClickCommentLoadMore,

--- a/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/detail/PostDetailViewModel.kt
+++ b/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/detail/PostDetailViewModel.kt
@@ -12,6 +12,7 @@ import me.matsumo.fanbox.core.common.util.suspendRunCatching
 import me.matsumo.fanbox.core.model.PageOffsetInfo
 import me.matsumo.fanbox.core.model.ScreenState
 import me.matsumo.fanbox.core.model.UserData
+import me.matsumo.fanbox.core.model.fanbox.FanboxComments
 import me.matsumo.fanbox.core.model.fanbox.FanboxCreatorDetail
 import me.matsumo.fanbox.core.model.fanbox.FanboxMetaData
 import me.matsumo.fanbox.core.model.fanbox.FanboxPost
@@ -62,12 +63,14 @@ class PostDetailViewModel(
             _screenState.value = suspendRunCatching {
                 val postDetail = fanboxRepository.getPost(postId)
                 val creatorDetail = fanboxRepository.getCreatorCached(postDetail.user.creatorId)
+                val comments = fanboxRepository.getPostComment(postId)
 
                 PostDetailUiState(
                     userData = userDataRepository.userData.first(),
                     metaData = fanboxRepository.metaData.first(),
                     postDetail = postDetail,
                     creatorDetail = creatorDetail,
+                    comments = comments,
                 )
             }.fold(
                 onSuccess = { ScreenState.Idle(it) },
@@ -110,12 +113,10 @@ class PostDetailViewModel(
 
             _screenState.value = screenState.updateWhenIdle {
                 it.copy(
-                    postDetail = it.postDetail.copy(
-                        commentList = PageOffsetInfo(
-                            contents = it.postDetail.commentList.contents + comments.contents,
-                            offset = comments.offset,
-                        ),
-                    ),
+                    comments = PageOffsetInfo(
+                        contents = it.comments.contents + comments.contents,
+                        offset = comments.offset,
+                    )
                 )
             }
         }
@@ -236,5 +237,6 @@ data class PostDetailUiState(
     val metaData: FanboxMetaData,
     val creatorDetail: FanboxCreatorDetail,
     val postDetail: FanboxPostDetail,
+    val comments: PageOffsetInfo<FanboxComments.Item>,
     val messageToast: StringResource? = null,
 )

--- a/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/detail/items/PostDetailCommentSection.kt
+++ b/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/detail/items/PostDetailCommentSection.kt
@@ -43,6 +43,8 @@ import coil3.compose.LocalPlatformContext
 import coil3.request.ImageRequest
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
+import me.matsumo.fanbox.core.model.PageOffsetInfo
+import me.matsumo.fanbox.core.model.fanbox.FanboxComments
 import me.matsumo.fanbox.core.model.fanbox.FanboxMetaData
 import me.matsumo.fanbox.core.model.fanbox.FanboxPostDetail
 import me.matsumo.fanbox.core.model.fanbox.id.CommentId
@@ -67,6 +69,7 @@ import org.jetbrains.compose.resources.stringResource
 internal fun LazyListScope.postDetailCommentItems(
     isShowCommentEditor: Boolean,
     postDetail: FanboxPostDetail,
+    comments: PageOffsetInfo<FanboxComments.Item>,
     metaData: FanboxMetaData,
     onClickLoadMore: (PostId, Int) -> Unit,
     onClickCommentLike: (CommentId) -> Unit,
@@ -119,9 +122,9 @@ internal fun LazyListScope.postDetailCommentItems(
         }
     }
 
-    if (postDetail.commentList.contents.isNotEmpty()) {
+    if (comments.contents.isNotEmpty()) {
         items(
-            items = postDetail.commentList.contents,
+            items = comments.contents,
             key = { comment -> comment.id.uniqueValue },
         ) {
             CommentItem(
@@ -155,7 +158,7 @@ internal fun LazyListScope.postDetailCommentItems(
         }
     }
 
-    if (postDetail.commentList.offset != null) {
+    if (comments.offset != null) {
         item {
             Box(
                 modifier = Modifier
@@ -166,7 +169,7 @@ internal fun LazyListScope.postDetailCommentItems(
                     modifier = Modifier
                         .padding(top = 24.dp)
                         .align(Alignment.Center),
-                    onClick = { onClickLoadMore.invoke(postDetail.id, postDetail.commentList.offset!!) },
+                    onClick = { onClickLoadMore.invoke(postDetail.id, comments.offset!!) },
                 ) {
                     Row(
                         verticalAlignment = Alignment.CenterVertically,
@@ -193,7 +196,7 @@ internal fun LazyListScope.postDetailCommentItems(
 @OptIn(ExperimentalCoilApi::class)
 @Composable
 private fun CommentItem(
-    comment: FanboxPostDetail.Comment.CommentItem,
+    comment: FanboxComments.Item,
     metaData: FanboxMetaData,
     onClickCommentLike: (CommentId) -> Unit,
     onClickCommentReply: (String, CommentId, CommentId) -> Unit,


### PR DESCRIPTION
## Linked issue
- closes #19 
- closes #20 

## Description
- FANBOX 側の API 変更により、レスポンス型が変更されてしまったことに起因するパースエラーで投稿詳細画面が閲覧できなくなっていた問題を修正
- エラー時に `STATUS.md` へのリンクを表示することで、ユーザーがアプリの不具合を認識できるように変更。