### PR TITLE
Fix Android native ad recomposition after preload

### DIFF
--- a/core/ui/src/androidMain/kotlin/me/matsumo/fanbox/core/ui/ads/NativeAdView.android.kt
+++ b/core/ui/src/androidMain/kotlin/me/matsumo/fanbox/core/ui/ads/NativeAdView.android.kt
@@ -2,6 +2,7 @@ package me.matsumo.fanbox.core.ui.ads
 
 import android.annotation.SuppressLint
 import android.content.res.ColorStateList
+import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.ViewParent
@@ -13,6 +14,7 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -28,6 +30,7 @@ import androidx.core.view.isVisible
 import androidx.core.view.postDelayed
 import com.google.android.gms.ads.nativead.NativeAd
 import io.github.aakira.napier.Napier
+import me.matsumo.fanbox.core.ui.R
 import me.matsumo.fanbox.core.ui.databinding.LayoutNativeAdsMediumBinding
 import org.koin.compose.koinInject
 
@@ -41,50 +44,6 @@ actual fun NativeAdView(
     val nativeAdInventoryVersion by nativeAdsPreLoader.nativeAdInventoryVersion.collectAsState()
     var nativeAd by remember(key) { mutableStateOf<NativeAd?>(null) }
 
-    fun setupNativeAd(binding: LayoutNativeAdsMediumBinding, nativeAd: NativeAd) {
-        if (binding.tvPrice.text.isNotBlank()) return
-
-        val adView = binding.root.also { adView ->
-            adView.advertiserView = binding.tvAdvertiser
-            adView.bodyView = binding.tvBody
-            adView.callToActionView = binding.btnCta
-            adView.headlineView = binding.tvHeadline
-            adView.iconView = binding.ivAppIcon
-            adView.priceView = binding.tvPrice
-            adView.starRatingView = binding.rtbStars
-            adView.storeView = binding.tvStore
-            adView.mediaView = binding.mvContent
-        }
-
-        nativeAd.advertiser?.let { binding.tvAdvertiser.text = it }
-        nativeAd.body?.let { binding.tvBody.text = it }
-        nativeAd.callToAction?.let { binding.btnCta.text = it }
-        nativeAd.headline?.let { binding.tvHeadline.text = it }
-        nativeAd.icon?.let { binding.ivAppIcon.setImageDrawable(it.drawable) }
-        nativeAd.price?.let { binding.tvPrice.text = it }
-        nativeAd.starRating?.let { binding.rtbStars.rating = it.toFloat() }
-        nativeAd.store?.let { binding.tvStore.text = it }
-        nativeAd.mediaContent?.let { binding.mvContent.mediaContent = it }
-
-        binding.tvAdvertiser.visibility = if (nativeAd.advertiser.isNullOrBlank()) View.GONE else View.VISIBLE
-
-        binding.mvContent.isVisible = nativeAd.mediaContent != null
-        binding.mvContent.setOnHierarchyChangeListener(object : ViewGroup.OnHierarchyChangeListener {
-            override fun onChildViewAdded(parent: View, child: View) {
-                if (child is ImageView) {
-                    child.adjustViewBounds = true
-                }
-            }
-
-            override fun onChildViewRemoved(parent: View, child: View) = Unit
-        })
-
-        adView.setNativeAd(nativeAd)
-        adView.requestLayoutWithDelay(500L)
-
-        Napier.d("NativeAdView: setupNativeAd, ${binding.tvPrice.text}, $key")
-    }
-
     LaunchedEffect(key, nativeAdInventoryVersion) {
         if (nativeAd == null) {
             nativeAd = nativeAdsPreLoader.getNativeAd(key)
@@ -95,6 +54,12 @@ actual fun NativeAdView(
     val bodyTextColor = MaterialTheme.colorScheme.onSurfaceVariant.toArgb()
     val buttonColor = MaterialTheme.colorScheme.primary.toArgb()
     val buttonTextColor = MaterialTheme.colorScheme.onPrimary.toArgb()
+    val colorPalette = NativeAdViewColorPalette(
+        titleTextColor = titleTextColor,
+        bodyTextColor = bodyTextColor,
+        buttonColor = buttonColor,
+        buttonTextColor = buttonTextColor,
+    )
 
     Card(
         modifier = modifier.clip(RoundedCornerShape(8.dp)),
@@ -104,24 +69,119 @@ actual fun NativeAdView(
         AndroidViewBinding(
             modifier = Modifier.fillMaxWidth(),
             factory = { inflater, parent, attachToParent ->
-                val binding = LayoutNativeAdsMediumBinding.inflate(inflater, parent, attachToParent)
-
-                binding.tvAdvertiser.setTextColor(bodyTextColor)
-                binding.tvBody.setTextColor(bodyTextColor)
-                binding.btnCta.setTextColor(buttonTextColor)
-                binding.btnCta.backgroundTintList = ColorStateList.valueOf(buttonColor)
-                binding.tvHeadline.setTextColor(titleTextColor)
-                binding.tvPrice.setTextColor(bodyTextColor)
-                binding.tvStore.setTextColor(bodyTextColor)
-                binding.tvAd.setTextColor(bodyTextColor)
-
-                binding
+                createNativeAdBinding(
+                    inflater = inflater,
+                    parent = parent,
+                    attachToParent = attachToParent,
+                    colorPalette = colorPalette,
+                )
             },
             update = {
-                nativeAd?.let { nativeAd -> setupNativeAd(this, nativeAd) }
+                nativeAd?.let { loadedNativeAd ->
+                    setupNativeAd(
+                        nativeAd = loadedNativeAd,
+                        key = key,
+                    )
+                }
             },
         )
     }
+}
+
+private fun createNativeAdBinding(
+    inflater: LayoutInflater,
+    parent: ViewGroup,
+    attachToParent: Boolean,
+    colorPalette: NativeAdViewColorPalette,
+): LayoutNativeAdsMediumBinding {
+    val binding = LayoutNativeAdsMediumBinding.inflate(inflater, parent, attachToParent)
+
+    binding.applyColors(colorPalette = colorPalette)
+
+    return binding
+}
+
+/** ネイティブ広告ビューへ適用する色設定。 */
+@Immutable
+private data class NativeAdViewColorPalette(
+    val titleTextColor: Int,
+    val bodyTextColor: Int,
+    val buttonColor: Int,
+    val buttonTextColor: Int,
+)
+
+private fun LayoutNativeAdsMediumBinding.applyColors(
+    colorPalette: NativeAdViewColorPalette,
+) {
+    tvAdvertiser.setTextColor(colorPalette.bodyTextColor)
+    tvBody.setTextColor(colorPalette.bodyTextColor)
+    btnCta.setTextColor(colorPalette.buttonTextColor)
+    btnCta.backgroundTintList = ColorStateList.valueOf(colorPalette.buttonColor)
+    tvHeadline.setTextColor(colorPalette.titleTextColor)
+    tvPrice.setTextColor(colorPalette.bodyTextColor)
+    tvStore.setTextColor(colorPalette.bodyTextColor)
+    tvAd.setTextColor(colorPalette.bodyTextColor)
+}
+
+private fun LayoutNativeAdsMediumBinding.setupNativeAd(
+    nativeAd: NativeAd,
+    key: String,
+) {
+    if (isSameNativeAdBound(nativeAd = nativeAd)) return
+
+    registerNativeAdAssetViews()
+    bindNativeAdAssets(nativeAd = nativeAd)
+    adjustMediaImageBounds()
+
+    root.setNativeAd(nativeAd)
+    root.setTag(R.id.tag_native_ad_view_bound_ad, nativeAd)
+    root.requestLayoutWithDelay(500L)
+
+    Napier.d("NativeAdView: setupNativeAd, ${tvPrice.text}, $key")
+}
+
+private fun LayoutNativeAdsMediumBinding.isSameNativeAdBound(nativeAd: NativeAd): Boolean {
+    val boundNativeAd = root.getTag(R.id.tag_native_ad_view_bound_ad) as? NativeAd
+    return boundNativeAd === nativeAd
+}
+
+private fun LayoutNativeAdsMediumBinding.registerNativeAdAssetViews() {
+    root.advertiserView = tvAdvertiser
+    root.bodyView = tvBody
+    root.callToActionView = btnCta
+    root.headlineView = tvHeadline
+    root.iconView = ivAppIcon
+    root.priceView = tvPrice
+    root.starRatingView = rtbStars
+    root.storeView = tvStore
+    root.mediaView = mvContent
+}
+
+private fun LayoutNativeAdsMediumBinding.bindNativeAdAssets(nativeAd: NativeAd) {
+    tvAdvertiser.text = nativeAd.advertiser.orEmpty()
+    tvBody.text = nativeAd.body.orEmpty()
+    btnCta.text = nativeAd.callToAction.orEmpty()
+    tvHeadline.text = nativeAd.headline.orEmpty()
+    ivAppIcon.setImageDrawable(nativeAd.icon?.drawable)
+    tvPrice.text = nativeAd.price.orEmpty()
+    rtbStars.rating = nativeAd.starRating?.toFloat() ?: 0f
+    tvStore.text = nativeAd.store.orEmpty()
+    mvContent.mediaContent = nativeAd.mediaContent
+
+    tvAdvertiser.visibility = if (nativeAd.advertiser.isNullOrBlank()) View.GONE else View.VISIBLE
+    mvContent.isVisible = nativeAd.mediaContent != null
+}
+
+private fun LayoutNativeAdsMediumBinding.adjustMediaImageBounds() {
+    mvContent.setOnHierarchyChangeListener(object : ViewGroup.OnHierarchyChangeListener {
+        override fun onChildViewAdded(parent: View, child: View) {
+            if (child is ImageView) {
+                child.adjustViewBounds = true
+            }
+        }
+
+        override fun onChildViewRemoved(parent: View, child: View) = Unit
+    })
 }
 
 private fun View.requestLayoutWithDelay(delayMillis: Long) {

--- a/core/ui/src/androidMain/kotlin/me/matsumo/fanbox/core/ui/ads/NativeAdView.android.kt
+++ b/core/ui/src/androidMain/kotlin/me/matsumo/fanbox/core/ui/ads/NativeAdView.android.kt
@@ -13,6 +13,12 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.toArgb
@@ -32,7 +38,8 @@ actual fun NativeAdView(
     modifier: Modifier,
 ) {
     val nativeAdsPreLoader = koinInject<NativeAdsPreLoader>()
-    var nativeAd: NativeAd? = null
+    val nativeAdInventoryVersion by nativeAdsPreLoader.nativeAdInventoryVersion.collectAsState()
+    var nativeAd by remember(key) { mutableStateOf<NativeAd?>(null) }
 
     fun setupNativeAd(binding: LayoutNativeAdsMediumBinding, nativeAd: NativeAd) {
         if (binding.tvPrice.text.isNotBlank()) return
@@ -78,6 +85,12 @@ actual fun NativeAdView(
         Napier.d("NativeAdView: setupNativeAd, ${binding.tvPrice.text}, $key")
     }
 
+    LaunchedEffect(key, nativeAdInventoryVersion) {
+        if (nativeAd == null) {
+            nativeAd = nativeAdsPreLoader.getNativeAd(key)
+        }
+    }
+
     val titleTextColor = MaterialTheme.colorScheme.onSurface.toArgb()
     val bodyTextColor = MaterialTheme.colorScheme.onSurfaceVariant.toArgb()
     val buttonColor = MaterialTheme.colorScheme.primary.toArgb()
@@ -105,7 +118,6 @@ actual fun NativeAdView(
                 binding
             },
             update = {
-                nativeAd = nativeAdsPreLoader.getNativeAd(key)
                 nativeAd?.let { nativeAd -> setupNativeAd(this, nativeAd) }
             },
         )

--- a/core/ui/src/androidMain/kotlin/me/matsumo/fanbox/core/ui/ads/NativeAdsPreLoader.kt
+++ b/core/ui/src/androidMain/kotlin/me/matsumo/fanbox/core/ui/ads/NativeAdsPreLoader.kt
@@ -13,9 +13,14 @@ import com.google.android.gms.ads.nativead.NativeAdOptions
 import io.github.aakira.napier.Napier
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import me.matsumo.fanbox.core.common.PixiViewConfig
 
+/** Android ネイティブ広告のプリロード在庫と表示キーへの割り当てを管理するクラス。 */
 class NativeAdsPreLoader(
     context: Context,
     pixiViewConfig: PixiViewConfig,
@@ -24,7 +29,9 @@ class NativeAdsPreLoader(
     private val scope = CoroutineScope(ioDispatcher)
     private val preloadedNativeAds: MutableList<NativeAd> = mutableListOf()
     private val keyMap: MutableMap<String, NativeAd> = mutableMapOf()
+    private val _nativeAdInventoryVersion = MutableStateFlow(0)
     private val adLoader: AdLoader
+    val nativeAdInventoryVersion: StateFlow<Int> = _nativeAdInventoryVersion.asStateFlow()
 
     init {
         val nativeAdOptions = NativeAdOptions.Builder()
@@ -48,9 +55,7 @@ class NativeAdsPreLoader(
         adLoader = AdLoader.Builder(context, pixiViewConfig.nativeAdUnitId)
             .withNativeAdOptions(nativeAdOptions)
             .withAdListener(adListener)
-            .forNativeAd { nativeAd ->
-                preloadedNativeAds.add(nativeAd)
-            }
+            .forNativeAd(::onNativeAdLoaded)
             .build()
 
         preloadAd()
@@ -87,7 +92,11 @@ class NativeAdsPreLoader(
         keyMap.remove(key)?.destroy()
     }
 
-    companion object {
-        const val NUMBER_OF_PRELOAD_ADS = 4
+    private fun onNativeAdLoaded(nativeAd: NativeAd) {
+        preloadedNativeAds.add(nativeAd)
+        _nativeAdInventoryVersion.update { currentVersion -> currentVersion + 1 }
     }
 }
+
+/** プリロードして保持するネイティブ広告の最大数。 */
+private const val NUMBER_OF_PRELOAD_ADS = 4

--- a/core/ui/src/androidMain/res/values/ids.xml
+++ b/core/ui/src/androidMain/res/values/ids.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <item name="tag_native_ad_view_bound_ad" type="id" />
+</resources>


### PR DESCRIPTION
## 概要
Android の post-item ネイティブ広告で、プリロード完了が Compose に通知されず、初回表示時に空だった広告スロットがスクロール等の再コンポーズまで表示されない問題を修正しました。

Closes #70

## 変更内容
- ① `NativeAdsPreLoader` にプリロード在庫更新を通知する `StateFlow` の世代カウンタを追加
- ① `forNativeAd` のロード完了時に在庫へ追加した後、世代カウンタを更新して購読側へ通知
- ② `NativeAdView` で `nativeAdInventoryVersion` を `collectAsState()` し、プリロード完了後に空スロットへ `getNativeAd(key)` を再実行
- ② `AndroidViewBinding` の `update` で非 observable な取得を行う構造をやめ、Compose state に入った `NativeAd` を binding へ反映
- ③ `tvPrice.text` 依存の重複セットアップ guard を廃止し、`NativeAdView` root の keyed tag に設定済み `NativeAd` 参照を保持して同一広告の `setNativeAd` 重複実行を防止
- ③ binding 初期化・色適用・広告 asset binding を private 関数へ分離し、price 無し広告でも正しくセットアップされるように修正

## 確認
- `JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home rtk ./gradlew :composeApp:compileDebugKotlinAndroid` PASS
- `JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home rtk ./gradlew detekt` PASS