### PR TITLE
Fix native ad SDK initialization gating

### DIFF
--- a/core/ui/src/androidMain/kotlin/me/matsumo/fanbox/core/ui/ads/NativeAdView.android.kt
+++ b/core/ui/src/androidMain/kotlin/me/matsumo/fanbox/core/ui/ads/NativeAdView.android.kt
@@ -7,7 +7,9 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.ViewParent
 import android.widget.ImageView
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -44,10 +46,24 @@ actual fun NativeAdView(
 ) {
     val isAdsSdkInitialized = LocalAdsSdkInitialized.current
 
-    if (!isAdsSdkInitialized) {
-        return
+    Card(
+        modifier = modifier.clip(RoundedCornerShape(8.dp)),
+        shape = RoundedCornerShape(8.dp),
+        colors = CardDefaults.cardColors(MaterialTheme.colorScheme.surfaceColorAtElevation(2.dp)),
+    ) {
+        if (isAdsSdkInitialized) {
+            NativeAdViewContent(key = key)
+        } else {
+            NativeAdViewPlaceholder()
+        }
     }
+}
 
+@Composable
+private fun NativeAdViewContent(
+    key: String,
+    modifier: Modifier = Modifier,
+) {
     val nativeAdsPreLoader = koinInject<NativeAdsPreLoader>()
     val nativeAdInventoryVersion by nativeAdsPreLoader.nativeAdInventoryVersion.collectAsState()
     var nativeAd by remember(key) { mutableStateOf<NativeAd?>(null) }
@@ -79,31 +95,36 @@ actual fun NativeAdView(
         buttonTextColor = buttonTextColor,
     )
 
-    Card(
-        modifier = modifier.clip(RoundedCornerShape(8.dp)),
-        shape = RoundedCornerShape(8.dp),
-        colors = CardDefaults.cardColors(MaterialTheme.colorScheme.surfaceColorAtElevation(2.dp)),
-    ) {
-        AndroidViewBinding(
-            modifier = Modifier.fillMaxWidth(),
-            factory = { inflater, parent, attachToParent ->
-                createNativeAdBinding(
-                    inflater = inflater,
-                    parent = parent,
-                    attachToParent = attachToParent,
-                    colorPalette = colorPalette,
+    AndroidViewBinding(
+        modifier = modifier.fillMaxWidth(),
+        factory = { inflater, parent, attachToParent ->
+            createNativeAdBinding(
+                inflater = inflater,
+                parent = parent,
+                attachToParent = attachToParent,
+                colorPalette = colorPalette,
+            )
+        },
+        update = {
+            nativeAd?.let { loadedNativeAd ->
+                setupNativeAd(
+                    nativeAd = loadedNativeAd,
+                    key = key,
                 )
-            },
-            update = {
-                nativeAd?.let { loadedNativeAd ->
-                    setupNativeAd(
-                        nativeAd = loadedNativeAd,
-                        key = key,
-                    )
-                }
-            },
-        )
-    }
+            }
+        },
+    )
+}
+
+@Composable
+private fun NativeAdViewPlaceholder(
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(NativeAdPlaceholderHeight),
+    )
 }
 
 private fun createNativeAdBinding(
@@ -220,3 +241,6 @@ private fun ViewParent?.findAndroidComposeViewParent(): ViewParent? = when {
     this != null -> this.parent.findAndroidComposeViewParent()
     else -> null
 }
+
+/** SDK 初期化前にネイティブ広告枠として確保する高さ。 */
+private val NativeAdPlaceholderHeight = 60.dp

--- a/core/ui/src/androidMain/kotlin/me/matsumo/fanbox/core/ui/ads/NativeAdView.android.kt
+++ b/core/ui/src/androidMain/kotlin/me/matsumo/fanbox/core/ui/ads/NativeAdView.android.kt
@@ -33,6 +33,7 @@ import com.google.android.gms.ads.nativead.NativeAd
 import io.github.aakira.napier.Napier
 import me.matsumo.fanbox.core.ui.R
 import me.matsumo.fanbox.core.ui.databinding.LayoutNativeAdsMediumBinding
+import me.matsumo.fanbox.core.ui.theme.LocalAdsSdkInitialized
 import org.koin.compose.koinInject
 
 @SuppressLint("MissingPermission")
@@ -41,6 +42,12 @@ actual fun NativeAdView(
     key: String,
     modifier: Modifier,
 ) {
+    val isAdsSdkInitialized = LocalAdsSdkInitialized.current
+
+    if (!isAdsSdkInitialized) {
+        return
+    }
+
     val nativeAdsPreLoader = koinInject<NativeAdsPreLoader>()
     val nativeAdInventoryVersion by nativeAdsPreLoader.nativeAdInventoryVersion.collectAsState()
     var nativeAd by remember(key) { mutableStateOf<NativeAd?>(null) }
@@ -49,9 +56,7 @@ actual fun NativeAdView(
         key1 = key,
         key2 = nativeAdInventoryVersion,
     ) {
-        if (nativeAd == null) {
-            nativeAd = nativeAdsPreLoader.getNativeAd(key)
-        }
+        nativeAd = nativeAd ?: nativeAdsPreLoader.getNativeAd(key)
     }
 
     DisposableEffect(

--- a/core/ui/src/androidMain/kotlin/me/matsumo/fanbox/core/ui/ads/NativeAdsPreLoader.kt
+++ b/core/ui/src/androidMain/kotlin/me/matsumo/fanbox/core/ui/ads/NativeAdsPreLoader.kt
@@ -57,39 +57,47 @@ class NativeAdsPreLoader(
             .withAdListener(adListener)
             .forNativeAd(::onNativeAdLoaded)
             .build()
-
-        preloadAd()
     }
 
     @SuppressLint("MissingPermission")
-    fun preloadAd() {
+    private fun preloadAd() {
         if (adLoader.isLoading) return
 
         scope.launch {
-            val numberOfAds = NUMBER_OF_PRELOAD_ADS - preloadedNativeAds.count()
-            if (numberOfAds > 0) {
-                adLoader.loadAds(AdRequest.Builder().build(), numberOfAds)
-            }
+            loadMissingNativeAds()
         }
     }
 
     fun getNativeAd(key: String): NativeAd? {
         Napier.d("getNativeAd: $key, ${keyMap.containsKey(key)}, ${keyMap.size}, ${preloadedNativeAds.size}")
 
-        keyMap[key]?.let { return it }
-        preloadedNativeAds.removeFirstOrNull()?.also {
-            preloadAd()
-
-            keyMap[key] = it
-            return it
+        val mappedNativeAd = keyMap[key]
+        if (mappedNativeAd != null) {
+            return mappedNativeAd
         }
 
-        return null
+        val preloadedNativeAd = preloadedNativeAds.removeFirstOrNull()
+        if (preloadedNativeAd == null) {
+            preloadAd()
+            return null
+        }
+
+        preloadAd()
+        keyMap[key] = preloadedNativeAd
+
+        return preloadedNativeAd
     }
 
     fun popAd(key: String) {
         Napier.d("popAd: $key")
         keyMap.remove(key)?.destroy()
+    }
+
+    private fun loadMissingNativeAds() {
+        val numberOfAds = NUMBER_OF_PRELOAD_ADS - preloadedNativeAds.count()
+        if (numberOfAds > 0) {
+            adLoader.loadAds(AdRequest.Builder().build(), numberOfAds)
+        }
     }
 
     private fun onNativeAdLoaded(nativeAd: NativeAd) {

--- a/core/ui/src/androidMain/kotlin/me/matsumo/fanbox/core/ui/ads/NativeAdsPreLoader.kt
+++ b/core/ui/src/androidMain/kotlin/me/matsumo/fanbox/core/ui/ads/NativeAdsPreLoader.kt
@@ -11,22 +11,17 @@ import com.google.android.gms.ads.VideoOptions
 import com.google.android.gms.ads.nativead.NativeAd
 import com.google.android.gms.ads.nativead.NativeAdOptions
 import io.github.aakira.napier.Napier
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
 import me.matsumo.fanbox.core.common.PixiViewConfig
 
 /** Android ネイティブ広告のプリロード在庫と表示キーへの割り当てを管理するクラス。 */
 class NativeAdsPreLoader(
     context: Context,
     pixiViewConfig: PixiViewConfig,
-    ioDispatcher: CoroutineDispatcher,
 ) {
-    private val scope = CoroutineScope(ioDispatcher)
     private val preloadedNativeAds: MutableList<NativeAd> = mutableListOf()
     private val keyMap: MutableMap<String, NativeAd> = mutableMapOf()
     private val _nativeAdInventoryVersion = MutableStateFlow(0)
@@ -63,9 +58,7 @@ class NativeAdsPreLoader(
     private fun preloadAd() {
         if (adLoader.isLoading) return
 
-        scope.launch {
-            loadMissingNativeAds()
-        }
+        loadMissingNativeAds()
     }
 
     fun getNativeAd(key: String): NativeAd? {

--- a/core/ui/src/androidMain/kotlin/me/matsumo/fanbox/core/ui/di/UiModule.android.kt
+++ b/core/ui/src/androidMain/kotlin/me/matsumo/fanbox/core/ui/di/UiModule.android.kt
@@ -27,7 +27,6 @@ actual val uiSubModule: Module = module {
         NativeAdsPreLoader(
             context = get(),
             pixiViewConfig = get(),
-            ioDispatcher = get(),
         )
     }
 


### PR DESCRIPTION
## 概要

NativeAdView が Google Mobile Ads SDK の初期化完了前にネイティブ広告をリクエストし得る問題を修正しました。

## 変更内容

- `NativeAdView` で `LocalAdsSdkInitialized` を確認し、初期化完了前は `NativeAdsPreLoader` の注入と広告取得を行わないようにしました
- SDK 初期化前もネイティブ広告枠の placeholder 高さを確保し、初期化完了時のレイアウト変化を抑えました
- `NativeAdsPreLoader` の constructor 直後の `preloadAd()` を削除し、初期化完了後の `getNativeAd()` 経由で preload を開始するようにしました
- `NativeAdsPreLoader` の `ioDispatcher` 経由ロードをやめ、広告ロードと在庫コレクション操作を呼び出し元スレッド側に寄せました

## 原因

`NativeAdsPreLoader` は Koin の `single` として初回注入時に生成され、constructor 内で即 `preloadAd()` を実行していました。そのため、`NativeAdView` が表示されたタイミングによっては SDK / メディエーション初期化完了前にネイティブ広告ロードが始まる可能性がありました。

## 確認項目

- `:core:ui:detekt`
- `:core:ui:compileDebugKotlinAndroid`
- `:composeApp:compileDebugKotlinAndroid`

Closes #85