### PR TITLE
fix: destroy native ads on dispose

### DIFF
--- a/core/ui/src/androidMain/kotlin/me/matsumo/fanbox/core/ui/ads/NativeAdView.android.kt
+++ b/core/ui/src/androidMain/kotlin/me/matsumo/fanbox/core/ui/ads/NativeAdView.android.kt
@@ -14,6 +14,7 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -44,9 +45,21 @@ actual fun NativeAdView(
     val nativeAdInventoryVersion by nativeAdsPreLoader.nativeAdInventoryVersion.collectAsState()
     var nativeAd by remember(key) { mutableStateOf<NativeAd?>(null) }
 
-    LaunchedEffect(key, nativeAdInventoryVersion) {
+    LaunchedEffect(
+        key1 = key,
+        key2 = nativeAdInventoryVersion,
+    ) {
         if (nativeAd == null) {
             nativeAd = nativeAdsPreLoader.getNativeAd(key)
+        }
+    }
+
+    DisposableEffect(
+        key1 = key,
+        key2 = nativeAdsPreLoader,
+    ) {
+        onDispose {
+            nativeAdsPreLoader.popAd(key = key)
         }
     }
 


### PR DESCRIPTION
## 概要

- Android の `NativeAdView` に `DisposableEffect` を追加し、Composable が破棄されるタイミングで `NativeAdsPreLoader.popAd(key)` を呼ぶようにしました。
- 広告在庫更新時の再取得処理は既存の `getNativeAd` フローを維持しつつ、`LaunchedEffect` のキー指定を名前付き引数に整理しました。

## 背景

#76 で報告されている通り、表示キーに割り当てた `NativeAd` が `keyMap` に残り続け、`destroy()` されないまま蓄積する可能性がありました。

## 影響

- Lazy リストなどで `NativeAdView` が composition から外れたタイミングで、割り当て済みの `NativeAd` が破棄されます。
- 再表示が必要な場合は、既存の `getNativeAd` によりプリロード済み広告を再割り当てします。

## 動作確認

- IntelliJ `build_project`: 成功
- `JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home ./gradlew :core:ui:compileDebugKotlinAndroid`: 成功
- `JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home ./gradlew :core:ui:detekt`: 成功

Closes #76