### PR TITLE
fix: restore following creators list with fankt 0.0.17

### DIFF
--- a/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/follow/FollowingCreatorsViewModel.kt
+++ b/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/follow/FollowingCreatorsViewModel.kt
@@ -42,7 +42,7 @@ class FollowingCreatorsViewModel(
 
     suspend fun follow(creatorUserId: FanboxUserId): Result<Unit> {
         return suspendRunCatching {
-            fanboxRepository.unfollowCreator(creatorUserId)
+            fanboxRepository.followCreator(creatorUserId)
         }
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -57,7 +57,7 @@ gms = "4.4.3"
 koin = "4.1.0"
 
 # matsumo
-fankt = "0.0.16"
+fankt = "0.0.17"
 
 # OpenAI
 openai = "4.0.1"


### PR DESCRIPTION
## 概要

フォロー中クリエイター画面が「エラーが発生しました」となり閲覧できない問題を修正する。

原因は FANBOX API の creator 一覧系エンドポイント (`creator.listFollowing` / `listPixiv` / `listRecommended`) のレスポンス形が `body: [...]` から `body: { creators: [...] }` にネストされる形へ変更されたこと。パースは fankt ライブラリ側で行われており、対応版の **fankt 0.0.17** を取り込むことで解消する。

## 変更内容

- `gradle/libs.versions.toml`: `fankt` を `0.0.16` → `0.0.17` に更新（新レスポンス形対応版）
- `FollowingCreatorsViewModel.follow()`: 誤って `unfollowCreator()` を呼んでいたコピペミスを `followCreator()` に修正

## 動作確認

- `FANBOXSESSID` で実 API を叩き、`creator.listFollowing`(144件) / `listPixiv`(379件) / `listRecommended`(20件) がいずれも `body.creators` 形・必須フィールド欠落なしで HTTP 200 を返すことを確認
- 実機 Pixel に debug ビルドをインストールして起動 → ドロワー「フォロー中」画面でフォロー中クリエイター一覧が正常に表示されることを確認（修正前は parse エラーで `ScreenState.Error`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)