### PR TITLE
Fix interstitial trigger after post detail close

### DIFF
--- a/composeApp/src/commonMain/kotlin/me/matsumo/fanbox/PixiViewApp.kt
+++ b/composeApp/src/commonMain/kotlin/me/matsumo/fanbox/PixiViewApp.kt
@@ -11,6 +11,7 @@ import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
@@ -28,8 +29,11 @@ import kotlinx.coroutines.launch
 import me.matsumo.fanbox.components.PixiViewScreen
 import me.matsumo.fanbox.core.common.PixiViewConfig
 import me.matsumo.fanbox.core.model.ScreenState
+import me.matsumo.fanbox.core.model.Setting
 import me.matsumo.fanbox.core.model.ThemeConfig
 import me.matsumo.fanbox.core.ui.AsyncLoadContents
+import me.matsumo.fanbox.core.ui.ads.InterstitialAdState
+import me.matsumo.fanbox.core.ui.ads.rememberInterstitialAdState
 import me.matsumo.fanbox.core.ui.component.PixiViewBackground
 import me.matsumo.fanbox.core.ui.extensition.LocalNavigationType
 import me.matsumo.fanbox.core.ui.extensition.NavigationType
@@ -78,12 +82,24 @@ fun PixiViewApp(
                 modifier = Modifier.fillMaxSize(),
                 screenState = screenState,
                 containerColor = if (shouldUseDarkTheme) DarkDefaultColorScheme.surface else LightDefaultColorScheme.surface,
-            ) {
+            ) { uiState ->
+                val shouldLoadInterstitialAd = uiState.setting.shouldLoadInterstitialAd()
+                val interstitialAdState = rememberInterstitialAdState(
+                    adUnitId = pixiViewConfig.interstitialAdUnitId,
+                    enable = shouldLoadInterstitialAd,
+                )
+
+                LaunchedEffect(shouldLoadInterstitialAd, interstitialAdState) {
+                    if (shouldLoadInterstitialAd) {
+                        interstitialAdState.load()
+                    }
+                }
+
                 PixiViewTheme(
-                    sessionId = it.sessionId,
-                    fanboxMetadata = it.fanboxMetadata,
-                    themeConfig = it.setting.themeConfig,
-                    themeColorConfig = it.setting.themeColorConfig,
+                    sessionId = uiState.sessionId,
+                    fanboxMetadata = uiState.fanboxMetadata,
+                    themeConfig = uiState.setting.themeConfig,
+                    themeColorConfig = uiState.setting.themeColorConfig,
                     pixiViewConfig = pixiViewConfig,
                     isAdsSdkInitialized = isAdsSdkInitialized,
                     nativeViews = nativeViews,
@@ -92,14 +108,20 @@ fun PixiViewApp(
                     PixiViewBackground(modifier) {
                         PixiViewScreen(
                             modifier = Modifier.fillMaxSize(),
-                            uiState = it,
+                            uiState = uiState,
                             onRequestInitPixiViewId = viewModel::initPixiViewId,
                             onRequestFirstLaunchFlag = viewModel::initFirstLaunchTime,
                             onRequestUpdateState = viewModel::updateState,
+                            onPostDetailClosed = {
+                                handlePostDetailClosedForInterstitialAd(
+                                    viewModel = viewModel,
+                                    interstitialAdState = interstitialAdState,
+                                )
+                            },
                         )
 
                         AnimatedVisibility(
-                            visible = it.isAppLocked,
+                            visible = uiState.isAppLocked,
                             enter = fadeIn(),
                             exit = fadeOut(),
                         ) {
@@ -110,7 +132,7 @@ fun PixiViewApp(
                             )
                         }
 
-                        if (it.isAppLocked) {
+                        if (uiState.isAppLocked) {
                             scope.launch {
                                 if (currentPlatform == Platform.Android) {
                                     // Wait for the bind fragment manager.
@@ -149,6 +171,30 @@ fun PixiViewApp(
             }
         }
     }
+}
+
+private fun Setting.shouldLoadInterstitialAd(): Boolean {
+    return !hasPrivilege && shouldShowInterstitialAd
+}
+
+private suspend fun handlePostDetailClosedForInterstitialAd(
+    viewModel: PixiViewViewModel,
+    interstitialAdState: InterstitialAdState,
+) {
+    viewModel.onPostDetailClosedForInterstitialAd {
+        showInterstitialAdAndReload(interstitialAdState)
+    }
+}
+
+private suspend fun showInterstitialAdAndReload(
+    interstitialAdState: InterstitialAdState,
+): Boolean {
+    val wasShown = interstitialAdState.show()
+    if (wasShown) {
+        interstitialAdState.load()
+    }
+
+    return wasShown
 }
 
 @Composable

--- a/composeApp/src/commonMain/kotlin/me/matsumo/fanbox/PixiViewNavHost.kt
+++ b/composeApp/src/commonMain/kotlin/me/matsumo/fanbox/PixiViewNavHost.kt
@@ -2,14 +2,22 @@ package me.matsumo.fanbox
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
+import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavController
+import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
+import androidx.navigation.compose.ComposeNavigator
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.rememberNavController
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import me.matsumo.fanbox.core.model.Destination
 import me.matsumo.fanbox.core.ui.animation.NavigateAnimation
@@ -51,11 +59,24 @@ internal fun PixiViewNavHost(
     bottomSheetNavigator: BottomSheetNavigator = rememberBottomSheetNavigator(),
     navController: NavHostController = rememberNavController(bottomSheetNavigator),
     startDestination: Destination = Destination.Library,
+    onPostDetailClosed: suspend () -> Unit = {},
 ) {
     val bottomNavigationNavController = rememberNavController()
     val scope = rememberCoroutineScope()
+    val composeNavigator: ComposeNavigator = remember(navController) {
+        navController.navigatorProvider.getNavigator(COMPOSE_NAVIGATOR_NAME)
+    }
+    val currentOnPostDetailClosed by rememberUpdatedState(onPostDetailClosed)
 
     HandleDeepLink(navController)
+
+    LaunchedEffect(navController, composeNavigator) {
+        observePostDetailClosedEntries(
+            navController = navController,
+            composeNavigator = composeNavigator,
+            onPostDetailClosed = { currentOnPostDetailClosed() },
+        )
+    }
 
     CompositionLocalProvider(LocalNavController provides navController) {
         ModalBottomSheetLayout(bottomSheetNavigator) {
@@ -78,6 +99,69 @@ internal fun PixiViewNavHost(
         }
     }
 }
+
+private suspend fun observePostDetailClosedEntries(
+    navController: NavHostController,
+    composeNavigator: ComposeNavigator,
+    onPostDetailClosed: suspend () -> Unit,
+) = coroutineScope {
+    val pendingClosedEntryIds = mutableSetOf<String>()
+    var previousBackStack = composeNavigator.backStack.value
+
+    launch {
+        composeNavigator.backStack.collect { currentBackStack ->
+            pendingClosedEntryIds.addAll(previousBackStack.findClosedPostDetailEntryIds(currentBackStack))
+            previousBackStack = currentBackStack
+            dispatchCompletedPostDetailClosedEntries(
+                pendingClosedEntryIds = pendingClosedEntryIds,
+                visibleEntries = navController.visibleEntries.value,
+                onPostDetailClosed = onPostDetailClosed,
+            )
+        }
+    }
+
+    launch {
+        navController.visibleEntries.collect { visibleEntries ->
+            dispatchCompletedPostDetailClosedEntries(
+                pendingClosedEntryIds = pendingClosedEntryIds,
+                visibleEntries = visibleEntries,
+                onPostDetailClosed = onPostDetailClosed,
+            )
+        }
+    }
+}
+
+private suspend fun dispatchCompletedPostDetailClosedEntries(
+    pendingClosedEntryIds: MutableSet<String>,
+    visibleEntries: List<NavBackStackEntry>,
+    onPostDetailClosed: suspend () -> Unit,
+) {
+    val visibleEntryIds = visibleEntries.map { visibleEntry -> visibleEntry.id }.toSet()
+    val completedEntryIds = pendingClosedEntryIds.filter { pendingEntryId ->
+        !visibleEntryIds.contains(pendingEntryId)
+    }
+
+    for (completedEntryId in completedEntryIds) {
+        pendingClosedEntryIds.remove(completedEntryId)
+        onPostDetailClosed()
+    }
+}
+
+private fun List<NavBackStackEntry>.findClosedPostDetailEntryIds(
+    currentBackStack: List<NavBackStackEntry>,
+): List<String> {
+    val currentEntryIds = currentBackStack.map { currentEntry -> currentEntry.id }.toSet()
+
+    return mapNotNull { previousEntry ->
+        val wasRemoved = !currentEntryIds.contains(previousEntry.id)
+        val isPostDetail = previousEntry.destination.hasRoute<Destination.PostDetail>()
+
+        if (wasRemoved && isPostDetail) previousEntry.id else null
+    }
+}
+
+/** Compose の画面遷移を管理する Navigator の登録名。 */
+private const val COMPOSE_NAVIGATOR_NAME = "composable"
 
 /**
  * mainNavController

--- a/composeApp/src/commonMain/kotlin/me/matsumo/fanbox/PixiViewViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/me/matsumo/fanbox/PixiViewViewModel.kt
@@ -168,6 +168,26 @@ class PixiViewViewModel(
         }
     }
 
+    @OptIn(ExperimentalTime::class)
+    suspend fun onPostDetailClosedForInterstitialAd(
+        showInterstitialAd: suspend () -> Boolean,
+    ) {
+        val setting = settingRepository.setting.first()
+        if (!setting.canHandlePostDetailInterstitialAd()) return
+
+        val currentEpochSeconds = Clock.System.now().epochSeconds
+        val postCloseCount = setting.interstitialPostCloseCount + 1
+
+        settingRepository.setInterstitialPostCloseCount(postCloseCount)
+
+        if (!setting.shouldShowPostDetailInterstitialAd(postCloseCount, currentEpochSeconds)) return
+
+        if (showInterstitialAd()) {
+            settingRepository.setInterstitialPostCloseCount(0)
+            settingRepository.setLastInterstitialShownEpochSeconds(currentEpochSeconds)
+        }
+    }
+
     suspend fun tryToAuthenticate(biometryAuthenticator: BiometryAuthenticator): Boolean = suspendRunCatching {
         biometryAuthenticator.checkBiometryAuthentication(
             requestTitle = getString(Res.string.home_app_lock_title).desc(),
@@ -181,6 +201,29 @@ class PixiViewViewModel(
     )
 }
 
+private fun Setting.canHandlePostDetailInterstitialAd(): Boolean {
+    return !hasPrivilege && shouldShowInterstitialAd
+}
+
+private fun Setting.shouldShowPostDetailInterstitialAd(
+    postCloseCount: Int,
+    currentEpochSeconds: Long,
+): Boolean {
+    val reachesTriggerCount = postCloseCount >= INTERSTITIAL_POST_CLOSE_TRIGGER_COUNT
+    val matchesTriggerInterval = postCloseCount % INTERSTITIAL_POST_CLOSE_TRIGGER_COUNT == 0
+    val elapsedSeconds = currentEpochSeconds - lastInterstitialShownEpochSeconds
+    val satisfiesCooldown = elapsedSeconds >= INTERSTITIAL_AD_COOLDOWN_SECONDS
+
+    return reachesTriggerCount && matchesTriggerInterval && satisfiesCooldown
+}
+
+/** インタースティシャル広告を表示する投稿詳細クローズ回数。 */
+private const val INTERSTITIAL_POST_CLOSE_TRIGGER_COUNT = 3
+
+/** インタースティシャル広告表示後に再表示を抑制する秒数。 */
+private const val INTERSTITIAL_AD_COOLDOWN_SECONDS = 180L
+
+/** アプリ全体の表示状態をまとめた UI モデル。 */
 @Stable
 data class MainUiState(
     val setting: Setting,

--- a/composeApp/src/commonMain/kotlin/me/matsumo/fanbox/PixiViewViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/me/matsumo/fanbox/PixiViewViewModel.kt
@@ -55,6 +55,10 @@ class PixiViewViewModel(
     private val _isAppLockedFlow: MutableStateFlow<Boolean> = MutableStateFlow(true)
     private val _metadataFlow: MutableStateFlow<FanboxMetaData> = MutableStateFlow(getFanboxMetadataDummy())
 
+    // インタースティシャル広告の頻度判定用。永続化せずプロセス内のみ保持する
+    private var interstitialPostCloseCount = 0
+    private var lastInterstitialShownEpochSeconds = 0L
+
     val screenState = combine(
         listOf(
             settingRepository.setting,
@@ -176,15 +180,18 @@ class PixiViewViewModel(
         if (!setting.canHandlePostDetailInterstitialAd()) return
 
         val currentEpochSeconds = Clock.System.now().epochSeconds
-        val postCloseCount = setting.interstitialPostCloseCount + 1
+        interstitialPostCloseCount += 1
 
-        settingRepository.setInterstitialPostCloseCount(postCloseCount)
-
-        if (!setting.shouldShowPostDetailInterstitialAd(postCloseCount, currentEpochSeconds)) return
+        val canShowInterstitialAd = shouldShowPostDetailInterstitialAd(
+            postCloseCount = interstitialPostCloseCount,
+            currentEpochSeconds = currentEpochSeconds,
+            lastShownEpochSeconds = lastInterstitialShownEpochSeconds,
+        )
+        if (!canShowInterstitialAd) return
 
         if (showInterstitialAd()) {
-            settingRepository.setInterstitialPostCloseCount(0)
-            settingRepository.setLastInterstitialShownEpochSeconds(currentEpochSeconds)
+            interstitialPostCloseCount = 0
+            lastInterstitialShownEpochSeconds = currentEpochSeconds
         }
     }
 
@@ -205,13 +212,14 @@ private fun Setting.canHandlePostDetailInterstitialAd(): Boolean {
     return !hasPrivilege && shouldShowInterstitialAd
 }
 
-private fun Setting.shouldShowPostDetailInterstitialAd(
+private fun shouldShowPostDetailInterstitialAd(
     postCloseCount: Int,
     currentEpochSeconds: Long,
+    lastShownEpochSeconds: Long,
 ): Boolean {
     val reachesTriggerCount = postCloseCount >= INTERSTITIAL_POST_CLOSE_TRIGGER_COUNT
     val matchesTriggerInterval = postCloseCount % INTERSTITIAL_POST_CLOSE_TRIGGER_COUNT == 0
-    val elapsedSeconds = currentEpochSeconds - lastInterstitialShownEpochSeconds
+    val elapsedSeconds = currentEpochSeconds - lastShownEpochSeconds
     val satisfiesCooldown = elapsedSeconds >= INTERSTITIAL_AD_COOLDOWN_SECONDS
 
     return reachesTriggerCount && matchesTriggerInterval && satisfiesCooldown

--- a/composeApp/src/commonMain/kotlin/me/matsumo/fanbox/components/PixiViewContent.kt
+++ b/composeApp/src/commonMain/kotlin/me/matsumo/fanbox/components/PixiViewContent.kt
@@ -12,6 +12,7 @@ import me.matsumo.fanbox.core.ui.component.sheet.BottomSheetNavigator
 internal fun PixiViewContent(
     bottomSheetNavigator: BottomSheetNavigator,
     navController: NavHostController,
+    onPostDetailClosed: suspend () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Box(modifier) {
@@ -19,6 +20,7 @@ internal fun PixiViewContent(
             modifier = Modifier.fillMaxSize(),
             bottomSheetNavigator = bottomSheetNavigator,
             navController = navController,
+            onPostDetailClosed = onPostDetailClosed,
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/me/matsumo/fanbox/components/PixiViewScreen.kt
+++ b/composeApp/src/commonMain/kotlin/me/matsumo/fanbox/components/PixiViewScreen.kt
@@ -24,6 +24,7 @@ internal fun PixiViewScreen(
     onRequestInitPixiViewId: () -> Unit,
     onRequestFirstLaunchFlag: () -> Unit,
     onRequestUpdateState: () -> Unit,
+    onPostDetailClosed: suspend () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val bottomSheetNavigator = rememberBottomSheetNavigator()
@@ -68,6 +69,7 @@ internal fun PixiViewScreen(
                 modifier = Modifier.fillMaxSize(),
                 bottomSheetNavigator = bottomSheetNavigator,
                 navController = navController,
+                onPostDetailClosed = onPostDetailClosed,
             )
 
             if (showPaywallFlag) {

--- a/core/datastore/src/commonMain/kotlin/me/matsumo/fanbox/core/datastore/SettingDataStore.kt
+++ b/core/datastore/src/commonMain/kotlin/me/matsumo/fanbox/core/datastore/SettingDataStore.kt
@@ -357,11 +357,19 @@ class SettingDataStore(
         }
     }
 
-    suspend fun setDownloadCountForAd(count: Int) = withContext(ioDispatcher) {
-        if (setting.first().downloadCountForAd == count) return@withContext
+    suspend fun setInterstitialPostCloseCount(count: Int) = withContext(ioDispatcher) {
+        if (setting.first().interstitialPostCloseCount == count) return@withContext
 
         settingPreference.edit {
-            it[intPreferencesKey(Setting::downloadCountForAd.name)] = count
+            it[intPreferencesKey(Setting::interstitialPostCloseCount.name)] = count
+        }
+    }
+
+    suspend fun setLastInterstitialShownEpochSeconds(epochSeconds: Long) = withContext(ioDispatcher) {
+        if (setting.first().lastInterstitialShownEpochSeconds == epochSeconds) return@withContext
+
+        settingPreference.edit {
+            it[longPreferencesKey(Setting::lastInterstitialShownEpochSeconds.name)] = epochSeconds
         }
     }
 }

--- a/core/datastore/src/commonMain/kotlin/me/matsumo/fanbox/core/datastore/SettingDataStore.kt
+++ b/core/datastore/src/commonMain/kotlin/me/matsumo/fanbox/core/datastore/SettingDataStore.kt
@@ -2,7 +2,6 @@ package me.matsumo.fanbox.core.datastore
 
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
-import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import kotlinx.coroutines.CoroutineDispatcher
@@ -354,22 +353,6 @@ class SettingDataStore(
 
         settingPreference.edit {
             it[booleanPreferencesKey(Setting::isPlusMode.name)] = isPlusMode
-        }
-    }
-
-    suspend fun setInterstitialPostCloseCount(count: Int) = withContext(ioDispatcher) {
-        if (setting.first().interstitialPostCloseCount == count) return@withContext
-
-        settingPreference.edit {
-            it[intPreferencesKey(Setting::interstitialPostCloseCount.name)] = count
-        }
-    }
-
-    suspend fun setLastInterstitialShownEpochSeconds(epochSeconds: Long) = withContext(ioDispatcher) {
-        if (setting.first().lastInterstitialShownEpochSeconds == epochSeconds) return@withContext
-
-        settingPreference.edit {
-            it[longPreferencesKey(Setting::lastInterstitialShownEpochSeconds.name)] = epochSeconds
         }
     }
 }

--- a/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/Setting.kt
+++ b/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/Setting.kt
@@ -18,8 +18,6 @@ data class Setting(
     val fileSaveDirectory: String,
     val postSaveDirectory: String,
     val firstLaunchTime: Long,
-    val interstitialPostCloseCount: Int,
-    val lastInterstitialShownEpochSeconds: Long,
     val isAgreedPrivacyPolicy: Boolean,
     val isAgreedTermsOfService: Boolean,
     val isUseAppLock: Boolean,
@@ -40,7 +38,7 @@ data class Setting(
     val isAllowedShowAdultContents get() = !isTestUser && isOverrideAdultContents
 
     @OptIn(ExperimentalTime::class)
-    val shouldShowInterstitialAd get() = (Clock.System.now().epochSeconds - firstLaunchTime) > 7.days.inWholeSeconds
+    val shouldShowInterstitialAd get() = (Clock.System.now().epochSeconds - firstLaunchTime) > 2.days.inWholeSeconds
 
     /** アプリ設定の初期値を生成するオブジェクト。 */
     companion object Companion {
@@ -56,8 +54,6 @@ data class Setting(
                 fileSaveDirectory = "",
                 postSaveDirectory = "",
                 firstLaunchTime = -1L,
-                interstitialPostCloseCount = 0,
-                lastInterstitialShownEpochSeconds = 0L,
                 isAgreedPrivacyPolicy = false,
                 isAgreedTermsOfService = false,
                 isUseAppLock = false,

--- a/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/Setting.kt
+++ b/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/Setting.kt
@@ -6,6 +6,7 @@ import kotlin.time.Clock
 import kotlin.time.Duration.Companion.days
 import kotlin.time.ExperimentalTime
 
+/** アプリ全体のユーザー設定を表すモデル。 */
 @Serializable
 data class Setting(
     val pixiViewId: String,
@@ -17,7 +18,8 @@ data class Setting(
     val fileSaveDirectory: String,
     val postSaveDirectory: String,
     val firstLaunchTime: Long,
-    val downloadCountForAd: Int,
+    val interstitialPostCloseCount: Int,
+    val lastInterstitialShownEpochSeconds: Long,
     val isAgreedPrivacyPolicy: Boolean,
     val isAgreedTermsOfService: Boolean,
     val isUseAppLock: Boolean,
@@ -40,6 +42,7 @@ data class Setting(
     @OptIn(ExperimentalTime::class)
     val shouldShowInterstitialAd get() = (Clock.System.now().epochSeconds - firstLaunchTime) > 7.days.inWholeSeconds
 
+    /** アプリ設定の初期値を生成するオブジェクト。 */
     companion object Companion {
         @OptIn(ExperimentalTime::class)
         fun default(): Setting {
@@ -53,7 +56,8 @@ data class Setting(
                 fileSaveDirectory = "",
                 postSaveDirectory = "",
                 firstLaunchTime = -1L,
-                downloadCountForAd = 0,
+                interstitialPostCloseCount = 0,
+                lastInterstitialShownEpochSeconds = 0L,
                 isAgreedPrivacyPolicy = false,
                 isAgreedTermsOfService = false,
                 isUseAppLock = false,

--- a/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/SettingRepository.kt
+++ b/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/SettingRepository.kt
@@ -39,8 +39,6 @@ interface SettingRepository {
     suspend fun setHideRestricted(isHideRestricted: Boolean)
     suspend fun setDeveloperMode(isDeveloperMode: Boolean)
     suspend fun setPlusMode(isPlusMode: Boolean)
-    suspend fun setInterstitialPostCloseCount(count: Int)
-    suspend fun setLastInterstitialShownEpochSeconds(epochSeconds: Long)
 }
 
 class SettingRepositoryImpl(
@@ -155,13 +153,5 @@ class SettingRepositoryImpl(
                 setAutoImagePreview(false)
             }
         }
-    }
-
-    override suspend fun setInterstitialPostCloseCount(count: Int) {
-        settingDataStore.setInterstitialPostCloseCount(count)
-    }
-
-    override suspend fun setLastInterstitialShownEpochSeconds(epochSeconds: Long) {
-        settingDataStore.setLastInterstitialShownEpochSeconds(epochSeconds)
     }
 }

--- a/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/SettingRepository.kt
+++ b/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/SettingRepository.kt
@@ -39,7 +39,8 @@ interface SettingRepository {
     suspend fun setHideRestricted(isHideRestricted: Boolean)
     suspend fun setDeveloperMode(isDeveloperMode: Boolean)
     suspend fun setPlusMode(isPlusMode: Boolean)
-    suspend fun setDownloadCountForAd(count: Int)
+    suspend fun setInterstitialPostCloseCount(count: Int)
+    suspend fun setLastInterstitialShownEpochSeconds(epochSeconds: Long)
 }
 
 class SettingRepositoryImpl(
@@ -156,7 +157,11 @@ class SettingRepositoryImpl(
         }
     }
 
-    override suspend fun setDownloadCountForAd(count: Int) {
-        settingDataStore.setDownloadCountForAd(count)
+    override suspend fun setInterstitialPostCloseCount(count: Int) {
+        settingDataStore.setInterstitialPostCloseCount(count)
+    }
+
+    override suspend fun setLastInterstitialShownEpochSeconds(epochSeconds: Long) {
+        settingDataStore.setLastInterstitialShownEpochSeconds(epochSeconds)
     }
 }

--- a/core/ui/src/androidMain/kotlin/me/matsumo/fanbox/core/ui/ads/InterstitialAdState.android.kt
+++ b/core/ui/src/androidMain/kotlin/me/matsumo/fanbox/core/ui/ads/InterstitialAdState.android.kt
@@ -17,6 +17,7 @@ import kotlin.concurrent.atomics.AtomicBoolean
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.coroutines.resume
 
+/** Android のインタースティシャル広告ロードと表示状態を管理するクラス。 */
 @Stable
 class InterstitialAdStateImpl internal constructor(
     private val activity: Activity,
@@ -25,11 +26,13 @@ class InterstitialAdStateImpl internal constructor(
 ) : InterstitialAdState {
     private var interstitialAd: InterstitialAd? = null
     private var loaded = false
+    private var loading = false
     private var loadRequestId = 0
 
     override fun load() {
-        if (!enable || loaded) return
+        if (!enable || loaded || loading) return
 
+        loading = true
         val requestId = ++loadRequestId
         val adRequest = AdRequest.Builder().build()
 
@@ -39,6 +42,7 @@ class InterstitialAdStateImpl internal constructor(
 
                 interstitialAd = ad
                 loaded = true
+                loading = false
 
                 Napier.d("InterstitialAd: loaded")
             }
@@ -48,6 +52,7 @@ class InterstitialAdStateImpl internal constructor(
 
                 interstitialAd = null
                 loaded = false
+                loading = false
 
                 Napier.w("InterstitialAd: failed to load, $loadAdError")
             }

--- a/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/detail/PostDetailRootViewModel.kt
+++ b/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/detail/PostDetailRootViewModel.kt
@@ -107,9 +107,9 @@ class PostDetailRootViewModel(
         }
     }
 
-    fun updateDownloadCountForAd(count: Int) {
+    fun updateInterstitialPostCloseCount(count: Int) {
         viewModelScope.launch {
-            settingRepository.setDownloadCountForAd(count)
+            settingRepository.setInterstitialPostCloseCount(count)
         }
     }
 

--- a/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/detail/PostDetailRootViewModel.kt
+++ b/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/detail/PostDetailRootViewModel.kt
@@ -107,12 +107,6 @@ class PostDetailRootViewModel(
         }
     }
 
-    fun updateInterstitialPostCloseCount(count: Int) {
-        viewModelScope.launch {
-            settingRepository.setInterstitialPostCloseCount(count)
-        }
-    }
-
     private fun Flow<PagingData<FanboxPost>>.toIdFlow(): Flow<PagingData<FanboxPostId>> {
         return map { list -> list.map { it.id } }
     }

--- a/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/detail/PostDetailScreen.kt
+++ b/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/detail/PostDetailScreen.kt
@@ -78,7 +78,6 @@ import me.matsumo.fanbox.core.ui.AsyncLoadContents
 import me.matsumo.fanbox.core.ui.LazyPagingItemsLoadContents
 import me.matsumo.fanbox.core.ui.ads.BannerAdView
 import me.matsumo.fanbox.core.ui.ads.NativeAdView
-import me.matsumo.fanbox.core.ui.ads.rememberInterstitialAdState
 import me.matsumo.fanbox.core.ui.appName
 import me.matsumo.fanbox.core.ui.extensition.FadePlaceHolder
 import me.matsumo.fanbox.core.ui.extensition.LocalRevealCanvasState
@@ -92,7 +91,6 @@ import me.matsumo.fanbox.core.ui.extensition.isNullOrEmpty
 import me.matsumo.fanbox.core.ui.extensition.marquee
 import me.matsumo.fanbox.core.ui.extensition.padding
 import me.matsumo.fanbox.core.ui.extensition.revealByStep
-import me.matsumo.fanbox.core.ui.theme.LocalPixiViewConfig
 import me.matsumo.fanbox.core.ui.theme.bold
 import me.matsumo.fanbox.core.ui.theme.center
 import me.matsumo.fanbox.core.ui.view.ErrorView
@@ -150,33 +148,6 @@ internal fun PostDetailRoute(
     val revealState = rememberRevealState()
     val revealOverlayContainerColor = MaterialTheme.colorScheme.tertiaryContainer
     val revealOverlayContentColor = MaterialTheme.colorScheme.onTertiaryContainer
-
-    var interstitialPostCloseCount by remember(uiState.setting.interstitialPostCloseCount) {
-        mutableStateOf(uiState.setting.interstitialPostCloseCount)
-    }
-    val interstitialAdState = rememberInterstitialAdState(
-        adUnitId = LocalPixiViewConfig.current.interstitialAdUnitId,
-        enable = !uiState.setting.hasPrivilege && uiState.setting.shouldShowInterstitialAd,
-    )
-
-    LaunchedEffect(true) {
-        if (!uiState.setting.hasPrivilege && uiState.setting.shouldShowInterstitialAd) {
-            interstitialAdState.load()
-        }
-    }
-
-    suspend fun showInterstitialAdIfNeeded(imageCount: Int) {
-        interstitialPostCloseCount += imageCount
-        viewModel.updateInterstitialPostCloseCount(interstitialPostCloseCount)
-
-        if (interstitialPostCloseCount >= 20) {
-            interstitialAdState.show()
-            interstitialPostCloseCount = 0
-            viewModel.updateInterstitialPostCloseCount(0)
-            delay(500)
-            interstitialAdState.load()
-        }
-    }
 
     Reveal(
         modifier = modifier,
@@ -251,7 +222,6 @@ internal fun PostDetailRoute(
                                 navigateToCommentDeleteDialog = navigateToCommentDeleteDialog,
                                 onPostDetailFetched = { postDetailMap[id] = it },
                                 onRevealCompleted = viewModel::finishReveal,
-                                onShowInterstitialAd = ::showInterstitialAdIfNeeded,
                                 terminate = terminate,
                             )
                         }
@@ -281,7 +251,6 @@ private fun PostDetailView(
     navigateToCommentDeleteDialog: (SimpleAlertContents, () -> Unit) -> Unit,
     onPostDetailFetched: (FanboxPostDetail) -> Unit,
     onRevealCompleted: () -> Unit,
-    onShowInterstitialAd: suspend (Int) -> Unit,
     terminate: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: PostDetailViewModel = koinViewModel(key = postId.value) {
@@ -362,7 +331,6 @@ private fun PostDetailView(
             onClickFile = {
                 scope.launch {
                     viewModel.downloadFiles(uiState.postDetail.id, uiState.postDetail.title, listOf(it))
-                    onShowInterstitialAd(1)
                     snackExtension.show(
                         snackbarHostState = snackbarHostState,
                         message = Res.string.queue_added,
@@ -378,7 +346,6 @@ private fun PostDetailView(
             onClickDownloadImages = {
                 scope.launch {
                     viewModel.downloadImages(uiState.postDetail.id, uiState.postDetail.title, it)
-                    onShowInterstitialAd(it.size)
                     snackExtension.show(
                         snackbarHostState = snackbarHostState,
                         message = Res.string.queue_added,

--- a/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/detail/PostDetailScreen.kt
+++ b/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/detail/PostDetailScreen.kt
@@ -151,7 +151,9 @@ internal fun PostDetailRoute(
     val revealOverlayContainerColor = MaterialTheme.colorScheme.tertiaryContainer
     val revealOverlayContentColor = MaterialTheme.colorScheme.onTertiaryContainer
 
-    var downloadCount by remember(uiState.setting.downloadCountForAd) { mutableStateOf(uiState.setting.downloadCountForAd) }
+    var interstitialPostCloseCount by remember(uiState.setting.interstitialPostCloseCount) {
+        mutableStateOf(uiState.setting.interstitialPostCloseCount)
+    }
     val interstitialAdState = rememberInterstitialAdState(
         adUnitId = LocalPixiViewConfig.current.interstitialAdUnitId,
         enable = !uiState.setting.hasPrivilege && uiState.setting.shouldShowInterstitialAd,
@@ -164,13 +166,13 @@ internal fun PostDetailRoute(
     }
 
     suspend fun showInterstitialAdIfNeeded(imageCount: Int) {
-        downloadCount += imageCount
-        viewModel.updateDownloadCountForAd(downloadCount)
+        interstitialPostCloseCount += imageCount
+        viewModel.updateInterstitialPostCloseCount(interstitialPostCloseCount)
 
-        if (downloadCount >= 20) {
+        if (interstitialPostCloseCount >= 20) {
             interstitialAdState.show()
-            downloadCount = 0
-            viewModel.updateDownloadCountForAd(0)
+            interstitialPostCloseCount = 0
+            viewModel.updateInterstitialPostCloseCount(0)
             delay(500)
             interstitialAdState.load()
         }


### PR DESCRIPTION
## 概要

Closes #71

Android のインタースティシャル広告表示トリガーを、従来のダウンロード累計起点から「投稿詳細を閉じて一覧へ戻った後」の自然な切れ目へ変更しました。

## 確定仕様

- トリガー: PostDetail が pop され、画面遷移完了後にのみ判定
- 頻度: 投稿詳細クローズ回数が 3 回の倍数に到達したとき
- クールダウン: 前回表示成功から 180 秒以上経過しているとき
- 表示条件: 頻度条件とクールダウン条件は AND
- 既存ガード維持: `hasPrivilege` と `shouldShowInterstitialAd`
- 対象外: PostImage のクローズ、Welcome/ログイン、HorizontalPager のスワイプ、その他画面の pop

## 変更内容

### ① 状態の置き換え

- `downloadCountForAd` を `interstitialPostCloseCount` に置き換え
- `lastInterstitialShownEpochSeconds` を追加
- `Setting` / `SettingDataStore` / `SettingRepository` の読み書きを更新

### ② トリガーロジックの作り替え

- PostDetail 内のダウンロード起点広告表示を削除
- アプリ階層でインタースティシャルを保持・ロードするよう変更
- `ComposeNavigator.backStack` と `navController.visibleEntries` を監視し、PostDetail の pop 完了後に広告判定を実行
- 表示成功時のみクローズ回数を 0 に戻し、表示時刻を更新して次回分をロード

### ③ 範囲の限定

- pop された back stack entry が `Destination.PostDetail` の場合だけクローズイベントを発火
- PostImage への遷移や PostImage の close ではカウント・表示が発生しないように限定

## 検証

- `rtk ./gradlew :composeApp:compileDebugKotlinAndroid` 成功
- `rtk ./gradlew detekt` 成功
- `rtk ./gradlew :composeApp:installDebug` 成功
- Android SDK 36 実機で PostDetail を開き、システム戻るジェスチャーで一覧へ戻ることを確認
- 同実機ログで `CoreBackPreview` の animation callback が出ることを確認
- Android SDK 36 実機で TopAppBar の戻るボタンから一覧へ戻ることを確認
- 上記操作中に `FATAL EXCEPTION` が出ていないことを確認
