### PR TITLE
fix: initialize ads after mediation setup

### DIFF
--- a/composeApp/src/androidMain/kotlin/me/matsumo/fanbox/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/me/matsumo/fanbox/MainActivity.kt
@@ -19,12 +19,16 @@ import androidx.lifecycle.lifecycleScope
 import com.applovin.sdk.AppLovinMediationProvider
 import com.applovin.sdk.AppLovinPrivacySettings
 import com.applovin.sdk.AppLovinSdk
+import com.applovin.sdk.AppLovinSdkConfiguration
 import com.applovin.sdk.AppLovinSdkInitializationConfiguration
 import com.google.ads.mediation.inmobi.InMobiConsent
 import com.google.android.gms.ads.MobileAds
+import com.google.android.gms.ads.initialization.AdapterStatus
+import com.google.android.gms.ads.initialization.InitializationStatus
 import com.inmobi.sdk.InMobiSdk
 import com.unity3d.ads.metadata.MetaData
 import com.vungle.ads.VunglePrivacySettings
+import io.github.aakira.napier.Napier
 import kotlinx.collections.immutable.persistentMapOf
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -109,13 +113,12 @@ class MainActivity : FragmentActivity(), KoinComponent {
             return
         }
 
+        configureMediationPrivacySettings()
+        initializeAppLovinSdk()
+    }
+
+    private fun configureMediationPrivacySettings() {
         // AppLovin
-        AppLovinSdk.getInstance(this).initialize(
-            AppLovinSdkInitializationConfiguration.builder(BuildKonfig.APPLOVIN_SDK_KEY)
-                .setMediationProvider(AppLovinMediationProvider.ADMOB)
-                .build(),
-            null,
-        )
         AppLovinPrivacySettings.setHasUserConsent(true)
 
         // InMobi
@@ -140,9 +143,67 @@ class MainActivity : FragmentActivity(), KoinComponent {
         val ccpaMetaData = MetaData(this)
         ccpaMetaData["privacy.consent"] = true
         ccpaMetaData.commit()
+    }
 
-        MobileAds.initialize(this) {
-            viewModel.setAdsSdkInitialized()
+    private fun initializeAppLovinSdk() {
+        val appLovinSdkKey = BuildKonfig.APPLOVIN_SDK_KEY
+
+        if (appLovinSdkKey.isBlank()) {
+            Napier.w { "AppLovin SDK key is blank. Skip AppLovin SDK initialization." }
+            initializeMobileAdsSdk()
+            return
+        }
+
+        val initializationConfiguration = AppLovinSdkInitializationConfiguration.builder(appLovinSdkKey)
+            .setMediationProvider(AppLovinMediationProvider.ADMOB)
+            .build()
+
+        AppLovinSdk.getInstance(this).initialize(
+            initializationConfiguration,
+            ::onAppLovinSdkInitialized,
+        )
+    }
+
+    private fun onAppLovinSdkInitialized(sdkConfiguration: AppLovinSdkConfiguration) {
+        Napier.d { "AppLovin SDK initialized: $sdkConfiguration" }
+        initializeMobileAdsSdk()
+    }
+
+    private fun initializeMobileAdsSdk() {
+        MobileAds.initialize(
+            this,
+            ::onMobileAdsInitialized,
+        )
+    }
+
+    private fun onMobileAdsInitialized(initializationStatus: InitializationStatus) {
+        logAdapterInitializationStatus(initializationStatus = initializationStatus)
+        viewModel.setAdsSdkInitialized()
+    }
+
+    private fun logAdapterInitializationStatus(initializationStatus: InitializationStatus) {
+        for ((adapterClassName, adapterStatus) in initializationStatus.adapterStatusMap) {
+            logAdapterInitializationStatus(
+                adapterClassName = adapterClassName,
+                adapterStatus = adapterStatus,
+            )
+        }
+    }
+
+    private fun logAdapterInitializationStatus(
+        adapterClassName: String,
+        adapterStatus: AdapterStatus,
+    ) {
+        val initializationState = adapterStatus.initializationState
+        val logMessage = "MobileAds adapter initialized: $adapterClassName, " +
+            "state=$initializationState, " +
+            "latency=${adapterStatus.latency}, " +
+            "description=${adapterStatus.description}"
+
+        if (initializationState == AdapterStatus.State.READY) {
+            Napier.d { logMessage }
+        } else {
+            Napier.w { logMessage }
         }
     }
 }

--- a/composeApp/src/androidMain/kotlin/me/matsumo/fanbox/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/me/matsumo/fanbox/MainActivity.kt
@@ -30,6 +30,7 @@ import com.unity3d.ads.metadata.MetaData
 import com.vungle.ads.VunglePrivacySettings
 import io.github.aakira.napier.Napier
 import kotlinx.collections.immutable.persistentMapOf
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.buildJsonObject
@@ -43,10 +44,12 @@ import me.matsumo.fanbox.feature.service.DownloadPostService
 import org.json.JSONObject
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.core.component.KoinComponent
+import java.util.concurrent.atomic.AtomicBoolean
 
 class MainActivity : FragmentActivity(), KoinComponent {
 
     private val viewModel by viewModel<MainViewModel>()
+    private val isMobileAdsSdkInitializationStarted = AtomicBoolean(false)
     private var stayTime = 0L
 
     @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
@@ -150,7 +153,7 @@ class MainActivity : FragmentActivity(), KoinComponent {
 
         if (appLovinSdkKey.isBlank()) {
             Napier.w { "AppLovin SDK key is blank. Skip AppLovin SDK initialization." }
-            initializeMobileAdsSdk()
+            tryInitializeMobileAdsSdk()
             return
         }
 
@@ -162,18 +165,39 @@ class MainActivity : FragmentActivity(), KoinComponent {
             initializationConfiguration,
             ::onAppLovinSdkInitialized,
         )
+        startAppLovinInitializationTimeout()
     }
 
     private fun onAppLovinSdkInitialized(sdkConfiguration: AppLovinSdkConfiguration) {
         Napier.d { "AppLovin SDK initialized: $sdkConfiguration" }
-        initializeMobileAdsSdk()
+        tryInitializeMobileAdsSdk()
     }
 
-    private fun initializeMobileAdsSdk() {
+    private fun startAppLovinInitializationTimeout() {
+        lifecycleScope.launch {
+            waitForAppLovinInitializationTimeout()
+        }
+    }
+
+    private suspend fun waitForAppLovinInitializationTimeout() {
+        delay(APPLOVIN_INITIALIZATION_TIMEOUT_MILLIS)
+
+        val isFallbackInitializationStarted = tryInitializeMobileAdsSdk()
+        if (isFallbackInitializationStarted) {
+            Napier.w { "AppLovin SDK initialization timed out. Start MobileAds initialization." }
+        }
+    }
+
+    private fun tryInitializeMobileAdsSdk(): Boolean {
+        if (!isMobileAdsSdkInitializationStarted.compareAndSet(false, true)) {
+            return false
+        }
+
         MobileAds.initialize(
             this,
             ::onMobileAdsInitialized,
         )
+        return true
     }
 
     private fun onMobileAdsInitialized(initializationStatus: InitializationStatus) {
@@ -207,3 +231,6 @@ class MainActivity : FragmentActivity(), KoinComponent {
         }
     }
 }
+
+/** AppLovin SDK 初期化 callback を待つ最大時間。 */
+private const val APPLOVIN_INITIALIZATION_TIMEOUT_MILLIS = 5_000L

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,7 +47,7 @@ androidxCompose = "2025.08.00"
 # Google
 playReview = "2.0.2"
 playUpdate = "2.1.0"
-playServiceAds = "25.3.0"
+playServiceAds = "25.2.0"
 playServiceOss = "17.2.2"
 material = "1.12.0"
 ksp = "2.2.10-2.0.2"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,7 +47,7 @@ androidxCompose = "2025.08.00"
 # Google
 playReview = "2.0.2"
 playUpdate = "2.1.0"
-playServiceAds = "24.5.0"
+playServiceAds = "25.3.0"
 playServiceOss = "17.2.2"
 material = "1.12.0"
 ksp = "2.2.10-2.0.2"
@@ -172,11 +172,11 @@ play-service-ads = { module = "com.google.android.gms:play-services-ads", versio
 google-material = { module = "com.google.android.material:material", version.ref = "material" }
 
 # Ads
-ads-unity-core = { module = "com.unity3d.ads:unity-ads", version = "4.16.0" }
-ads-unity = { module = "com.google.ads.mediation:unity", version = "4.16.0.0" }
-ads-applovin = { module = "com.google.ads.mediation:applovin", version = "13.3.1.1" }
-ads-inmobi = { module = "com.google.ads.mediation:inmobi", version = "10.8.7.0" }
-ads-liftoff = { module = "com.google.ads.mediation:vungle", version = "7.5.1.0" }
+ads-unity-core = { module = "com.unity3d.ads:unity-ads", version = "4.18.0" }
+ads-unity = { module = "com.google.ads.mediation:unity", version = "4.18.0.0" }
+ads-applovin = { module = "com.google.ads.mediation:applovin", version = "13.6.2.0" }
+ads-inmobi = { module = "com.google.ads.mediation:inmobi", version = "11.3.0.0" }
+ads-liftoff = { module = "com.google.ads.mediation:vungle", version = "7.7.4.0" }
 
 # Firebase
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebase" }


### PR DESCRIPTION
## 概要

- Android の広告 SDK 初期化フローを整理し、メディエーション各社の同意設定を先に反映してから AppLovin SDK を初期化するようにしました。
- AppLovin SDK の初期化完了 callback 後に `MobileAds.initialize()` を呼び、起動直後の広告リクエスト前にメディエーション adapter 初期化が進む順序へ変更しました。
- `MobileAds.initialize()` 完了時に各 adapter の `AdapterStatus` をログ出力し、READY かどうかを確認できるようにしました。
- Google Maven metadata を確認し、AdMob / メディエーション adapter を現行の最新系へ更新しました。

## 裏付け調査

- ローカルコードでは `AppLovinSdk.initialize(..., null)` の直後に `MobileAds.initialize()` が呼ばれており、AppLovin 初期化完了を待っていませんでした。
- AdMob 公式ドキュメントでは、`MobileAds.initialize()` 中にメディエーション adapter も初期化され、広告ロード前に初期化完了を待つことが重要とされています。
  - https://developers.google.com/admob/android/mediation
- `MobileAds` API には `getInitializationStatus()` と初期化完了 listener があり、adapter 状態の確認に使えることを確認しました。
  - https://developers.google.com/admob/android/reference/com/google/android/gms/ads/MobileAds
- AppLovin SDK 公式ガイドでは SDK 初期化完了 callback を使って広告ロード開始に進む構成が示されています。
  - https://support.axon.ai/en/max/android/overview/integration/
- Google Maven metadata で最新 version を確認しました。
  - `play-services-ads`: 25.3.0
  - `com.google.ads.mediation:applovin`: 13.6.2.0
  - `com.google.ads.mediation:inmobi`: 11.3.0.0
  - `com.google.ads.mediation:unity`: 4.18.0.0
  - `com.google.ads.mediation:vungle`: 7.7.4.0

## 動作確認

- `JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home ./gradlew :composeApp:compileDebugKotlinAndroid`: 成功
- `JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home ./gradlew :composeApp:detekt`: 成功
- `JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home ./gradlew :composeApp:assembleDebug`: 成功

`assembleDebug` では既存依存由来の Amazon Appstore SDK の D8 warning と `extractNativeLibs` warning が出ていますが、ビルドは成功しています。

Closes #79