### PR TITLE
Add ability to manually attempt login

### DIFF
--- a/composeApp/src/androidMain/kotlin/me/matsumo/fanbox/PixiViewNavHost.android.kt
+++ b/composeApp/src/androidMain/kotlin/me/matsumo/fanbox/PixiViewNavHost.android.kt
@@ -50,6 +50,7 @@ import me.matsumo.fanbox.core.resources.domain_validation_request_button
 import me.matsumo.fanbox.core.resources.domain_validation_request_message
 import me.matsumo.fanbox.core.resources.domain_validation_request_never_ask
 import me.matsumo.fanbox.core.resources.domain_validation_request_title
+import me.matsumo.fanbox.core.resources.error_no_available_this_device
 import me.matsumo.fanbox.core.resources.error_unknown
 import me.matsumo.fanbox.core.ui.extensition.padding
 import me.matsumo.fanbox.core.ui.theme.bold
@@ -85,7 +86,7 @@ private fun RequestDomainVerification(
 ) {
     val scope = rememberCoroutineScope()
     var shouldRequest by remember { mutableStateOf(false) }
-    val errorMessage = stringResource(Res.string.error_unknown)
+    val errorMessage = stringResource(Res.string.error_no_available_this_device)
 
     LaunchedEffect(Unit) {
         val manager = activity.getSystemService(DomainVerificationManager::class.java)

--- a/composeApp/src/androidMain/kotlin/me/matsumo/fanbox/PixiViewNavHost.android.kt
+++ b/composeApp/src/androidMain/kotlin/me/matsumo/fanbox/PixiViewNavHost.android.kt
@@ -51,10 +51,8 @@ import me.matsumo.fanbox.core.resources.domain_validation_request_message
 import me.matsumo.fanbox.core.resources.domain_validation_request_never_ask
 import me.matsumo.fanbox.core.resources.domain_validation_request_title
 import me.matsumo.fanbox.core.resources.error_no_available_this_device
-import me.matsumo.fanbox.core.resources.error_unknown
 import me.matsumo.fanbox.core.ui.extensition.padding
 import me.matsumo.fanbox.core.ui.theme.bold
-import org.jetbrains.compose.resources.getString
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.koinInject
 

--- a/composeApp/src/commonMain/kotlin/me/matsumo/fanbox/PixiViewApp.kt
+++ b/composeApp/src/commonMain/kotlin/me/matsumo/fanbox/PixiViewApp.kt
@@ -11,7 +11,6 @@ import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
@@ -23,7 +22,6 @@ import com.svenjacobs.reveal.RevealCanvas
 import com.svenjacobs.reveal.rememberRevealCanvasState
 import dev.icerock.moko.biometry.compose.BindBiometryAuthenticatorEffect
 import dev.icerock.moko.biometry.compose.rememberBiometryAuthenticatorFactory
-import io.github.aakira.napier.Napier
 import kotlinx.collections.immutable.ImmutableMap
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch

--- a/composeApp/src/commonMain/kotlin/me/matsumo/fanbox/PixiViewApp.kt
+++ b/composeApp/src/commonMain/kotlin/me/matsumo/fanbox/PixiViewApp.kt
@@ -129,24 +129,25 @@ fun PixiViewApp(
 
                 DisposableEffect(lifecycleOwner) {
                     val observer = object : DefaultLifecycleObserver {
-                        override fun onResume(owner: LifecycleOwner) {
-                            Napier.d { "onResume" }
+                        override fun onCreate(owner: LifecycleOwner) {
+                            viewModel.billingClientInitialize()
+                        }
 
+                        override fun onResume(owner: LifecycleOwner) {
                             viewModel.setAppLock(true)
                             viewModel.billingClientUpdate()
+                        }
+
+                        override fun onDestroy(owner: LifecycleOwner) {
+                            viewModel.billingClientFinish()
                         }
                     }
 
                     lifecycleOwner.lifecycle.addObserver(observer)
-
                     onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
                 }
             }
         }
-    }
-
-    LaunchedEffect(true) {
-        viewModel.billingClientInitialize()
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/me/matsumo/fanbox/PixiViewViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/me/matsumo/fanbox/PixiViewViewModel.kt
@@ -62,7 +62,7 @@ class PixiViewViewModel(
         ),
     ) { flows ->
         val userData = flows[0] as UserData
-        val sessionId = flows[1] as String
+        val sessionId = flows[1] as String?
         val downloadState = flows[2] as DownloadState
         val isLoggedIn = flows[3] as Boolean
         val isAppLocked = flows[4] as Boolean
@@ -70,7 +70,7 @@ class PixiViewViewModel(
         ScreenState.Idle(
             MainUiState(
                 userData = userData,
-                sessionId = sessionId,
+                sessionId = sessionId.orEmpty(),
                 fanboxMetadata = suspendRunCatching { fanboxRepository.getMetadata() }.getOrElse { getFanboxMetadataDummy() },
                 downloadState = downloadState,
                 isLoggedIn = isLoggedIn,
@@ -111,6 +111,10 @@ class PixiViewViewModel(
 
     fun billingClientInitialize() {
         billingStatus.init()
+    }
+
+    fun billingClientFinish() {
+        billingStatus.finish()
     }
 
     fun billingClientUpdate() {

--- a/core/billing/src/androidMain/kotlin/me/matsumo/fanbox/core/billing/BillingStatus.kt
+++ b/core/billing/src/androidMain/kotlin/me/matsumo/fanbox/core/billing/BillingStatus.kt
@@ -29,6 +29,6 @@ class BillingStatusImpl(
     }
 
     override fun finish() {
-        // do nothing
+        billingClient.dispose()
     }
 }

--- a/core/resources/src/commonMain/composeResources/files/versions.json
+++ b/core/resources/src/commonMain/composeResources/files/versions.json
@@ -183,7 +183,7 @@
   },
   {
     "versionName": "2.2.0",
-    "versionCode": 51,
+    "versionCode": 52,
     "date": "2025/01/20",
     "logJp": "・クリエイターの投稿をキーワードから検索できる機能を追加\n・ダウンロードキュー画面を追加\n・Android App Links に対応\n・UIの調整\n・投稿詳細画面にバナー広告を追加（アプリ維持費のためです。ごめんなさい！）",
     "logEn": "・Added the ability to search creators' posts by keyword\n・Added a download queue screen\n・Supports Android App Links\n・Added banner ads to the post details screen (to cover app maintenance costs. Sorry!)"

--- a/core/resources/src/commonMain/composeResources/files/versions.json
+++ b/core/resources/src/commonMain/composeResources/files/versions.json
@@ -187,5 +187,12 @@
     "date": "2025/01/20",
     "logJp": "・クリエイターの投稿をキーワードから検索できる機能を追加\n・ダウンロードキュー画面を追加\n・Android App Links に対応\n・UIの調整\n・投稿詳細画面にバナー広告を追加（アプリ維持費のためです。ごめんなさい！）",
     "logEn": "・Added the ability to search creators' posts by keyword\n・Added a download queue screen\n・Supports Android App Links\n・Added banner ads to the post details screen (to cover app maintenance costs. Sorry!)"
+  },
+  {
+    "versionName": "2.2.1",
+    "versionCode": 5,
+    "date": "2025/01/23",
+    "logJp": "・ログインができない場合の救済導線を追加\n・アプリがクラッシュする恐れのある不具合の修正",
+    "logEn": "・Added a rescue guide for when you can't log in\n・Fixed a bug that could cause the app to crash"
   }
 ]

--- a/core/resources/src/commonMain/composeResources/files/versions.json
+++ b/core/resources/src/commonMain/composeResources/files/versions.json
@@ -190,7 +190,7 @@
   },
   {
     "versionName": "2.2.1",
-    "versionCode": 5,
+    "versionCode": 53,
     "date": "2025/01/23",
     "logJp": "・ログインができない場合の救済導線を追加\n・アプリがクラッシュする恐れのある不具合の修正",
     "logEn": "・Added a rescue guide for when you can't log in\n・Fixed a bug that could cause the app to crash"

--- a/core/resources/src/commonMain/composeResources/values-ja/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-ja/strings.xml
@@ -62,6 +62,7 @@
     <string name="error_service_status">サービス稼働状況</string>
     <string name="error_ad_load_failed">広告の読み込みに失敗しました</string>
     <string name="error_ad_load_failed_description">サービスの品質維持のために広告を表示しています。</string>
+    <string name="error_no_available_this_device">このデバイスでは利用できない機能です</string>
 
     <!-- Common Unit -->
     <string name="unit_day_before">%1$d日前</string>
@@ -354,8 +355,10 @@
     <string name="welcome_login_dialog_message">GoogleやX(Twitter)のOAuthを利用した認証はセキュリティ上の懸念により対応していません。\n\nメールアドレスとパスワードを直接入力してログインを行ってください。</string>
     <string name="welcome_login_debug_dialog_title">注意</string>
     <string name="welcome_login_debug_dialog_message">デバッグログインを実行しますか？\n\nデバッグアカウントは事前に準備されたアカウントで、通常ユーザーの挙動を模倣します。ステージング環境保全のため、一部操作ができないもしくはエラーになる場合があります。</string>
-    <string name="welcome_login_other_title">ログインできない場合</string>
+    <string name="welcome_login_other_title">FANBOXSESSID 直接入力</string>
     <string name="welcome_login_other_message">このアプリが動作するためには FANBOXSESSID というセッションIDが必要です。以下のリンクの手順に従って FANBOXSESSID を取得し、入力してください。</string>
+    <string name="welcome_login_web_help">ログインできない場合</string>
+    <string name="welcome_login_web_help_description">email と passwordを入力し、画面上ではログインできているにも関わらず、自動的に画面が切り替わらない場合のみ以下をお試しください。\n\nこのダイアログを一旦閉じ、ログインしていないと閲覧することができない情報があるページまで、画面上で遷移してください（ex: 支援しているクリエイターの投稿詳細画面）。\n\nその画面まで遷移したら再度画面下部の「ログインできない場合」のボタンを押し、このダイアログを表示してください。\n\nこの状態でダイアログ下部のログインボタンをタップしてください。WebView からログイン情報を取得し、ログインを試みます。</string>
     <string name="welcome_permission_title">権限</string>
     <string name="welcome_permission_message">アプリの利用には以下の権限が必要です\n下のボタンを押して権限を許可してください</string>
     <string name="welcome_permission_ready_title">準備完了</string>

--- a/core/resources/src/commonMain/composeResources/values-ko/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-ko/strings.xml
@@ -58,6 +58,7 @@
     <string name="error_service_status">서비스 운영 현황</string>
     <string name="error_ad_load_failed">광고를 로드하지 못했습니다.</string>
     <string name="error_ad_load_failed_description">서비스 품질 유지를 위해 광고를 게재하고 있습니다.</string>
+    <string name="error_no_available_this_device">이 기기에서는 사용할 수 없는 기능입니다</string>
 
     <!-- Common Unit -->
     <string name="unit_day_before">%1$d일 전</string>
@@ -343,8 +344,10 @@
     <string name="welcome_login_dialog_message">구글이나 X의 OAuth를 이용한 인증은 보안상의 문제로 인해 지원하지 않습니다.\n\n 이메일 주소와 비밀번호를 직접 입력하여 로그인하십시오.</string>
     <string name="welcome_login_debug_dialog_title">주의</string>
     <string name="welcome_login_debug_dialog_message">디버그 로그인을 실행하시겠습니까?\n\n디버그 계정은 미리 준비된 계정으로, 일반 사용자의 행동을 모방합니다. 스테이징 환경 보존을 위해 일부 조작이 불가능하거나 오류가 발생할 수 있습니다.</string>
-    <string name="welcome_login_other_title">로그인할 수 없는 경우</string>
-    <string name="welcome_login_other_message">이 앱이 작동하려면 FANBOXSESSID라는 세션 ID가 필요합니다. 아래 링크의 절차에 따라 FANBOXSESSID를 발급받아 입력하세요.</string>
+    <string name="welcome_login_other_title">FANBOXSESSID 직접 입력</string>
+    <string name="welcome_login_other_message">이 앱이 작동하려면 FANBOXSESSID라는 세션 ID가 필요합니다. 아래 링크의 지침에 따라 FANBOXSESSID를 얻은 후 입력해주세요.</string>
+    <string name="welcome_login_web_help">로그인할 수 없는 경우</string>
+    <string name="welcome_login_web_help_description">이메일과 비밀번호를 입력하고 화면에서 로그인된 것처럼 보이지만 화면이 자동으로 전환되지 않을 경우 아래 단계를 시도해보세요:\n\n이 대화 상자를 한 번 닫고 로그인하지 않으면 볼 수 없는 페이지(예: 후원 중인 창작자의 게시물 상세 페이지)로 화면을 이동하세요.\n\n그 화면으로 이동한 후 다시 화면 하단의 '로그인할 수 없는 경우' 버튼을 눌러 이 대화 상자를 표시해주세요.\n\n이 상태에서 대화 상자 하단의 로그인 버튼을 눌러주세요. WebView에서 로그인 정보를 가져와 로그인을 시도합니다."</string>
     <string name="welcome_permission_title">권한 설정</string>
     <string name="welcome_permission_message">이 앱을 이용하려면 다음 권한이 필요합니다.\n아래의 버튼을 눌러 권한을 허용해주세요</string>
     <string name="welcome_permission_ready_title">준비 완료</string>

--- a/core/resources/src/commonMain/composeResources/values-zh-rCN/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-zh-rCN/strings.xml
@@ -62,6 +62,7 @@
     <string name="error_service_status">服务可用性</string>
     <string name="error_ad_load_failed">广告加载失败</string>
     <string name="error_ad_load_failed_description">我们展示广告来维护我们服务的质量。</string>
+    <string name="error_no_available_this_device">此设备无法使用该功能</string>
 
     <!-- Common Unit -->
     <string name="unit_day_before">%1$d天前</string>
@@ -355,8 +356,10 @@
     <string name="welcome_login_dialog_message">由于安全问题，不支持使用Google或X（Twitter）的OAuth进行身份验证。\n\n请直接输入您的电子邮件地址和密码登录。</string>
     <string name="welcome_login_debug_dialog_title">注意</string>
     <string name="welcome_login_debug_dialog_message">是否要执行调试登录？\n\n调试帐户是模拟常规用户行为的预先设置的帐户。为了保留暂存环境，某些操作可能无法执行或可能会发生错误。</string>
-    <string name="welcome_login_other_title">如果无法登录</string>
-    <string name="welcome_login_other_message">此应用需要名为FANBOXSESSID的会话ID才能运行。请按照下面链接中的步骤获取并输入您的FANBOXSESSID。</string>
+    <string name="welcome_login_other_title">直接输入 FANBOXSESSID</string>
+    <string name="welcome_login_other_message">此应用需要一个名为 FANBOXSESSID 的会话 ID 才能运行。请按照以下链接中的步骤获取 FANBOXSESSID 并输入。</string>
+    <string name="welcome_login_web_help">无法登录时</string>
+    <string name="welcome_login_web_help_description">如果输入邮箱和密码后，虽然屏幕显示已登录，但界面没有自动切换，请尝试以下步骤：\n\n先关闭此对话框，并在屏幕上导航到需要登录才能查看的页面（例如：支持的创作者的帖子详细页面）。\n\n导航到该页面后，再次点击屏幕底部的“无法登录时”按钮，显示此对话框。\n\n在此状态下，点击对话框底部的登录按钮。应用将尝试从 WebView 获取登录信息并进行登录。”</string>
     <string name="welcome_permission_title">权限</string>
     <string name="welcome_permission_message">使用应用程序需要以下权限。\n单击下面的按钮以授予权限。</string>
     <string name="welcome_permission_ready_title">准备就绪</string>

--- a/core/resources/src/commonMain/composeResources/values/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values/strings.xml
@@ -62,6 +62,7 @@
     <string name="error_service_status">Service operation status</string>
     <string name="error_ad_load_failed">Failed to load ads.</string>
     <string name="error_ad_load_failed_description">We display advertisements to maintain the quality of our service.</string>
+    <string name="error_no_available_this_device">This feature is not available on this device</string>
 
     <!-- Common Unit -->
     <string name="unit_day_before">%1$d days ago</string>
@@ -355,8 +356,10 @@
     <string name="welcome_login_dialog_message">Authentication using Google or X (Twitter)'s OAuth is not supported due to security concerns. \n\nPlease log in by directly entering your email address and password.</string>
     <string name="welcome_login_debug_dialog_title">Caution</string>
     <string name="welcome_login_debug_dialog_message">Do you want to perform a debug login?\n\nDebug accounts are pre-provisioned accounts that mimic the behavior of regular users. In order to preserve the staging environment, some operations may not be possible or errors may occur.</string>
-    <string name="welcome_login_other_title">When can't log in</string>
-    <string name="welcome_login_other_message">A session ID called FANBOXSESSID is required for this app to work. Please follow the steps in the link below to obtain and enter your FANBOXSESSID.</string>
+    <string name="welcome_login_other_title">Direct Input of FANBOXSESSID</string>
+    <string name="welcome_login_other_message">This app requires a session ID called FANBOXSESSID to function. Please follow the instructions in the link below to obtain FANBOXSESSID and input it.</string>
+    <string name="welcome_login_web_help">If You Cannot Log In</string>
+    <string name="welcome_login_web_help_description">If you enter your email and password, and although it seems like you are logged in on the screen, the screen does not automatically transition, please try the following:\n\nClose this dialog once and navigate to a page that requires login to view content (e.g., the post details of a creator you are supporting).\n\nOnce you have navigated to such a page, press the 'If You Cannot Log In' button at the bottom of the screen again to display this dialog.\n\nIn this state, tap the login button at the bottom of the dialog. The app will attempt to retrieve login information from WebView and log you in."</string>
     <string name="welcome_permission_title">Permissions</string>
     <string name="welcome_permission_message">The following permissions are required to use the app\nClick the button below to grant permission</string>
     <string name="welcome_permission_ready_title">Ready</string>

--- a/feature/setting/src/commonMain/kotlin/me/matsumo/fanbox/feature/setting/top/SettingTopViewModel.kt
+++ b/feature/setting/src/commonMain/kotlin/me/matsumo/fanbox/feature/setting/top/SettingTopViewModel.kt
@@ -39,7 +39,7 @@ class SettingTopViewModel(
             SettingTopUiState(
                 userData = userData,
                 metaData = suspendRunCatching { fanboxRepository.getMetadata() }.getOrElse { getFanboxMetadataDummy() },
-                fanboxSessionId = sessionId ?: "unknown",
+                fanboxSessionId = sessionId ?: "Unknown",
                 config = pixiViewConfig,
             ),
         )

--- a/feature/welcome/src/commonMain/kotlin/me/matsumo/fanbox/feature/welcome/web/WelcomeWebDialog.kt
+++ b/feature/welcome/src/commonMain/kotlin/me/matsumo/fanbox/feature/welcome/web/WelcomeWebDialog.kt
@@ -1,18 +1,15 @@
 package me.matsumo.fanbox.feature.welcome.web
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.MaterialTheme.colors
@@ -22,22 +19,17 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
+import kotlinx.collections.immutable.ImmutableList
 import me.matsumo.fanbox.core.resources.Res
 import me.matsumo.fanbox.core.resources.common_cancel
-import me.matsumo.fanbox.core.resources.welcome_login_other_message
-import me.matsumo.fanbox.core.resources.welcome_login_other_title
 import me.matsumo.fanbox.core.resources.welcome_login_title
 import me.matsumo.fanbox.core.resources.welcome_login_web_help
 import me.matsumo.fanbox.core.resources.welcome_login_web_help_description
@@ -47,7 +39,7 @@ import org.jetbrains.compose.resources.stringResource
 @Composable
 internal fun WelcomeWebDialog(
     currentUrl: String,
-    currentCookies: List<String>,
+    currentCookies: ImmutableList<String>,
     onClickLogin: () -> Unit,
     onDismissRequest: () -> Unit,
 ) {

--- a/feature/welcome/src/commonMain/kotlin/me/matsumo/fanbox/feature/welcome/web/WelcomeWebDialog.kt
+++ b/feature/welcome/src/commonMain/kotlin/me/matsumo/fanbox/feature/welcome/web/WelcomeWebDialog.kt
@@ -1,0 +1,131 @@
+package me.matsumo.fanbox.feature.welcome.web
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.MaterialTheme.colors
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.surfaceColorAtElevation
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import me.matsumo.fanbox.core.resources.Res
+import me.matsumo.fanbox.core.resources.common_cancel
+import me.matsumo.fanbox.core.resources.welcome_login_other_message
+import me.matsumo.fanbox.core.resources.welcome_login_other_title
+import me.matsumo.fanbox.core.resources.welcome_login_title
+import me.matsumo.fanbox.core.resources.welcome_login_web_help
+import me.matsumo.fanbox.core.resources.welcome_login_web_help_description
+import me.matsumo.fanbox.core.ui.theme.bold
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+internal fun WelcomeWebDialog(
+    currentUrl: String,
+    currentCookies: List<String>,
+    onClickLogin: () -> Unit,
+    onDismissRequest: () -> Unit,
+) {
+    Dialog(
+        onDismissRequest = onDismissRequest,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .wrapContentHeight()
+                .clip(RoundedCornerShape(16.dp))
+                .background(MaterialTheme.colorScheme.surface)
+                .padding(24.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Text(
+                modifier = Modifier.fillMaxWidth(),
+                text = stringResource(Res.string.welcome_login_web_help),
+                style = MaterialTheme.typography.titleMedium.bold(),
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                Text(
+                    modifier = Modifier.fillMaxWidth(),
+                    text = stringResource(Res.string.welcome_login_web_help_description),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+
+                Card(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clip(RoundedCornerShape(8.dp)),
+                    shape = RoundedCornerShape(8.dp),
+                    colors = CardDefaults.cardColors(MaterialTheme.colorScheme.surfaceColorAtElevation(2.dp)),
+                ) {
+                    SelectionContainer {
+                        Text(
+                            modifier = Modifier
+                                .horizontalScroll(rememberScrollState())
+                                .padding(16.dp),
+                            text = "URL: $currentUrl\nCookies: $currentCookies",
+                            style = MaterialTheme.typography.bodySmall,
+                        )
+                    }
+                }
+            }
+
+            Row(
+                modifier = Modifier
+                    .padding(top = 8.dp)
+                    .fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(16.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                OutlinedButton(
+                    modifier = Modifier.weight(1f),
+                    shape = RoundedCornerShape(4.dp),
+                    onClick = onDismissRequest,
+                ) {
+                    Text(text = stringResource(Res.string.common_cancel))
+                }
+
+                Button(
+                    modifier = Modifier.weight(1f),
+                    shape = RoundedCornerShape(4.dp),
+                    colors = ButtonDefaults.buttonColors(MaterialTheme.colorScheme.primary),
+                    onClick = onClickLogin,
+                ) {
+                    Text(text = stringResource(Res.string.welcome_login_title))
+                }
+            }
+        }
+    }
+}

--- a/feature/welcome/src/commonMain/kotlin/me/matsumo/fanbox/feature/welcome/web/WelcomeWebScreen.kt
+++ b/feature/welcome/src/commonMain/kotlin/me/matsumo/fanbox/feature/welcome/web/WelcomeWebScreen.kt
@@ -37,6 +37,7 @@ import com.multiplatform.webview.web.LoadingState
 import com.multiplatform.webview.web.WebView
 import com.multiplatform.webview.web.rememberWebViewState
 import io.github.aakira.napier.Napier
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -185,7 +186,7 @@ internal fun WelcomeWebScreen(
     if (isDisplayHelpDialog) {
         WelcomeWebDialog(
             currentUrl = webViewState.lastLoadedUrl.orEmpty(),
-            currentCookies = currentCookies.map { "${it.name}=${it.value}" },
+            currentCookies = currentCookies.map { "${it.name}=${it.value}" }.toImmutableList(),
             onDismissRequest = { isDisplayHelpDialog = false },
             onClickLogin = {
                 scope.launch {

--- a/feature/welcome/src/commonMain/kotlin/me/matsumo/fanbox/feature/welcome/web/WelcomeWebViewModel.kt
+++ b/feature/welcome/src/commonMain/kotlin/me/matsumo/fanbox/feature/welcome/web/WelcomeWebViewModel.kt
@@ -3,6 +3,7 @@ package me.matsumo.fanbox.feature.welcome.web
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.launch
+import me.matsumo.fanbox.core.common.util.suspendRunCatching
 import me.matsumo.fanbox.core.repository.FanboxRepository
 import me.matsumo.fanbox.core.repository.UserDataRepository
 
@@ -11,10 +12,19 @@ class WelcomeWebViewModel(
     private val userDataRepository: UserDataRepository,
 ) : ViewModel() {
 
-    fun saveSessionId(sessionId: String) {
-        viewModelScope.launch {
-            fanboxRepository.setSessionId(sessionId)
-        }
+    suspend fun saveSessionId(sessionId: String) {
+        fanboxRepository.setSessionId(sessionId)
+    }
+
+    suspend fun checkSessionId(sessionId: String): Boolean {
+        saveSessionId(sessionId)
+
+        return suspendRunCatching {
+            fanboxRepository.updateCsrfToken()
+            fanboxRepository.getNewsLetters()
+        }.onFailure {
+            saveSessionId("")
+        }.isSuccess
     }
 
     fun debugLogin() {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # Application
-versionName = "2.2.0"
-versionCode = "52"
+versionName = "2.2.1"
+versionCode = "53"
 
 # SDK
 minSdk = "26"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # Application
 versionName = "2.2.0"
-versionCode = "51"
+versionCode = "52"
 
 # SDK
 minSdk = "26"


### PR DESCRIPTION
## Issue
- #1 
- #17 
- #23 
- #29 

## Why?
- 現状のログインの仕組みは、認証開始時に私た `return_to=$url` に WebView が遷移したことを持ってログイン完了と判定しており、なんらかの原因でリダイレクト URL に飛ばなかった場合は認証が失敗する恐れがあった
- 加えて、`WelcomeWebScreen` でのログイン完了判定は URL の一致という情報のみで、実際に session id が正しいか判定するロジックは戻った後の `WelcomeLoginScreen` が担っているため、「リダイレクトが正しく行われたがログインができていない」という状態の時自動的に `WelcomeLoginScreen` に戻されてしまいユーザーがスタックするということがあった

## How?
- リダイレクトされた際に session id が正しいか判定してから画面を戻すように変更
- `WelcomeWebScreen` に手動でログインをトライできるボタンを追加
- いくつかの crashlytics を修正
- 2.2.1 にバージョンアップ