### PR TITLE
fix: stop repeating posts on home feeds (fankt 0.0.18)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -57,7 +57,7 @@ gms = "4.4.3"
 koin = "4.1.0"
 
 # matsumo
-fankt = "0.0.16"
+fankt = "0.0.18"
 
 # OpenAI
 openai = "4.0.1"


### PR DESCRIPTION
## 概要

Home の Supporting / Following タブで、しばらくスクロールすると同じ投稿が繰り返し表示される問題を修正する (#63)。

## 原因

ページングのカーソルが前進していなかった。FANBOX API の `nextUrl` はクエリ値が URL エンコード済みだが、fankt 側 `translateToCursor()` がデコードせず保持していたため、リクエスト時に二重エンコードされ、サーバがカーソルを無視して常に1ページ目を返していた。

パース層は fankt ライブラリにあるため、対応版の **fankt 0.0.18** を取り込むことで解消する（fankt 側修正: matsumo0922/fankt#10）。

## 変更内容

- `gradle/libs.versions.toml`: `fankt` を `0.0.16` → `0.0.18` に更新

## 確認

- 実 API 検証で、デコード済みカーソルを渡すと次ページの新しい投稿が返り `nextUrl` も前進することを確認（二重エンコード時は1ページ目をループ）
- debug ビルドが 0.0.18 で正常にコンパイル・起動することを確認

## 注意

`fankt` のバージョン更新を含むため、#64（0.0.17 への bump）とは `gradle/libs.versions.toml` で競合します。0.0.18 は 0.0.17 の変更（フォロー中クリエイター一覧の修正）も含むため、本PRをマージすれば #64 のバージョン更新は不要になります（#64 の `follow()` バグ修正は別途必要）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)