### PR TITLE
Retry banner ad loads on failure

### DIFF
--- a/core/resources/src/commonMain/composeResources/files/versions.json
+++ b/core/resources/src/commonMain/composeResources/files/versions.json
@@ -236,5 +236,12 @@
     "date": "2025/12/19",
     "logJp": "・画像ダウンロード時のファイル名を連番方式に変更\n・ダウンロードサービスの信頼性を向上\n・インタースティシャル広告の実装\n・課金システムの改善と購入成功ダイアログの追加",
     "logEn": "・Changed image download file naming to index-based system\n・Improved download service reliability\n・Implemented interstitial ads\n・Enhanced billing system and added purchase success dialog"
+  },
+  {
+    "versionName": "2.3.3",
+    "versionCode": 72,
+    "date": "2026/06/08",
+    "logJp": "・フォロー画面が見られない問題の修正\n・軽微なUIの修正",
+    "logEn": "・Fixed an issue where the follow screen could not be displayed.\n・Minor UI fixes"
   }
 ]

--- a/core/ui/src/androidMain/kotlin/me/matsumo/fanbox/core/ui/ads/BannerAdView.android.kt
+++ b/core/ui/src/androidMain/kotlin/me/matsumo/fanbox/core/ui/ads/BannerAdView.android.kt
@@ -1,6 +1,7 @@
 package me.matsumo.fanbox.core.ui.ads
 
 import android.annotation.SuppressLint
+import android.content.Context
 import android.content.res.Configuration
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
@@ -140,14 +141,18 @@ fun rememberAdViewWithLifecycle(
     adListener: AdListener = object : AdListener() {},
 ): AdView {
     val context = LocalContext.current
+    val retryController = remember(context, adUnitId, adSize) {
+        AdLoadRetryController(adFormatName = "BannerAds")
+    }
     val adView = remember(context, adUnitId, adSize) {
-        AdView(context).apply {
-            setAdSize(adSize)
-            this.adListener = adListener
-            this.adUnitId = adUnitId
-
-            loadAd(adRequest)
-        }
+        createBannerAdView(
+            context = context,
+            adUnitId = adUnitId,
+            adSize = adSize,
+            adRequest = adRequest,
+            retryController = retryController,
+            adListener = adListener,
+        )
     }
 
     val lifecycleOwner = LocalLifecycleOwner.current
@@ -171,11 +176,68 @@ fun rememberAdViewWithLifecycle(
 
         onDispose {
             lifecycleOwner.lifecycle.removeObserver(observer)
+            retryController.reset()
             adView.destroy()
         }
     }
 
     return adView
+}
+
+@SuppressLint("MissingPermission")
+private fun createBannerAdView(
+    context: Context,
+    adUnitId: String,
+    adSize: AdSize,
+    adRequest: AdRequest,
+    retryController: AdLoadRetryController,
+    adListener: AdListener,
+): AdView {
+    val adView = AdView(context)
+    adView.setAdSize(adSize)
+    adView.adUnitId = adUnitId
+    adView.adListener = BannerAdRetryListener(
+        adView = adView,
+        adRequest = adRequest,
+        retryController = retryController,
+        delegate = adListener,
+    )
+    adView.loadAd(adRequest)
+    return adView
+}
+
+/** バナー広告のロード失敗時に指数バックオフで再試行し、その他の通知は delegate へ委譲する AdListener。 */
+private class BannerAdRetryListener(
+    private val adView: AdView,
+    private val adRequest: AdRequest,
+    private val retryController: AdLoadRetryController,
+    private val delegate: AdListener,
+) : AdListener() {
+    override fun onAdLoaded() {
+        retryController.reset()
+        delegate.onAdLoaded()
+    }
+
+    override fun onAdFailedToLoad(error: LoadAdError) {
+        delegate.onAdFailedToLoad(error)
+        retryController.scheduleRetry(
+            failureMessage = error.toString(),
+            retryAction = ::reloadAd,
+        )
+    }
+
+    override fun onAdClicked() = delegate.onAdClicked()
+
+    override fun onAdClosed() = delegate.onAdClosed()
+
+    override fun onAdImpression() = delegate.onAdImpression()
+
+    override fun onAdOpened() = delegate.onAdOpened()
+
+    @SuppressLint("MissingPermission")
+    private fun reloadAd() {
+        adView.loadAd(adRequest)
+    }
 }
 
 private fun LoadAdError.toBannerAdLoadFailedLog(

--- a/core/ui/src/androidMain/kotlin/me/matsumo/fanbox/core/ui/ads/BannerAdView.android.kt
+++ b/core/ui/src/androidMain/kotlin/me/matsumo/fanbox/core/ui/ads/BannerAdView.android.kt
@@ -158,6 +158,7 @@ fun rememberAdViewWithLifecycle(
     val lifecycleOwner = LocalLifecycleOwner.current
 
     DisposableEffect(lifecycleOwner, adView) {
+        // 破棄は onDispose に一本化し、resume/pause のみ lifecycle へ追従させる
         val observer = object : DefaultLifecycleObserver {
             override fun onResume(owner: LifecycleOwner) {
                 adView.resume()
@@ -165,10 +166,6 @@ fun rememberAdViewWithLifecycle(
 
             override fun onPause(owner: LifecycleOwner) {
                 adView.pause()
-            }
-
-            override fun onDestroy(owner: LifecycleOwner) {
-                adView.destroy()
             }
         }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # Application
-versionName = "2.3.2"
-versionCode = "71"
+versionName = "2.3.3"
+versionCode = "72"
 
 # SDK
 minSdk = "26"


### PR DESCRIPTION
## 概要

バナー広告（`BannerAdView`）のロード失敗時にリトライが無く、no-fill や一時的な失敗で一度コケると画面を閉じるまでバナーが空白＝収益を取りこぼしていた。Native / Interstitial と同じ `AdLoadRetryController`（指数バックオフ・最大5回）を適用してリトライするようにする。

## 変更点

- `rememberAdViewWithLifecycle` に `AdLoadRetryController` を持たせ、`AdView` の `AdListener` を `BannerAdRetryListener` でラップ。
  - `onAdFailedToLoad`: delegate へ通知後、指数バックオフで `loadAd` を再試行。
  - `onAdLoaded`: リトライ状態を `reset()`（表示中のエラー UI も解消）。
  - その他のコールバックは元の `adListener` へ委譲。
- Composable 破棄時 / 広告サイズ変更時（回転など）に `retryController.reset()` で保留中のリトライをキャンセル。controller も AdView と同じキーで `remember` し、インスタンスごとに分離。
- `loadAd` 呼び出し箇所に `@SuppressLint("MissingPermission")` を付与。

## 補足

ロード失敗時のリトライ対応のみを範囲とする（App Open 広告・collapsible banner・feed の広告追加などは別途）。

## テスト

- `:core:ui:compileDebugKotlinAndroid` のコンパイル通過を確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)