### PR TITLE
Fix ad load retry on failure

### DIFF
--- a/core/ui/src/androidMain/kotlin/me/matsumo/fanbox/core/ui/ads/AdLoadRetryController.kt
+++ b/core/ui/src/androidMain/kotlin/me/matsumo/fanbox/core/ui/ads/AdLoadRetryController.kt
@@ -1,0 +1,68 @@
+package me.matsumo.fanbox.core.ui.ads
+
+import android.os.Handler
+import android.os.Looper
+import io.github.aakira.napier.Napier
+
+/** 広告ロード失敗時の指数バックオフ再試行を管理するクラス。 */
+internal class AdLoadRetryController(
+    private val adFormatName: String,
+) {
+    private val handler = Handler(Looper.getMainLooper())
+    private val retryRunnable = Runnable { executePendingRetry() }
+    private var retryAttemptCount = 0
+    private var pendingRetryAction: (() -> Unit)? = null
+
+    fun reset() {
+        retryAttemptCount = 0
+        pendingRetryAction = null
+        handler.removeCallbacks(retryRunnable)
+    }
+
+    fun scheduleRetry(
+        failureMessage: String,
+        retryAction: () -> Unit,
+    ) {
+        if (retryAttemptCount >= AD_LOAD_RETRY_MAX_ATTEMPTS) {
+            Napier.w { "$adFormatName: ad load retry limit reached. $failureMessage" }
+            pendingRetryAction = null
+            handler.removeCallbacks(retryRunnable)
+            return
+        }
+
+        retryAttemptCount += 1
+        pendingRetryAction = retryAction
+        handler.removeCallbacks(retryRunnable)
+
+        val retryDelayMillis = calculateRetryDelayMillis(retryAttemptCount = retryAttemptCount)
+        handler.postDelayed(retryRunnable, retryDelayMillis)
+
+        Napier.w {
+            "$adFormatName: ad load failed. " +
+                "retry=$retryAttemptCount/$AD_LOAD_RETRY_MAX_ATTEMPTS, " +
+                "delayMillis=$retryDelayMillis, " +
+                failureMessage
+        }
+    }
+
+    private fun executePendingRetry() {
+        val retryAction = pendingRetryAction ?: return
+        pendingRetryAction = null
+        retryAction.invoke()
+    }
+
+    private fun calculateRetryDelayMillis(retryAttemptCount: Int): Long {
+        val retryDelayMultiplier = 1L shl (retryAttemptCount - 1)
+        return (AD_LOAD_RETRY_INITIAL_DELAY_MILLIS * retryDelayMultiplier)
+            .coerceAtMost(AD_LOAD_RETRY_MAX_DELAY_MILLIS)
+    }
+}
+
+/** 広告ロード再試行の最大回数。 */
+private const val AD_LOAD_RETRY_MAX_ATTEMPTS = 5
+
+/** 広告ロード再試行の初期待機時間。 */
+private const val AD_LOAD_RETRY_INITIAL_DELAY_MILLIS = 1_000L
+
+/** 広告ロード再試行の最大待機時間。 */
+private const val AD_LOAD_RETRY_MAX_DELAY_MILLIS = 32_000L

--- a/core/ui/src/androidMain/kotlin/me/matsumo/fanbox/core/ui/ads/InterstitialAdState.android.kt
+++ b/core/ui/src/androidMain/kotlin/me/matsumo/fanbox/core/ui/ads/InterstitialAdState.android.kt
@@ -3,6 +3,7 @@ package me.matsumo.fanbox.core.ui.ads
 import android.app.Activity
 import androidx.activity.compose.LocalActivity
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.remember
 import com.google.android.gms.ads.AdError
@@ -25,12 +26,21 @@ class InterstitialAdStateImpl internal constructor(
     private val enable: Boolean,
 ) : InterstitialAdState {
     private var interstitialAd: InterstitialAd? = null
+    private val retryController = AdLoadRetryController(adFormatName = "InterstitialAd")
     private var loaded = false
     private var loading = false
     private var loadRequestId = 0
 
     override fun load() {
+        load(isRetry = false)
+    }
+
+    private fun load(isRetry: Boolean) {
         if (!enable || loaded || loading) return
+
+        if (!isRetry) {
+            retryController.reset()
+        }
 
         loading = true
         val requestId = ++loadRequestId
@@ -43,6 +53,7 @@ class InterstitialAdStateImpl internal constructor(
                 interstitialAd = ad
                 loaded = true
                 loading = false
+                retryController.reset()
 
                 Napier.d("InterstitialAd: loaded")
             }
@@ -54,17 +65,25 @@ class InterstitialAdStateImpl internal constructor(
                 loaded = false
                 loading = false
 
-                Napier.w("InterstitialAd: failed to load, $loadAdError")
+                retryController.scheduleRetry(
+                    failureMessage = loadAdError.toString(),
+                    retryAction = ::retryLoad,
+                )
             }
         }
 
         InterstitialAd.load(activity, adUnitId, adRequest, callback)
     }
 
+    private fun retryLoad() {
+        load(isRetry = true)
+    }
+
     @OptIn(ExperimentalAtomicApi::class)
     override suspend fun show(): Boolean {
         if (!enable || !loaded || interstitialAd == null) {
             Napier.w("InterstitialAd: not loaded, $enable, $loaded, $interstitialAd")
+            load()
             return false
         }
 
@@ -104,6 +123,15 @@ class InterstitialAdStateImpl internal constructor(
 
         load()
     }
+
+    internal fun dispose() {
+        retryController.reset()
+        interstitialAd?.fullScreenContentCallback = null
+        interstitialAd = null
+        loaded = false
+        loading = false
+        loadRequestId += 1
+    }
 }
 
 @Composable
@@ -112,8 +140,15 @@ actual fun rememberInterstitialAdState(
     enable: Boolean,
 ): InterstitialAdState {
     val context = LocalActivity.current!!
-
-    return remember(adUnitId, enable) {
+    val interstitialAdState = remember(adUnitId, enable) {
         InterstitialAdStateImpl(context, adUnitId, enable)
     }
+
+    DisposableEffect(interstitialAdState) {
+        onDispose {
+            interstitialAdState.dispose()
+        }
+    }
+
+    return interstitialAdState
 }

--- a/core/ui/src/androidMain/kotlin/me/matsumo/fanbox/core/ui/ads/NativeAdsPreLoader.kt
+++ b/core/ui/src/androidMain/kotlin/me/matsumo/fanbox/core/ui/ads/NativeAdsPreLoader.kt
@@ -24,6 +24,7 @@ class NativeAdsPreLoader(
 ) {
     private val preloadedNativeAds: MutableList<NativeAd> = mutableListOf()
     private val keyMap: MutableMap<String, NativeAd> = mutableMapOf()
+    private val retryController = AdLoadRetryController(adFormatName = "NativeAds")
     private val _nativeAdInventoryVersion = MutableStateFlow(0)
     private val adLoader: AdLoader
     val nativeAdInventoryVersion: StateFlow<Int> = _nativeAdInventoryVersion.asStateFlow()
@@ -43,7 +44,10 @@ class NativeAdsPreLoader(
 
         val adListener = object : AdListener() {
             override fun onAdFailedToLoad(cause: LoadAdError) {
-                Napier.e("onAdFailedToLoad: ${cause.message}")
+                retryController.scheduleRetry(
+                    failureMessage = cause.toString(),
+                    retryAction = ::retryPreloadAd,
+                )
             }
         }
 
@@ -54,11 +58,23 @@ class NativeAdsPreLoader(
             .build()
     }
 
-    @SuppressLint("MissingPermission")
     private fun preloadAd() {
+        preloadAd(isRetry = false)
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun preloadAd(isRetry: Boolean) {
+        if (!isRetry) {
+            retryController.reset()
+        }
+
         if (adLoader.isLoading) return
 
         loadMissingNativeAds()
+    }
+
+    private fun retryPreloadAd() {
+        preloadAd(isRetry = true)
     }
 
     fun getNativeAd(key: String): NativeAd? {
@@ -94,6 +110,7 @@ class NativeAdsPreLoader(
     }
 
     private fun onNativeAdLoaded(nativeAd: NativeAd) {
+        retryController.reset()
         preloadedNativeAds.add(nativeAd)
         _nativeAdInventoryVersion.update { currentVersion -> currentVersion + 1 }
     }

--- a/core/ui/src/androidMain/kotlin/me/matsumo/fanbox/core/ui/ads/RewardAdLoader.kt
+++ b/core/ui/src/androidMain/kotlin/me/matsumo/fanbox/core/ui/ads/RewardAdLoader.kt
@@ -12,18 +12,28 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import me.matsumo.fanbox.core.common.PixiViewConfig
 
+/** Android のリワード広告ロード状態を管理するクラス。 */
 class RewardAdLoader(
     private val context: Context,
     private val pixiViewConfig: PixiViewConfig,
 ) {
     private val _rewardAd = MutableStateFlow<RewardedAd?>(null)
+    private val retryController = AdLoadRetryController(adFormatName = "RewardAd")
     val rewardAd = _rewardAd.asStateFlow()
 
     private var callback: FullScreenContentCallback? = null
     private var isLoading = false
 
     fun loadRewardAdIfNeeded() {
+        loadRewardAdIfNeeded(isRetry = false)
+    }
+
+    private fun loadRewardAdIfNeeded(isRetry: Boolean) {
         if (_rewardAd.value != null || isLoading) return
+
+        if (!isRetry) {
+            retryController.reset()
+        }
 
         isLoading = true
 
@@ -31,11 +41,13 @@ class RewardAdLoader(
             override fun onAdFailedToShowFullScreenContent(error: AdError) {
                 Napier.d { "onAdFailedToShowFullScreenContent: ${error.message}" }
                 _rewardAd.value = null
+                loadRewardAdIfNeeded()
             }
 
             override fun onAdShowedFullScreenContent() {
                 Napier.d { "onAdShowedFullScreenContent" }
                 _rewardAd.value = null
+                loadRewardAdIfNeeded()
             }
         }
 
@@ -46,14 +58,22 @@ class RewardAdLoader(
                 _rewardAd.value = rewardedAd
                 _rewardAd.value!!.fullScreenContentCallback = callback
                 isLoading = false
+                retryController.reset()
             }
 
             override fun onAdFailedToLoad(error: LoadAdError) {
-                Napier.e { "onAdFailedToLoad: ${error.message}" }
                 isLoading = false
+                retryController.scheduleRetry(
+                    failureMessage = error.toString(),
+                    retryAction = ::retryLoadRewardAd,
+                )
             }
         }
 
         RewardedAd.load(context, pixiViewConfig.rewardAdUnitId, adRequest, adLoadCallback)
+    }
+
+    private fun retryLoadRewardAd() {
+        loadRewardAdIfNeeded(isRetry = true)
     }
 }


### PR DESCRIPTION
## 概要

広告ロード失敗時に再試行されず、同一セッション中に広告在庫を回復しづらい問題を修正しました。

## 変更内容

- 広告ロード失敗時の指数バックオフ再試行を管理する `AdLoadRetryController` を追加しました
- Interstitial / Native / Rewarded のロード失敗時に、1s → 2s → 4s → 8s → 16s の最大 5 回まで再試行するようにしました
- Interstitial は未ロード状態で `show()` が呼ばれた場合にも `load()` を促すようにしました
- Native は在庫切れで `getNativeAd()` が呼ばれた場合にも preload を促すようにしました
- Rewarded は表示失敗時や表示後に次のロードを促すようにしました

## 原因

各広告フォーマットの `onAdFailedToLoad` がログ出力のみで終了しており、no fill や network error のあとに広告ロードを再開する導線が不足していました。

## 確認項目

- `:core:ui:detekt`
- `:core:ui:compileDebugKotlinAndroid`
- `:composeApp:compileDebugKotlinAndroid`

Closes #82