### PR TITLE
Fix Android banner ad implementation

### DIFF
--- a/composeApp/src/androidMain/kotlin/me/matsumo/fanbox/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/me/matsumo/fanbox/MainActivity.kt
@@ -52,6 +52,7 @@ class MainActivity : FragmentActivity(), KoinComponent {
         enableEdgeToEdge()
         setContent {
             val settings by viewModel.setting.collectAsStateWithLifecycle(null)
+            val isAdsSdkInitialized by viewModel.isAdsSdkInitialized.collectAsStateWithLifecycle()
             val isSystemInDarkTheme = shouldUseDarkTheme(settings?.themeConfig ?: ThemeConfig.System)
             val windowSize = calculateWindowSizeClass()
 
@@ -70,6 +71,7 @@ class MainActivity : FragmentActivity(), KoinComponent {
                 modifier = Modifier.fillMaxSize(),
                 windowSize = windowSize.widthSizeClass,
                 nativeViews = persistentMapOf(),
+                isAdsSdkInitialized = isAdsSdkInitialized,
             )
 
             splashScreen.setKeepOnScreenCondition { settings == null }
@@ -139,7 +141,8 @@ class MainActivity : FragmentActivity(), KoinComponent {
         ccpaMetaData["privacy.consent"] = true
         ccpaMetaData.commit()
 
-        MobileAds.initialize(this)
-        viewModel.setAdsSdkInitialized()
+        MobileAds.initialize(this) {
+            viewModel.setAdsSdkInitialized()
+        }
     }
 }

--- a/composeApp/src/commonMain/kotlin/me/matsumo/fanbox/PixiViewApp.kt
+++ b/composeApp/src/commonMain/kotlin/me/matsumo/fanbox/PixiViewApp.kt
@@ -50,6 +50,7 @@ fun PixiViewApp(
     windowSize: WindowWidthSizeClass,
     nativeViews: ImmutableMap<String, () -> NativeView?>,
     modifier: Modifier = Modifier,
+    isAdsSdkInitialized: Boolean = true,
     viewModel: PixiViewViewModel = koinViewModel(),
     navigatorExtension: NavigatorExtension = koinInject(),
     pixiViewConfig: PixiViewConfig = koinInject(),
@@ -84,6 +85,7 @@ fun PixiViewApp(
                     themeConfig = it.setting.themeConfig,
                     themeColorConfig = it.setting.themeColorConfig,
                     pixiViewConfig = pixiViewConfig,
+                    isAdsSdkInitialized = isAdsSdkInitialized,
                     nativeViews = nativeViews,
                     revealCanvasState = revealCanvasState,
                 ) {

--- a/core/ui/src/androidMain/kotlin/me/matsumo/fanbox/core/ui/ads/BannerAdView.android.kt
+++ b/core/ui/src/androidMain/kotlin/me/matsumo/fanbox/core/ui/ads/BannerAdView.android.kt
@@ -22,8 +22,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.DefaultLifecycleObserver
@@ -32,8 +32,8 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.google.android.gms.ads.AdListener
 import com.google.android.gms.ads.AdRequest
 import com.google.android.gms.ads.AdSize
+import com.google.android.gms.ads.AdView
 import com.google.android.gms.ads.LoadAdError
-import com.google.android.gms.ads.admanager.AdManagerAdView
 import io.github.aakira.napier.Napier
 import me.matsumo.fanbox.core.resources.Res
 import me.matsumo.fanbox.core.resources.error_ad_load_failed
@@ -74,7 +74,7 @@ actual fun BannerAdView(modifier: Modifier) {
                 .height(adSize?.height?.dp ?: 0.dp),
         ) {
             if (adSize != null && isAdsSdkInitialized) {
-                val adManagerAdView = rememberAdViewWithLifecycle(
+                val adView = rememberAdViewWithLifecycle(
                     adUnitId = pixiViewConfig.bannerAdUnitId,
                     adSize = adSize,
                     adRequest = AdRequest.Builder().build(),
@@ -99,7 +99,7 @@ actual fun BannerAdView(modifier: Modifier) {
 
                 AndroidView(
                     modifier = Modifier.fillMaxSize(),
-                    factory = { adManagerAdView },
+                    factory = { adView },
                 )
             }
 
@@ -138,10 +138,10 @@ fun rememberAdViewWithLifecycle(
     adSize: AdSize,
     adRequest: AdRequest = AdRequest.Builder().build(),
     adListener: AdListener = object : AdListener() {},
-): AdManagerAdView {
+): AdView {
     val context = LocalContext.current
     val adView = remember(context, adUnitId, adSize) {
-        AdManagerAdView(context).apply {
+        AdView(context).apply {
             setAdSize(adSize)
             this.adListener = adListener
             this.adUnitId = adUnitId

--- a/core/ui/src/androidMain/kotlin/me/matsumo/fanbox/core/ui/ads/BannerAdView.android.kt
+++ b/core/ui/src/androidMain/kotlin/me/matsumo/fanbox/core/ui/ads/BannerAdView.android.kt
@@ -1,12 +1,13 @@
 package me.matsumo.fanbox.core.ui.ads
 
 import android.annotation.SuppressLint
-import android.content.res.Resources
+import android.content.res.Configuration
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -22,7 +23,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.DefaultLifecycleObserver
@@ -33,9 +34,11 @@ import com.google.android.gms.ads.AdRequest
 import com.google.android.gms.ads.AdSize
 import com.google.android.gms.ads.LoadAdError
 import com.google.android.gms.ads.admanager.AdManagerAdView
+import io.github.aakira.napier.Napier
 import me.matsumo.fanbox.core.resources.Res
 import me.matsumo.fanbox.core.resources.error_ad_load_failed
 import me.matsumo.fanbox.core.resources.error_ad_load_failed_description
+import me.matsumo.fanbox.core.ui.extensition.LocalNavigationType
 import me.matsumo.fanbox.core.ui.theme.LocalPixiViewConfig
 import me.matsumo.fanbox.core.ui.theme.bold
 import org.jetbrains.compose.resources.stringResource
@@ -44,60 +47,83 @@ import org.jetbrains.compose.resources.stringResource
 @Composable
 actual fun BannerAdView(modifier: Modifier) {
     val context = LocalContext.current
-    val density = LocalDensity.current
+    val configuration = LocalConfiguration.current
+    val navigationType = LocalNavigationType.current.type
     val pixiViewConfig = LocalPixiViewConfig.current
 
     var isAdLoadFailed by remember { mutableStateOf(false) }
 
-    val adSizeHeight = remember {
-        val displayMetrics = Resources.getSystem().displayMetrics
-        val width = (displayMetrics.widthPixels / displayMetrics.density).toInt()
-        val adSize = AdSize.getCurrentOrientationAnchoredAdaptiveBannerAdSize(context, width)
-        (adSize.height * displayMetrics.density)
-    }
-
-    val adManagerAdView = rememberAdViewWithLifecycle(
-        adUnitId = pixiViewConfig.bannerAdUnitId,
-        adRequest = AdRequest.Builder().build(),
-        adListener = object : AdListener() {
-            override fun onAdFailedToLoad(error: LoadAdError) {
-                isAdLoadFailed = true
-            }
-        },
-    )
-
-    Box(
+    BoxWithConstraints(
         modifier = modifier
-            .fillMaxWidth()
-            .height(with(density) { adSizeHeight.toDp() }),
+            .fillMaxWidth(),
     ) {
-        AndroidView(
-            modifier = Modifier.fillMaxSize(),
-            factory = { adManagerAdView },
-        )
+        val containerWidthDp = maxWidth.value.toInt()
+        val adSize = remember(context, containerWidthDp, configuration.orientation) {
+            if (containerWidthDp > 0) {
+                AdSize.getCurrentOrientationAnchoredAdaptiveBannerAdSize(context, containerWidthDp)
+            } else {
+                null
+            }
+        }
 
-        AnimatedVisibility(
-            modifier = Modifier.align(Alignment.Center),
-            visible = isAdLoadFailed,
-            enter = fadeIn(),
-            exit = fadeOut(),
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(adSize?.height?.dp ?: 0.dp),
         ) {
-            Column(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                Text(
-                    text = stringResource(Res.string.error_ad_load_failed),
-                    style = MaterialTheme.typography.bodyMedium.bold(),
-                    color = MaterialTheme.colorScheme.onSurface,
+            if (adSize != null) {
+                val adManagerAdView = rememberAdViewWithLifecycle(
+                    adUnitId = pixiViewConfig.bannerAdUnitId,
+                    adSize = adSize,
+                    adRequest = AdRequest.Builder().build(),
+                    adListener = object : AdListener() {
+                        override fun onAdLoaded() {
+                            isAdLoadFailed = false
+                        }
+
+                        override fun onAdFailedToLoad(error: LoadAdError) {
+                            Napier.w(
+                                error.toBannerAdLoadFailedLog(
+                                    requestedWidthDp = adSize.width,
+                                    containerWidthDp = containerWidthDp,
+                                    orientation = configuration.orientation,
+                                    navigationType = navigationType.name,
+                                ),
+                            )
+                            isAdLoadFailed = true
+                        }
+                    },
                 )
 
-                Text(
-                    text = stringResource(Res.string.error_ad_load_failed_description),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                AndroidView(
+                    modifier = Modifier.fillMaxSize(),
+                    factory = { adManagerAdView },
                 )
+            }
+
+            AnimatedVisibility(
+                modifier = Modifier.align(Alignment.Center),
+                visible = isAdLoadFailed,
+                enter = fadeIn(),
+                exit = fadeOut(),
+            ) {
+                Column(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    Text(
+                        text = stringResource(Res.string.error_ad_load_failed),
+                        style = MaterialTheme.typography.bodyMedium.bold(),
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+
+                    Text(
+                        text = stringResource(Res.string.error_ad_load_failed_description),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
             }
         }
     }
@@ -107,17 +133,14 @@ actual fun BannerAdView(modifier: Modifier) {
 @Composable
 fun rememberAdViewWithLifecycle(
     adUnitId: String,
+    adSize: AdSize,
     adRequest: AdRequest = AdRequest.Builder().build(),
     adListener: AdListener = object : AdListener() {},
 ): AdManagerAdView {
     val context = LocalContext.current
-    val adView = remember {
+    val adView = remember(context, adUnitId, adSize) {
         AdManagerAdView(context).apply {
-            val displayMetrics = Resources.getSystem().displayMetrics
-            val width = (displayMetrics.widthPixels / displayMetrics.density).toInt()
-
-            setAdSize(AdSize.getCurrentOrientationAnchoredAdaptiveBannerAdSize(context, width))
-
+            setAdSize(adSize)
             this.adListener = adListener
             this.adUnitId = adUnitId
 
@@ -127,7 +150,7 @@ fun rememberAdViewWithLifecycle(
 
     val lifecycleOwner = LocalLifecycleOwner.current
 
-    DisposableEffect(lifecycleOwner) {
+    DisposableEffect(lifecycleOwner, adView) {
         val observer = object : DefaultLifecycleObserver {
             override fun onResume(owner: LifecycleOwner) {
                 adView.resume()
@@ -148,4 +171,27 @@ fun rememberAdViewWithLifecycle(
     }
 
     return adView
+}
+
+private fun LoadAdError.toBannerAdLoadFailedLog(
+    requestedWidthDp: Int,
+    containerWidthDp: Int,
+    orientation: Int,
+    navigationType: String,
+): String {
+    val orientationName = when (orientation) {
+        Configuration.ORIENTATION_LANDSCAPE -> "landscape"
+        Configuration.ORIENTATION_PORTRAIT -> "portrait"
+        else -> "undefined"
+    }
+
+    return "BannerAdView: onAdFailedToLoad, " +
+        "code=$code, " +
+        "domain=$domain, " +
+        "message=$message, " +
+        "responseInfo=$responseInfo, " +
+        "requestedWidthDp=$requestedWidthDp, " +
+        "containerWidthDp=$containerWidthDp, " +
+        "orientation=$orientationName, " +
+        "navigationType=$navigationType"
 }

--- a/core/ui/src/androidMain/kotlin/me/matsumo/fanbox/core/ui/ads/BannerAdView.android.kt
+++ b/core/ui/src/androidMain/kotlin/me/matsumo/fanbox/core/ui/ads/BannerAdView.android.kt
@@ -169,7 +169,10 @@ fun rememberAdViewWithLifecycle(
 
         lifecycleOwner.lifecycle.addObserver(observer)
 
-        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+            adView.destroy()
+        }
     }
 
     return adView

--- a/core/ui/src/androidMain/kotlin/me/matsumo/fanbox/core/ui/ads/BannerAdView.android.kt
+++ b/core/ui/src/androidMain/kotlin/me/matsumo/fanbox/core/ui/ads/BannerAdView.android.kt
@@ -39,6 +39,7 @@ import me.matsumo.fanbox.core.resources.Res
 import me.matsumo.fanbox.core.resources.error_ad_load_failed
 import me.matsumo.fanbox.core.resources.error_ad_load_failed_description
 import me.matsumo.fanbox.core.ui.extensition.LocalNavigationType
+import me.matsumo.fanbox.core.ui.theme.LocalAdsSdkInitialized
 import me.matsumo.fanbox.core.ui.theme.LocalPixiViewConfig
 import me.matsumo.fanbox.core.ui.theme.bold
 import org.jetbrains.compose.resources.stringResource
@@ -49,6 +50,7 @@ actual fun BannerAdView(modifier: Modifier) {
     val context = LocalContext.current
     val configuration = LocalConfiguration.current
     val navigationType = LocalNavigationType.current.type
+    val isAdsSdkInitialized = LocalAdsSdkInitialized.current
     val pixiViewConfig = LocalPixiViewConfig.current
 
     var isAdLoadFailed by remember { mutableStateOf(false) }
@@ -71,7 +73,7 @@ actual fun BannerAdView(modifier: Modifier) {
                 .fillMaxWidth()
                 .height(adSize?.height?.dp ?: 0.dp),
         ) {
-            if (adSize != null) {
+            if (adSize != null && isAdsSdkInitialized) {
                 val adManagerAdView = rememberAdViewWithLifecycle(
                     adUnitId = pixiViewConfig.bannerAdUnitId,
                     adSize = adSize,

--- a/core/ui/src/commonMain/kotlin/me/matsumo/fanbox/core/ui/theme/Config.kt
+++ b/core/ui/src/commonMain/kotlin/me/matsumo/fanbox/core/ui/theme/Config.kt
@@ -3,4 +3,8 @@ package me.matsumo.fanbox.core.ui.theme
 import androidx.compose.runtime.staticCompositionLocalOf
 import me.matsumo.fanbox.core.common.PixiViewConfig
 
+/** PixiView の実行時設定を提供する CompositionLocal。 */
 val LocalPixiViewConfig = staticCompositionLocalOf { PixiViewConfig.dummy() }
+
+/** Google Mobile Ads SDK の初期化完了状態を提供する CompositionLocal。 */
+val LocalAdsSdkInitialized = staticCompositionLocalOf { true }

--- a/core/ui/src/commonMain/kotlin/me/matsumo/fanbox/core/ui/theme/Theme.kt
+++ b/core/ui/src/commonMain/kotlin/me/matsumo/fanbox/core/ui/theme/Theme.kt
@@ -99,6 +99,7 @@ fun PixiViewTheme(
     sessionId: String = "",
     fanboxMetadata: FanboxMetaData = getFanboxMetadataDummy(),
     pixiViewConfig: PixiViewConfig = PixiViewConfig.dummy(),
+    isAdsSdkInitialized: Boolean = true,
     themeConfig: ThemeConfig = ThemeConfig.System,
     themeColorConfig: ThemeColorConfig = ThemeColorConfig.Blue,
     nativeViews: ImmutableMap<String, () -> NativeView?> = persistentMapOf(),
@@ -117,6 +118,7 @@ fun PixiViewTheme(
 
     CompositionLocalProvider(
         LocalPixiViewConfig provides pixiViewConfig,
+        LocalAdsSdkInitialized provides isAdsSdkInitialized,
         LocalColorScheme provides colorScheme,
         LocalFanboxSessionId provides FanboxSessionId(sessionId),
         LocalFanboxMetadata provides fanboxMetadata,


### PR DESCRIPTION
## 概要
Android のバナー広告実装について、実表示領域幅を使わずに adaptive size を算出していた点、Google Mobile Ads SDK 初期化完了前に load しうる点、Composable 破棄時に `destroy()` していなかった点を修正しました。
最後に `AdManagerAdView` から AdMob 標準の `AdView` へ移行しています。

Closes #69

## 変更内容
- ① `BoxWithConstraints` で広告の実コンテナ幅を取得し、幅確定後に anchored adaptive banner size を算出するように変更
- ② `MobileAds.initialize` の完了 callback 後に SDK 初期化完了状態を更新し、`BannerAdView` は初期化完了後のみ `loadAd` するように変更
- ③ `DisposableEffect` の `onDispose` で lifecycle observer を外し、広告 view の `destroy()` を呼ぶように変更
- ④ `AdManagerAdView` から標準 `AdView` へ移行
- 検証用に `onAdFailedToLoad` で error / responseInfo / requested width / container width / orientation / navigationType をログ出力

## 確認
- `JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home rtk ./gradlew :composeApp:compileDebugKotlinAndroid` PASS
- `JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home rtk ./gradlew :core:ui:detekt` PASS
- `JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home rtk ./gradlew detekt` PASS
- `JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home rtk ./gradlew build` は `:core:ui:compileCommonMainKotlinMetadata` で失敗。`origin/master` (`6e25afc`) の一時 worktree でも同一エラーを確認したため、本 PR 差分由来ではない既存の KMP navigation / lifecycle metadata 問題と判断しています。