### PR TITLE
[codex] Add Android Plus trial handling

### DIFF
--- a/composeApp/src/commonMain/kotlin/me/matsumo/fanbox/PixiViewViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/me/matsumo/fanbox/PixiViewViewModel.kt
@@ -122,8 +122,11 @@ class PixiViewViewModel(
         viewModelScope.launch {
             delay(3000)
 
-            suspendRunCatching { billingClient.hasPlus() }.onSuccess {
-                settingRepository.setPlusMode(it)
+            suspendRunCatching { billingClient.getPlusStatus() }.onSuccess { plusStatus ->
+                settingRepository.setPlusStatus(
+                    isPlusMode = plusStatus.isActive,
+                    isPlusTrial = plusStatus.isTrial,
+                )
             }
         }
     }

--- a/core/billing/src/commonMain/kotlin/me/matsumo/fanbox/core/billing/BillingClient.kt
+++ b/core/billing/src/commonMain/kotlin/me/matsumo/fanbox/core/billing/BillingClient.kt
@@ -104,6 +104,7 @@ class BillingClient(
 
         val isActive = entitlement?.isActive == true
         val isTrialPeriod = entitlement?.periodType == PeriodType.TRIAL
+        // iOS でトライアル対応する場合は、この Android 限定ガードを見直す。
         val isTrial = isActive && isAndroidPlatform() && isTrialPeriod
 
         return BillingPlusStatus(

--- a/core/billing/src/commonMain/kotlin/me/matsumo/fanbox/core/billing/BillingClient.kt
+++ b/core/billing/src/commonMain/kotlin/me/matsumo/fanbox/core/billing/BillingClient.kt
@@ -6,16 +6,24 @@ import com.revenuecat.purchases.kmp.configure
 import com.revenuecat.purchases.kmp.ktx.awaitCustomerInfo
 import com.revenuecat.purchases.kmp.ktx.awaitOfferings
 import com.revenuecat.purchases.kmp.ktx.awaitPurchase
+import com.revenuecat.purchases.kmp.models.CustomerInfo
 import com.revenuecat.purchases.kmp.models.PackageType
+import com.revenuecat.purchases.kmp.models.Period
+import com.revenuecat.purchases.kmp.models.PeriodType
+import com.revenuecat.purchases.kmp.models.PeriodUnit
 import com.revenuecat.purchases.kmp.models.StoreProduct
+import com.revenuecat.purchases.kmp.models.freePhase
 import io.github.aakira.napier.Napier
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import me.matsumo.fanbox.core.common.PixiViewConfig
 import me.matsumo.fanbox.core.model.BillingPlan
+import me.matsumo.fanbox.core.model.BillingPlusStatus
+import me.matsumo.fanbox.core.model.BillingTrialPeriod
 import kotlin.coroutines.resume
 
+/** RevenueCat を利用して Plus 課金状態を扱うクライアント。 */
 class BillingClient(
     val pixiViewConfig: PixiViewConfig,
     val ioDispatcher: CoroutineDispatcher,
@@ -27,33 +35,36 @@ class BillingClient(
         Purchases.configure(pixiViewConfig.purchaseApiKey.orEmpty())
     }
 
-    suspend fun hasPlus(): Boolean = withContext(ioDispatcher) {
+    suspend fun getPlusStatus(): BillingPlusStatus = withContext(ioDispatcher) {
         val customerInfo = Purchases.sharedInstance.awaitCustomerInfo()
-        val entitlement = customerInfo.entitlements[PLUS_ENTITLEMENT_ID]
 
-        Napier.d { "entitlement: $entitlement" }
-
-        return@withContext entitlement?.isActive == true
+        return@withContext customerInfo.toBillingPlusStatus()
     }
 
-    suspend fun purchase(type: BillingPlan.Type) = withContext(ioDispatcher) {
-        val product = planCache[type] ?: return@withContext false
+    suspend fun purchase(type: BillingPlan.Type): BillingPlusStatus = withContext(ioDispatcher) {
+        val product = planCache[type] ?: return@withContext BillingPlusStatus(
+            isActive = false,
+            isTrial = false,
+        )
         val result = Purchases.sharedInstance.awaitPurchase(product)
-        val entitlement = result.customerInfo.entitlements[PLUS_ENTITLEMENT_ID]
 
-        return@withContext entitlement?.isActive == true
+        return@withContext result.customerInfo.toBillingPlusStatus()
     }
 
-    suspend fun restore() = suspendCancellableCoroutine { continuation ->
+    suspend fun restore(): BillingPlusStatus = suspendCancellableCoroutine { continuation ->
         Purchases.sharedInstance.restorePurchases(
             onSuccess = {
                 Napier.d { "restore success: $it" }
-                val entitlement = it.entitlements[PLUS_ENTITLEMENT_ID]
-                continuation.resume(entitlement?.isActive == true)
+                continuation.resume(it.toBillingPlusStatus())
             },
             onError = {
                 Napier.d { "restore error: $it" }
-                continuation.resume(false)
+                continuation.resume(
+                    BillingPlusStatus(
+                        isActive = false,
+                        isTrial = false,
+                    ),
+                )
             },
         )
     }
@@ -64,13 +75,15 @@ class BillingClient(
 
         return@withContext if (current != null && current.availablePackages.isNotEmpty()) {
             current.availablePackages.map { pkg ->
-                planCache[pkg.packageType.toBillingPlanType()] = pkg.storeProduct
+                val planType = pkg.packageType.toBillingPlanType()
+                planCache[planType] = pkg.storeProduct
 
                 BillingPlan(
                     id = pkg.identifier,
                     price = pkg.storeProduct.price.amountMicros,
                     formattedPrice = pkg.storeProduct.price.formatted,
-                    type = pkg.packageType.toBillingPlanType(),
+                    type = planType,
+                    trialPeriod = pkg.storeProduct.getTrialPeriod(),
                 )
             }
         } else {
@@ -84,7 +97,54 @@ class BillingClient(
         else -> BillingPlan.Type.UNKNOWN
     }
 
+    private fun CustomerInfo.toBillingPlusStatus(): BillingPlusStatus {
+        val entitlement = entitlements[PLUS_ENTITLEMENT_ID]
+
+        Napier.d { "entitlement: $entitlement" }
+
+        val isActive = entitlement?.isActive == true
+        val isTrialPeriod = entitlement?.periodType == PeriodType.TRIAL
+        val isTrial = isActive && isAndroidPlatform() && isTrialPeriod
+
+        return BillingPlusStatus(
+            isActive = isActive,
+            isTrial = isTrial,
+        )
+    }
+
+    private fun StoreProduct.getTrialPeriod(): BillingTrialPeriod? {
+        val freePhase = subscriptionOptions?.freeTrial?.freePhase ?: return null
+
+        return freePhase.billingPeriod.toBillingTrialPeriod()
+    }
+
+    private fun Period.toBillingTrialPeriod(): BillingTrialPeriod {
+        return BillingTrialPeriod(
+            value = value,
+            unit = unit.toBillingTrialPeriodUnit(),
+        )
+    }
+
+    private fun PeriodUnit.toBillingTrialPeriodUnit(): BillingTrialPeriod.Unit {
+        return when (this) {
+            PeriodUnit.DAY -> BillingTrialPeriod.Unit.DAY
+            PeriodUnit.WEEK -> BillingTrialPeriod.Unit.WEEK
+            PeriodUnit.MONTH -> BillingTrialPeriod.Unit.MONTH
+            PeriodUnit.YEAR -> BillingTrialPeriod.Unit.YEAR
+            PeriodUnit.UNKNOWN -> BillingTrialPeriod.Unit.UNKNOWN
+        }
+    }
+
+    private fun isAndroidPlatform(): Boolean {
+        return pixiViewConfig.platform.equals(ANDROID_PLATFORM, ignoreCase = true)
+    }
+
+    /** BillingClient で利用する固定値。 */
     companion object {
+        /** Plus 権限の Entitlement ID。 */
         private const val PLUS_ENTITLEMENT_ID = "Plus"
+
+        /** Android プラットフォーム名。 */
+        private const val ANDROID_PLATFORM = "Android"
     }
 }

--- a/core/datastore/src/commonMain/kotlin/me/matsumo/fanbox/core/datastore/SettingDataStore.kt
+++ b/core/datastore/src/commonMain/kotlin/me/matsumo/fanbox/core/datastore/SettingDataStore.kt
@@ -16,6 +16,7 @@ import me.matsumo.fanbox.core.logs.category.SettingsLog
 import me.matsumo.fanbox.core.logs.logger.send
 import me.matsumo.fanbox.core.model.DownloadFileType
 import me.matsumo.fanbox.core.model.Setting
+import me.matsumo.fanbox.core.model.SettingPlusStatusUpdate
 import me.matsumo.fanbox.core.model.ThemeColorConfig
 import me.matsumo.fanbox.core.model.ThemeConfig
 
@@ -342,37 +343,30 @@ class SettingDataStore(
         }
     }
 
-    suspend fun setPlusStatus(
-        isPlusMode: Boolean,
-        isPlusTrial: Boolean,
-    ) = withContext(ioDispatcher) {
+    suspend fun setPlusStatus(plusStatusUpdate: SettingPlusStatusUpdate) = withContext(ioDispatcher) {
         val currentSetting = setting.first()
-        val normalizedIsPlusTrial = isPlusMode && isPlusTrial
-        val isPlusModeChanged = currentSetting.isPlusMode != isPlusMode
-        val isPlusTrialChanged = currentSetting.isPlusTrial != normalizedIsPlusTrial
-        val hasPlusStatusChanged = isPlusModeChanged || isPlusTrialChanged
 
-        if (!hasPlusStatusChanged) return@withContext
+        if (!plusStatusUpdate.hasChanged) return@withContext
 
-        if (isPlusModeChanged) {
+        if (plusStatusUpdate.isPlusModeChanged) {
             SettingsLog.update(
                 propertyName = "isPlusMode",
                 oldValue = currentSetting.isPlusMode.toString(),
-                newValue = isPlusMode.toString(),
+                newValue = plusStatusUpdate.isPlusMode.toString(),
             ).send()
         }
 
-        if (isPlusTrialChanged) {
+        if (plusStatusUpdate.isPlusTrialChanged) {
             SettingsLog.update(
                 propertyName = "isPlusTrial",
                 oldValue = currentSetting.isPlusTrial.toString(),
-                newValue = normalizedIsPlusTrial.toString(),
+                newValue = plusStatusUpdate.isPlusTrial.toString(),
             ).send()
         }
 
         settingPreference.edit {
-            it[booleanPreferencesKey(Setting::isPlusMode.name)] = isPlusMode
-            it[booleanPreferencesKey(Setting::isPlusTrial.name)] = normalizedIsPlusTrial
+            it[booleanPreferencesKey(Setting::isPlusMode.name)] = plusStatusUpdate.isPlusMode
+            it[booleanPreferencesKey(Setting::isPlusTrial.name)] = plusStatusUpdate.isPlusTrial
         }
     }
 }

--- a/core/datastore/src/commonMain/kotlin/me/matsumo/fanbox/core/datastore/SettingDataStore.kt
+++ b/core/datastore/src/commonMain/kotlin/me/matsumo/fanbox/core/datastore/SettingDataStore.kt
@@ -342,17 +342,37 @@ class SettingDataStore(
         }
     }
 
-    suspend fun setPlusMode(isPlusMode: Boolean) = withContext(ioDispatcher) {
-        if (setting.first().isPlusMode == isPlusMode) return@withContext
+    suspend fun setPlusStatus(
+        isPlusMode: Boolean,
+        isPlusTrial: Boolean,
+    ) = withContext(ioDispatcher) {
+        val currentSetting = setting.first()
+        val normalizedIsPlusTrial = isPlusMode && isPlusTrial
+        val isPlusModeChanged = currentSetting.isPlusMode != isPlusMode
+        val isPlusTrialChanged = currentSetting.isPlusTrial != normalizedIsPlusTrial
+        val hasPlusStatusChanged = isPlusModeChanged || isPlusTrialChanged
 
-        SettingsLog.update(
-            propertyName = "isPlusMode",
-            oldValue = setting.first().isPlusMode.toString(),
-            newValue = isPlusMode.toString(),
-        ).send()
+        if (!hasPlusStatusChanged) return@withContext
+
+        if (isPlusModeChanged) {
+            SettingsLog.update(
+                propertyName = "isPlusMode",
+                oldValue = currentSetting.isPlusMode.toString(),
+                newValue = isPlusMode.toString(),
+            ).send()
+        }
+
+        if (isPlusTrialChanged) {
+            SettingsLog.update(
+                propertyName = "isPlusTrial",
+                oldValue = currentSetting.isPlusTrial.toString(),
+                newValue = normalizedIsPlusTrial.toString(),
+            ).send()
+        }
 
         settingPreference.edit {
             it[booleanPreferencesKey(Setting::isPlusMode.name)] = isPlusMode
+            it[booleanPreferencesKey(Setting::isPlusTrial.name)] = normalizedIsPlusTrial
         }
     }
 }

--- a/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/BillingPlan.kt
+++ b/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/BillingPlan.kt
@@ -1,14 +1,36 @@
 package me.matsumo.fanbox.core.model
 
+import androidx.compose.runtime.Immutable
+
+/** Plus の購入プランを表すモデル。 */
+@Immutable
 data class BillingPlan(
     val id: String,
     val price: Long,
     val formattedPrice: String,
     val type: Type,
+    val trialPeriod: BillingTrialPeriod?,
 ) {
+    /** Plus の購入プラン種別を表す列挙型。 */
     enum class Type {
         MONTHLY,
         ANNUAL,
+        UNKNOWN,
+    }
+}
+
+/** Plus の無料トライアル期間を表すモデル。 */
+@Immutable
+data class BillingTrialPeriod(
+    val value: Int,
+    val unit: Unit,
+) {
+    /** Plus の無料トライアル期間の単位を表す列挙型。 */
+    enum class Unit {
+        DAY,
+        WEEK,
+        MONTH,
+        YEAR,
         UNKNOWN,
     }
 }

--- a/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/BillingPlusStatus.kt
+++ b/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/BillingPlusStatus.kt
@@ -1,0 +1,10 @@
+package me.matsumo.fanbox.core.model
+
+import androidx.compose.runtime.Immutable
+
+/** Plus の利用状態を表すモデル。 */
+@Immutable
+data class BillingPlusStatus(
+    val isActive: Boolean,
+    val isTrial: Boolean,
+)

--- a/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/Setting.kt
+++ b/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/Setting.kt
@@ -1,5 +1,6 @@
 package me.matsumo.fanbox.core.model
 
+import androidx.compose.runtime.Immutable
 import androidx.compose.ui.text.intl.Locale
 import kotlinx.serialization.Serializable
 import kotlin.time.Clock
@@ -7,6 +8,7 @@ import kotlin.time.Duration.Companion.days
 import kotlin.time.ExperimentalTime
 
 /** アプリ全体のユーザー設定を表すモデル。 */
+@Immutable
 @Serializable
 data class Setting(
     val pixiViewId: String,
@@ -32,11 +34,18 @@ data class Setting(
     val isTestUser: Boolean,
     val isDeveloperMode: Boolean,
     val isPlusMode: Boolean,
+    val isPlusTrial: Boolean,
 ) {
+    /** Plus として扱う機能を利用できるかどうか。 */
     val hasPrivilege get() = isPlusMode || isDeveloperMode
 
+    /** クリエイター全投稿の一括ダウンロードを利用できるかどうか。 */
+    val canBulkDownload get() = isDeveloperMode || (isPlusMode && !isPlusTrial)
+
+    /** 成人向けコンテンツを表示できるかどうか。 */
     val isAllowedShowAdultContents get() = !isTestUser && isOverrideAdultContents
 
+    /** インタースティシャル広告を表示する期間に入っているかどうか。 */
     @OptIn(ExperimentalTime::class)
     val shouldShowInterstitialAd get() = (Clock.System.now().epochSeconds - firstLaunchTime) > 2.days.inWholeSeconds
 
@@ -68,6 +77,7 @@ data class Setting(
                 isTestUser = false,
                 isDeveloperMode = false,
                 isPlusMode = false,
+                isPlusTrial = false,
             )
         }
     }

--- a/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/SettingPlusStatusUpdate.kt
+++ b/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/SettingPlusStatusUpdate.kt
@@ -1,0 +1,33 @@
+package me.matsumo.fanbox.core.model
+
+import androidx.compose.runtime.Immutable
+
+/** Plus 課金状態の設定更新内容を表すモデル。 */
+@Immutable
+data class SettingPlusStatusUpdate(
+    val isPlusMode: Boolean,
+    val isPlusTrial: Boolean,
+    val isPlusModeChanged: Boolean,
+    val isPlusTrialChanged: Boolean,
+) {
+    /** Plus 課金状態の設定に変更があるかどうか。 */
+    val hasChanged get() = isPlusModeChanged || isPlusTrialChanged
+
+    /** Plus 課金状態の設定更新内容を生成するオブジェクト。 */
+    companion object {
+        fun from(
+            currentSetting: Setting,
+            isPlusMode: Boolean,
+            isPlusTrial: Boolean,
+        ): SettingPlusStatusUpdate {
+            val normalizedIsPlusTrial = isPlusMode && isPlusTrial
+
+            return SettingPlusStatusUpdate(
+                isPlusMode = isPlusMode,
+                isPlusTrial = normalizedIsPlusTrial,
+                isPlusModeChanged = currentSetting.isPlusMode != isPlusMode,
+                isPlusTrialChanged = currentSetting.isPlusTrial != normalizedIsPlusTrial,
+            )
+        }
+    }
+}

--- a/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/SettingRepository.kt
+++ b/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/SettingRepository.kt
@@ -38,7 +38,7 @@ interface SettingRepository {
     suspend fun setTestUser(isTestUser: Boolean)
     suspend fun setHideRestricted(isHideRestricted: Boolean)
     suspend fun setDeveloperMode(isDeveloperMode: Boolean)
-    suspend fun setPlusMode(isPlusMode: Boolean)
+    suspend fun setPlusStatus(isPlusMode: Boolean, isPlusTrial: Boolean)
 }
 
 class SettingRepositoryImpl(
@@ -139,9 +139,21 @@ class SettingRepositoryImpl(
         settingDataStore.setUseDynamicColor(useDynamicColor)
     }
 
-    override suspend fun setPlusMode(isPlusMode: Boolean) {
-        if (setting.first().isPlusMode != isPlusMode) {
-            settingDataStore.setPlusMode(isPlusMode)
+    override suspend fun setPlusStatus(isPlusMode: Boolean, isPlusTrial: Boolean) {
+        val currentSetting = setting.first()
+        val normalizedIsPlusTrial = isPlusMode && isPlusTrial
+        val isPlusModeChanged = currentSetting.isPlusMode != isPlusMode
+        val isPlusTrialChanged = currentSetting.isPlusTrial != normalizedIsPlusTrial
+        val hasPlusStatusChanged = isPlusModeChanged || isPlusTrialChanged
+
+        if (hasPlusStatusChanged) {
+            settingDataStore.setPlusStatus(
+                isPlusMode = isPlusMode,
+                isPlusTrial = normalizedIsPlusTrial,
+            )
+        }
+
+        if (isPlusModeChanged) {
             _updatePlusMode.send(isPlusMode)
 
             if (!isPlusMode) {

--- a/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/SettingRepository.kt
+++ b/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/SettingRepository.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.flow.receiveAsFlow
 import me.matsumo.fanbox.core.datastore.SettingDataStore
 import me.matsumo.fanbox.core.model.DownloadFileType
 import me.matsumo.fanbox.core.model.Setting
+import me.matsumo.fanbox.core.model.SettingPlusStatusUpdate
 import me.matsumo.fanbox.core.model.ThemeColorConfig
 import me.matsumo.fanbox.core.model.ThemeConfig
 
@@ -141,22 +142,20 @@ class SettingRepositoryImpl(
 
     override suspend fun setPlusStatus(isPlusMode: Boolean, isPlusTrial: Boolean) {
         val currentSetting = setting.first()
-        val normalizedIsPlusTrial = isPlusMode && isPlusTrial
-        val isPlusModeChanged = currentSetting.isPlusMode != isPlusMode
-        val isPlusTrialChanged = currentSetting.isPlusTrial != normalizedIsPlusTrial
-        val hasPlusStatusChanged = isPlusModeChanged || isPlusTrialChanged
+        val plusStatusUpdate = SettingPlusStatusUpdate.from(
+            currentSetting = currentSetting,
+            isPlusMode = isPlusMode,
+            isPlusTrial = isPlusTrial,
+        )
 
-        if (hasPlusStatusChanged) {
-            settingDataStore.setPlusStatus(
-                isPlusMode = isPlusMode,
-                isPlusTrial = normalizedIsPlusTrial,
-            )
+        if (plusStatusUpdate.hasChanged) {
+            settingDataStore.setPlusStatus(plusStatusUpdate)
         }
 
-        if (isPlusModeChanged) {
-            _updatePlusMode.send(isPlusMode)
+        if (plusStatusUpdate.isPlusModeChanged) {
+            _updatePlusMode.send(plusStatusUpdate.isPlusMode)
 
-            if (!isPlusMode) {
+            if (!plusStatusUpdate.isPlusMode) {
                 setUseDynamicColor(false)
                 setUseAppLock(false)
                 setHideRestricted(false)

--- a/core/resources/src/commonMain/composeResources/values-ja/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-ja/strings.xml
@@ -305,6 +305,12 @@
     <!-- Billing -->
     <string name="billing_plus_description">%1$s+ は、月々コーヒー1杯の金額で全ての機能にアクセスできるようになる開発者への支援プランです。</string>
     <string name="billing_plus_purchase_button">%1$sで支援</string>
+    <string name="billing_plus_purchase_trial_button">%1$s無料で試す</string>
+    <string name="billing_plus_trial_label">無料トライアル: %1$s</string>
+    <string name="billing_plus_trial_period_day">%1$d日間</string>
+    <string name="billing_plus_trial_period_week">%1$d週間</string>
+    <string name="billing_plus_trial_period_month">%1$dか月間</string>
+    <string name="billing_plus_trial_period_year">%1$d年間</string>
     <string name="billing_plus_verify_button">購入を復元</string>
     <string name="billing_plus_consume_button">購入を消費</string>
     <string name="billing_plus_caution1">※ %1$s+ は上記の限定機能を追加する定期購入契約です。支払いは直ちに行われ、機能を利用し続けるには指定された期間ごとの更新が必要となります。解約はいつでも可能です。</string>

--- a/core/resources/src/commonMain/composeResources/values-ko/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-ko/strings.xml
@@ -283,6 +283,12 @@
     <string name="billing_plus_title">%1$s+</string>
     <string name="billing_plus_description">%1$s+는 한 달에 커피 한 잔의 가격으로 개발자를 지원해 모든 기능의 접근 권한을 얻는 플랜입니다.</string>
     <string name="billing_plus_purchase_button">월 %1$s에 구매</string>
+    <string name="billing_plus_purchase_trial_button">%1$s 무료 체험 시작</string>
+    <string name="billing_plus_trial_label">무료 체험: %1$s</string>
+    <string name="billing_plus_trial_period_day">%1$d일</string>
+    <string name="billing_plus_trial_period_week">%1$d주</string>
+    <string name="billing_plus_trial_period_month">%1$d개월</string>
+    <string name="billing_plus_trial_period_year">%1$d년</string>
     <string name="billing_plus_verify_button">구매 복구</string>
     <string name="billing_plus_consume_button">활성화</string>
     <string name="billing_plus_caution1">※ %1$s+는 전용 기능을 추가하는 구독 서비스입니다. 결제는 즉시 실행되며, 기능을 계속 이용하시려면 월별 정기 결제가 필요합니다. 언제든지 취소할 수 있습니다.</string>

--- a/core/resources/src/commonMain/composeResources/values-ru/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-ru/strings.xml
@@ -284,6 +284,12 @@
     <string name="billing_plus_title">%1$s+</string>
     <string name="billing_plus_description">%1$s+ является планом поддержки для разработчиков, который предоставляет доступ ко всем функциям за стоимость одной чашки кофе в месяц.</string>
     <string name="billing_plus_purchase_button">Купить за %1$s</string>
+    <string name="billing_plus_purchase_trial_button">Начать бесплатный период: %1$s</string>
+    <string name="billing_plus_trial_label">Бесплатный период: %1$s</string>
+    <string name="billing_plus_trial_period_day">%1$d д.</string>
+    <string name="billing_plus_trial_period_week">%1$d нед.</string>
+    <string name="billing_plus_trial_period_month">%1$d мес.</string>
+    <string name="billing_plus_trial_period_year">%1$d г.</string>
     <string name="billing_plus_verify_button">Восстановить покупку</string>
     <string name="billing_plus_consume_button">Активировать покупку</string>
     <string name="billing_plus_caution1">※ %1$s+ является подпиской, добавляющей эксклюзивные функции. Платёж производится сразу, и для продолжения использования функций требуется ежемесячное или ежегодное продление. Подписку можно отменить в любое время.</string>

--- a/core/resources/src/commonMain/composeResources/values-zh-rCN/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-zh-rCN/strings.xml
@@ -281,6 +281,12 @@
     <string name="billing_plus_title">%1$s+</string>
     <string name="billing_plus_description">%1$s+ 是一项支持开发者的订阅计划，可使您以每月一杯咖啡的费用访问所有功能。</string>
     <string name="billing_plus_purchase_button">以 %1$s 的价格购买</string>
+    <string name="billing_plus_purchase_trial_button">开始 %1$s 免费试用</string>
+    <string name="billing_plus_trial_label">免费试用：%1$s</string>
+    <string name="billing_plus_trial_period_day">%1$d天</string>
+    <string name="billing_plus_trial_period_week">%1$d周</string>
+    <string name="billing_plus_trial_period_month">%1$d个月</string>
+    <string name="billing_plus_trial_period_year">%1$d年</string>
     <string name="billing_plus_verify_button">恢复购买</string>
     <string name="billing_plus_consume_button">消费购买</string>
     <string name="billing_plus_caution1">※ %1$s+ 是一个提供独家功能的订阅计划。付款后立即生效，继续使用这些功能需要每月或每年续订。您可以随时取消订阅。</string>

--- a/core/resources/src/commonMain/composeResources/values/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values/strings.xml
@@ -306,6 +306,12 @@
     <string name="billing_plus_title">%1$s+</string>
     <string name="billing_plus_description">%1$s+ is a support plan for developers that allows access to all features for the cost of one coffee per month.</string>
     <string name="billing_plus_purchase_button">Buy for %1$s</string>
+    <string name="billing_plus_purchase_trial_button">Start %1$s free trial</string>
+    <string name="billing_plus_trial_label">Free trial: %1$s</string>
+    <string name="billing_plus_trial_period_day">%1$d days</string>
+    <string name="billing_plus_trial_period_week">%1$d weeks</string>
+    <string name="billing_plus_trial_period_month">%1$d months</string>
+    <string name="billing_plus_trial_period_year">%1$d years</string>
     <string name="billing_plus_verify_button">Restore purchase</string>
     <string name="billing_plus_consume_button">Consume Purchase</string>
     <string name="billing_plus_caution1">※ %1$s+ is a subscription service that adds exclusive features. the payment is made immediately, and to continue using the features, monthly or yearly renewal is necessary. you can cancel the subscription at any time.</string>

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -45,13 +45,13 @@ kotlin {
                 api(libs.placeholder)
                 api(libs.rich.editor)
                 api(libs.autolink)
-                api(libs.play.service.ads)
             }
         }
 
         val androidMain by getting {
             dependencies {
                 implementation(libs.bundles.media3)
+                api(libs.play.service.ads)
                 api(libs.bundles.ui.android.api)
             }
         }

--- a/feature/about/src/commonMain/kotlin/me/matsumo/fanbox/feature/about/billing/BillingViewModel.kt
+++ b/feature/about/src/commonMain/kotlin/me/matsumo/fanbox/feature/about/billing/BillingViewModel.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.launch
 import me.matsumo.fanbox.core.billing.BillingClient
 import me.matsumo.fanbox.core.common.util.suspendRunCatching
 import me.matsumo.fanbox.core.model.BillingPlan
+import me.matsumo.fanbox.core.model.BillingPlusStatus
 import me.matsumo.fanbox.core.model.ScreenState
 import me.matsumo.fanbox.core.model.Setting
 import me.matsumo.fanbox.core.repository.SettingRepository
@@ -76,10 +77,13 @@ class BillingViewModel(
 
     private fun handleOnPurchase() {
         viewModelScope.launch {
-            val result = suspendRunCatching { billingClient.purchase(selectedPlanType.value) }.getOrElse { false }
+            val result = suspendRunCatching { billingClient.purchase(selectedPlanType.value) }.getOrElse { inactivePlusStatus() }
 
-            if (result) {
-                settingRepository.setPlusMode(true)
+            if (result.isActive) {
+                settingRepository.setPlusStatus(
+                    isPlusMode = result.isActive,
+                    isPlusTrial = result.isTrial,
+                )
                 _messageEvent.trySend(BillingMessageEvent.Purchased)
             } else {
                 _messageEvent.trySend(BillingMessageEvent.SnackBar(Res.string.billing_plus_toast_purchased_error))
@@ -89,10 +93,13 @@ class BillingViewModel(
 
     private fun handleRestore() {
         viewModelScope.launch {
-            val result = suspendRunCatching { billingClient.restore() }.getOrElse { false }
+            val result = suspendRunCatching { billingClient.restore() }.getOrElse { inactivePlusStatus() }
 
-            if (result) {
-                settingRepository.setPlusMode(true)
+            if (result.isActive) {
+                settingRepository.setPlusStatus(
+                    isPlusMode = result.isActive,
+                    isPlusTrial = result.isTrial,
+                )
                 _messageEvent.trySend(BillingMessageEvent.Purchased)
             } else {
                 _messageEvent.trySend(BillingMessageEvent.SnackBar(Res.string.billing_plus_toast_verify_error))
@@ -101,6 +108,14 @@ class BillingViewModel(
     }
 }
 
+private fun inactivePlusStatus(): BillingPlusStatus {
+    return BillingPlusStatus(
+        isActive = false,
+        isTrial = false,
+    )
+}
+
+/** Plus 課金画面の UI 状態を表すモデル。 */
 @Stable
 data class BillingUiState(
     val setting: Setting,

--- a/feature/about/src/commonMain/kotlin/me/matsumo/fanbox/feature/about/billing/items/BillingBottomBar.kt
+++ b/feature/about/src/commonMain/kotlin/me/matsumo/fanbox/feature/about/billing/items/BillingBottomBar.kt
@@ -25,16 +25,24 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.ImmutableList
 import me.matsumo.fanbox.core.model.BillingPlan
+import me.matsumo.fanbox.core.model.BillingTrialPeriod
 import me.matsumo.fanbox.core.resources.Res
 import me.matsumo.fanbox.core.resources.billing_plus_plan_monthly
 import me.matsumo.fanbox.core.resources.billing_plus_plan_yearly
 import me.matsumo.fanbox.core.resources.billing_plus_purchase_button
+import me.matsumo.fanbox.core.resources.billing_plus_purchase_trial_button
+import me.matsumo.fanbox.core.resources.billing_plus_trial_label
+import me.matsumo.fanbox.core.resources.billing_plus_trial_period_day
+import me.matsumo.fanbox.core.resources.billing_plus_trial_period_month
+import me.matsumo.fanbox.core.resources.billing_plus_trial_period_week
+import me.matsumo.fanbox.core.resources.billing_plus_trial_period_year
 import me.matsumo.fanbox.core.resources.billing_plus_verify_button
 import me.matsumo.fanbox.core.resources.error_unknown
 import me.matsumo.fanbox.core.resources.unit_month
 import me.matsumo.fanbox.core.resources.unit_year
 import me.matsumo.fanbox.feature.about.billing.BillingUiState
 import me.matsumo.fanbox.feature.about.billing.BillingViewEvent
+import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
@@ -43,8 +51,8 @@ internal fun BillingBottomBar(
     onViewEvent: (BillingViewEvent) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val selectedPlan = remember(uiState.selectedPlanType) {
-        uiState.plans.find { it.type == uiState.selectedPlanType }
+    val selectedPlan = remember(uiState.plans, uiState.selectedPlanType) {
+        uiState.plans.find { plan -> plan.type == uiState.selectedPlanType }
     }
 
     Column(
@@ -62,7 +70,7 @@ internal fun BillingBottomBar(
             modifier = Modifier.fillMaxWidth(),
             plans = uiState.plans,
             selectedPlanType = uiState.selectedPlanType,
-            onPlanSelected = { onViewEvent(BillingViewEvent.OnPlanSelected(it)) },
+            onPlanSelected = { planType -> onViewEvent(BillingViewEvent.OnPlanSelected(planType)) },
         )
 
         if (selectedPlan != null) {
@@ -87,50 +95,82 @@ private fun PlanSelectSection(
         modifier = modifier,
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        plans.forEach {
-            Row(
+        plans.forEach { plan ->
+            PlanSelectItem(
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .selectable(
-                        selected = (selectedPlanType == it.type),
-                        onClick = { onPlanSelected.invoke(it.type) },
-                        role = Role.RadioButton,
-                    )
-                    .clip(RoundedCornerShape(8.dp))
-                    .border(
-                        width = 1.dp,
-                        color = if (selectedPlanType == it.type) MaterialTheme.colorScheme.primary else Color.Transparent,
-                        shape = RoundedCornerShape(8.dp),
-                    )
-                    .padding(16.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(16.dp),
-            ) {
-                RadioButton(
-                    selected = (selectedPlanType == it.type),
-                    onClick = null,
-                )
+                    .fillMaxWidth(),
+                plan = plan,
+                isSelected = selectedPlanType == plan.type,
+                onPlanSelected = onPlanSelected,
+            )
+        }
+    }
+}
 
-                Text(
-                    text = when (it.type) {
-                        BillingPlan.Type.MONTHLY -> stringResource(Res.string.billing_plus_plan_monthly)
-                        BillingPlan.Type.ANNUAL -> stringResource(Res.string.billing_plus_plan_yearly)
-                        BillingPlan.Type.UNKNOWN -> stringResource(Res.string.error_unknown)
-                    },
-                    style = MaterialTheme.typography.titleMedium,
-                )
+@Composable
+private fun PlanSelectItem(
+    plan: BillingPlan,
+    isSelected: Boolean,
+    onPlanSelected: (BillingPlan.Type) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .selectable(
+                selected = isSelected,
+                onClick = { onPlanSelected.invoke(plan.type) },
+                role = Role.RadioButton,
+            )
+            .clip(RoundedCornerShape(8.dp))
+            .border(
+                width = 1.dp,
+                color = if (isSelected) MaterialTheme.colorScheme.primary else Color.Transparent,
+                shape = RoundedCornerShape(8.dp),
+            )
+            .padding(16.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        RadioButton(
+            selected = isSelected,
+            onClick = null,
+        )
 
-                Text(
-                    text = "${it.formattedPrice} / " + when (it.type) {
-                        BillingPlan.Type.MONTHLY -> stringResource(Res.string.unit_month)
-                        BillingPlan.Type.ANNUAL -> stringResource(Res.string.unit_year)
-                        BillingPlan.Type.UNKNOWN -> stringResource(Res.string.error_unknown)
-                    },
-                    style = MaterialTheme.typography.titleMedium,
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            Text(
+                text = plan.getPlanName(),
+                style = MaterialTheme.typography.titleMedium,
+            )
+
+            plan.trialPeriod?.let { trialPeriod ->
+                PlanTrialLabel(
+                    modifier = Modifier.fillMaxWidth(),
+                    trialPeriod = trialPeriod,
                 )
             }
         }
+
+        Text(
+            text = plan.getPriceText(),
+            style = MaterialTheme.typography.titleMedium,
+        )
     }
+}
+
+@Composable
+private fun PlanTrialLabel(
+    trialPeriod: BillingTrialPeriod,
+    modifier: Modifier = Modifier,
+) {
+    Text(
+        modifier = modifier,
+        text = stringResource(Res.string.billing_plus_trial_label, trialPeriod.getDisplayText()),
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.primary,
+    )
 }
 
 @Composable
@@ -140,6 +180,10 @@ private fun ButtonSection(
     onRestoreClicked: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val purchaseButtonText = selectedPlan.trialPeriod?.let { trialPeriod ->
+        stringResource(Res.string.billing_plus_purchase_trial_button, trialPeriod.getDisplayText())
+    } ?: stringResource(Res.string.billing_plus_purchase_button, selectedPlan.formattedPrice, selectedPlan.getUnit())
+
     Column(
         modifier = modifier,
         verticalArrangement = Arrangement.spacedBy(8.dp),
@@ -149,7 +193,7 @@ private fun ButtonSection(
             onClick = onPurchaseClicked,
         ) {
             Text(
-                text = stringResource(Res.string.billing_plus_purchase_button, selectedPlan.formattedPrice, selectedPlan.getUnit()),
+                text = purchaseButtonText,
             )
         }
 
@@ -165,10 +209,45 @@ private fun ButtonSection(
 }
 
 @Composable
-private fun BillingPlan.getUnit() = when (type) {
-    BillingPlan.Type.MONTHLY -> Res.string.unit_month
-    BillingPlan.Type.ANNUAL -> Res.string.unit_year
-    BillingPlan.Type.UNKNOWN -> Res.string.error_unknown
-}.let {
-    stringResource(it)
+private fun BillingPlan.getPlanName(): String {
+    return when (type) {
+        BillingPlan.Type.MONTHLY -> stringResource(Res.string.billing_plus_plan_monthly)
+        BillingPlan.Type.ANNUAL -> stringResource(Res.string.billing_plus_plan_yearly)
+        BillingPlan.Type.UNKNOWN -> stringResource(Res.string.error_unknown)
+    }
+}
+
+@Composable
+private fun BillingPlan.getPriceText(): String {
+    return "$formattedPrice / ${getUnit()}"
+}
+
+@Composable
+private fun BillingPlan.getUnit(): String {
+    val resource = when (type) {
+        BillingPlan.Type.MONTHLY -> Res.string.unit_month
+        BillingPlan.Type.ANNUAL -> Res.string.unit_year
+        BillingPlan.Type.UNKNOWN -> Res.string.error_unknown
+    }
+
+    return stringResource(resource)
+}
+
+@Composable
+private fun BillingTrialPeriod.getDisplayText(): String {
+    if (unit == BillingTrialPeriod.Unit.UNKNOWN) {
+        return stringResource(Res.string.error_unknown)
+    }
+
+    return stringResource(unit.toStringResource(), value)
+}
+
+private fun BillingTrialPeriod.Unit.toStringResource(): StringResource {
+    return when (this) {
+        BillingTrialPeriod.Unit.DAY -> Res.string.billing_plus_trial_period_day
+        BillingTrialPeriod.Unit.WEEK -> Res.string.billing_plus_trial_period_week
+        BillingTrialPeriod.Unit.MONTH -> Res.string.billing_plus_trial_period_month
+        BillingTrialPeriod.Unit.YEAR -> Res.string.billing_plus_trial_period_year
+        BillingTrialPeriod.Unit.UNKNOWN -> Res.string.error_unknown
+    }
 }

--- a/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/top/CreatorTopScreen.kt
+++ b/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/top/CreatorTopScreen.kt
@@ -441,7 +441,7 @@ private fun CreatorTopScreen(
                 ),
                 containerColor = MaterialTheme.colorScheme.primaryContainer,
                 onClick = {
-                    if (setting.hasPrivilege) {
+                    if (setting.canBulkDownload) {
                         onClickAllDownload.invoke(creatorDetail.creatorId)
                     } else {
                         isShowRewardAdDialog = true


### PR DESCRIPTION
Closes #87

## 概要
Android の Plus サブスクリプションに 3 日間無料トライアルを表示・判定するための実装を追加しました。

## 変更内容
- RevenueCat の entitlement `Plus` からトライアル状態を判定し、設定へ `isPlusTrial` として保存
- Paywall に無料トライアル期間表示とトライアル開始用の文言を追加
- トライアル中はクリエイタートップの一括ダウンロードを Plus 権限から除外し、リワード広告ダイアログへ遷移
- Billing plan に RevenueCat の free trial 期間情報を持たせるモデルを追加
- 各 locale の課金関連文言を追加

## 動作確認
- `JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home ./gradlew :composeApp:compileDebugKotlinAndroid`
- `JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home ./gradlew detekt`
- `JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home ./gradlew :core:model:compileKotlinIosSimulatorArm64 :core:billing:compileKotlinIosSimulatorArm64 :core:repository:compileKotlinIosSimulatorArm64`
- `git diff --check`

## 補足
`:composeApp:compileKotlinIosSimulatorArm64` は `core:ui -> play-services-ads -> kotlinx-coroutines-android` に iOS variant がないため失敗しました。今回の変更とは独立した既存の依存関係問題として扱っています。