### PR TITLE
feat: broaden rewarded ad usage

### DIFF
--- a/core/datastore/build.gradle.kts
+++ b/core/datastore/build.gradle.kts
@@ -1,3 +1,5 @@
+@file:Suppress("UnusedPrivateProperty")
+
 plugins {
     id("pixiview.primitive.kmp.common")
     id("pixiview.primitive.android.library")
@@ -9,6 +11,8 @@ plugins {
 kotlin {
     android {
         namespace = "me.matsumo.fanbox.core.datastore"
+
+        withHostTest {}
     }
 
     sourceSets {
@@ -21,6 +25,12 @@ kotlin {
             implementation(libs.androidx.datastore)
             implementation(libs.androidx.datastore.proto)
             api(libs.androidx.datastore.preferences)
+        }
+
+        val androidHostTest by getting {
+            dependencies {
+                implementation(kotlin("test-junit"))
+            }
         }
     }
 }

--- a/core/datastore/src/androidHostTest/kotlin/me/matsumo/fanbox/core/datastore/RewardLogDataStoreTest.kt
+++ b/core/datastore/src/androidHostTest/kotlin/me/matsumo/fanbox/core/datastore/RewardLogDataStoreTest.kt
@@ -1,0 +1,82 @@
+package me.matsumo.fanbox.core.datastore
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.runBlocking
+import me.matsumo.fanbox.core.model.RewardUsage
+import okio.Path.Companion.toPath
+import org.junit.After
+import org.junit.Test
+import java.io.File
+import kotlin.test.assertEquals
+
+/** RewardLogDataStore の用途別リワード視聴履歴を検証するテスト。 */
+class RewardLogDataStoreTest {
+
+    private val dataStoreScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    private val preferenceFiles = mutableListOf<File>()
+
+    @After
+    fun tearDown() {
+        dataStoreScope.cancel()
+        preferenceFiles.forEach { it.delete() }
+    }
+
+    @Test
+    fun rewardedCountsAreSeparatedByUsage() = runBlocking {
+        val rewardLogDataStore = RewardLogDataStore(createPreferenceHelper())
+
+        rewardLogDataStore.rewarded(RewardUsage.BulkDownload)
+        rewardLogDataStore.rewarded(RewardUsage.CreatorSearch)
+        rewardLogDataStore.rewarded(RewardUsage.CreatorSearch)
+
+        assertEquals(1, rewardLogDataStore.getRewardedCount(RewardUsage.BulkDownload))
+        assertEquals(2, rewardLogDataStore.getRewardedCount(RewardUsage.CreatorSearch))
+        assertEquals(0, rewardLogDataStore.getRewardedCount(RewardUsage.CreatorTranslation))
+    }
+
+    @Test
+    fun resetClearsAllUsageCounts() = runBlocking {
+        val rewardLogDataStore = RewardLogDataStore(createPreferenceHelper())
+
+        RewardUsage.entries.forEach { usage ->
+            rewardLogDataStore.rewarded(usage)
+        }
+
+        rewardLogDataStore.reset()
+
+        RewardUsage.entries.forEach { usage ->
+            assertEquals(0, rewardLogDataStore.getRewardedCount(usage))
+        }
+    }
+
+    private fun createPreferenceHelper(): PreferenceHelper {
+        return object : PreferenceHelper {
+            private val stores = mutableMapOf<String, DataStore<Preferences>>()
+
+            override fun create(name: String): DataStore<Preferences> {
+                return stores.getOrPut(name) { createDataStore(name) }
+            }
+
+            override fun delete(name: String) = Unit
+        }
+    }
+
+    private fun createDataStore(name: String): DataStore<Preferences> {
+        val preferenceFile = File.createTempFile(name, ".preferences_pb")
+        preferenceFile.delete()
+        preferenceFiles.add(preferenceFile)
+
+        return PreferenceDataStoreFactory.createWithPath(
+            corruptionHandler = null,
+            migrations = emptyList(),
+            scope = dataStoreScope,
+            produceFile = { preferenceFile.absolutePath.toPath() },
+        )
+    }
+}

--- a/core/datastore/src/androidHostTest/kotlin/me/matsumo/fanbox/core/datastore/RewardLogDataStoreTest.kt
+++ b/core/datastore/src/androidHostTest/kotlin/me/matsumo/fanbox/core/datastore/RewardLogDataStoreTest.kt
@@ -3,10 +3,13 @@ package me.matsumo.fanbox.core.datastore
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import me.matsumo.fanbox.core.model.RewardUsage
 import okio.Path.Companion.toPath
@@ -14,6 +17,7 @@ import org.junit.After
 import org.junit.Test
 import java.io.File
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 /** RewardLogDataStore の用途別リワード視聴履歴を検証するテスト。 */
 class RewardLogDataStoreTest {
@@ -55,12 +59,46 @@ class RewardLogDataStoreTest {
         }
     }
 
+    @Test
+    fun resetRemovesLegacyRewardedCount() = runBlocking {
+        val dataStore = createDataStore(PreferencesName.REWARD_LOG)
+        val rewardLogDataStore = RewardLogDataStore(createPreferenceHelper(dataStore))
+        val legacyRewardedCountKey = intPreferencesKey("rewarded_count")
+
+        dataStore.edit {
+            it[legacyRewardedCountKey] = 1
+        }
+
+        rewardLogDataStore.reset()
+
+        assertNull(dataStore.data.first()[legacyRewardedCountKey])
+    }
+
+    @Test
+    fun setRewardDateStoresDate() = runBlocking {
+        val rewardLogDataStore = RewardLogDataStore(createPreferenceHelper())
+
+        rewardLogDataStore.setRewardDate("2026-07-10")
+
+        assertEquals("2026-07-10", rewardLogDataStore.getRewardDate())
+    }
+
     private fun createPreferenceHelper(): PreferenceHelper {
         return object : PreferenceHelper {
             private val stores = mutableMapOf<String, DataStore<Preferences>>()
 
             override fun create(name: String): DataStore<Preferences> {
                 return stores.getOrPut(name) { createDataStore(name) }
+            }
+
+            override fun delete(name: String) = Unit
+        }
+    }
+
+    private fun createPreferenceHelper(dataStore: DataStore<Preferences>): PreferenceHelper {
+        return object : PreferenceHelper {
+            override fun create(name: String): DataStore<Preferences> {
+                return dataStore
             }
 
             override fun delete(name: String) = Unit

--- a/core/datastore/src/commonMain/kotlin/me/matsumo/fanbox/core/datastore/RewardLogDataStore.kt
+++ b/core/datastore/src/commonMain/kotlin/me/matsumo/fanbox/core/datastore/RewardLogDataStore.kt
@@ -3,47 +3,46 @@ package me.matsumo.fanbox.core.datastore
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.launch
 import me.matsumo.fanbox.core.common.util.format
+import me.matsumo.fanbox.core.model.RewardUsage
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 
+/** リワード広告の用途別視聴履歴を保存する DataStore。 */
 class RewardLogDataStore(
     private val preferenceHelper: PreferenceHelper,
-    private val ioDispatcher: CoroutineDispatcher,
 ) {
     private val preference = preferenceHelper.create(PreferencesName.REWARD_LOG)
-    private val scope = CoroutineScope(ioDispatcher)
 
     @OptIn(ExperimentalTime::class)
-    fun rewarded() {
-        scope.launch {
-            preference.edit {
-                it[intPreferencesKey(KEY_REWARDED_COUNT)] = getRewardedCount() + 1
-                it[stringPreferencesKey(KEY_REWARD_DATE)] = Clock.System.now().format("yyyy-MM-dd")
+    suspend fun rewarded(usage: RewardUsage) {
+        preference.edit {
+            val countKey = rewardedCountKey(usage)
+
+            it[countKey] = (it[countKey] ?: 0) + 1
+            it[stringPreferencesKey(KEY_REWARD_DATE)] = Clock.System.now().format("yyyy-MM-dd")
+        }
+    }
+
+    suspend fun reset() {
+        preference.edit {
+            RewardUsage.entries.forEach { usage ->
+                it[rewardedCountKey(usage)] = 0
             }
         }
     }
 
-    fun reset() {
-        scope.launch {
-            preference.edit {
-                it[intPreferencesKey(KEY_REWARDED_COUNT)] = 0
-            }
-        }
-    }
-
-    suspend fun getRewardedCount(): Int {
-        return preference.data.map { it[intPreferencesKey(KEY_REWARDED_COUNT)] ?: 0 }.first()
+    suspend fun getRewardedCount(usage: RewardUsage): Int {
+        return preference.data.map { it[rewardedCountKey(usage)] ?: 0 }.first()
     }
 
     suspend fun getRewardDate(): String? {
         return preference.data.map { it[stringPreferencesKey(KEY_REWARD_DATE)] }.first()
     }
+
+    private fun rewardedCountKey(usage: RewardUsage) = intPreferencesKey("${KEY_REWARDED_COUNT}_${usage.storageKey}")
 
     companion object {
         private const val KEY_REWARDED_COUNT = "rewarded_count"

--- a/core/datastore/src/commonMain/kotlin/me/matsumo/fanbox/core/datastore/RewardLogDataStore.kt
+++ b/core/datastore/src/commonMain/kotlin/me/matsumo/fanbox/core/datastore/RewardLogDataStore.kt
@@ -11,23 +11,27 @@ import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 
 /** リワード広告の用途別視聴履歴を保存する DataStore。 */
+@OptIn(ExperimentalTime::class)
 class RewardLogDataStore(
     private val preferenceHelper: PreferenceHelper,
+    private val clock: Clock = Clock.System,
 ) {
     private val preference = preferenceHelper.create(PreferencesName.REWARD_LOG)
 
-    @OptIn(ExperimentalTime::class)
     suspend fun rewarded(usage: RewardUsage) {
         preference.edit {
             val countKey = rewardedCountKey(usage)
 
             it[countKey] = (it[countKey] ?: 0) + 1
-            it[stringPreferencesKey(KEY_REWARD_DATE)] = Clock.System.now().format("yyyy-MM-dd")
+            it[stringPreferencesKey(KEY_REWARD_DATE)] = currentDate()
         }
     }
 
     suspend fun reset() {
         preference.edit {
+            it[intPreferencesKey(KEY_REWARDED_COUNT)] = 0
+            it[stringPreferencesKey(KEY_REWARD_DATE)] = currentDate()
+
             RewardUsage.entries.forEach { usage ->
                 it[rewardedCountKey(usage)] = 0
             }
@@ -43,6 +47,10 @@ class RewardLogDataStore(
     }
 
     private fun rewardedCountKey(usage: RewardUsage) = intPreferencesKey("${KEY_REWARDED_COUNT}_${usage.storageKey}")
+
+    private fun currentDate(): String {
+        return clock.now().format("yyyy-MM-dd")
+    }
 
     companion object {
         private const val KEY_REWARDED_COUNT = "rewarded_count"

--- a/core/datastore/src/commonMain/kotlin/me/matsumo/fanbox/core/datastore/RewardLogDataStore.kt
+++ b/core/datastore/src/commonMain/kotlin/me/matsumo/fanbox/core/datastore/RewardLogDataStore.kt
@@ -5,16 +5,11 @@ import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
-import me.matsumo.fanbox.core.common.util.format
 import me.matsumo.fanbox.core.model.RewardUsage
-import kotlin.time.Clock
-import kotlin.time.ExperimentalTime
 
 /** リワード広告の用途別視聴履歴を保存する DataStore。 */
-@OptIn(ExperimentalTime::class)
 class RewardLogDataStore(
     private val preferenceHelper: PreferenceHelper,
-    private val clock: Clock = Clock.System,
 ) {
     private val preference = preferenceHelper.create(PreferencesName.REWARD_LOG)
 
@@ -23,18 +18,22 @@ class RewardLogDataStore(
             val countKey = rewardedCountKey(usage)
 
             it[countKey] = (it[countKey] ?: 0) + 1
-            it[stringPreferencesKey(KEY_REWARD_DATE)] = currentDate()
         }
     }
 
     suspend fun reset() {
         preference.edit {
-            it[intPreferencesKey(KEY_REWARDED_COUNT)] = 0
-            it[stringPreferencesKey(KEY_REWARD_DATE)] = currentDate()
+            it.remove(intPreferencesKey(KEY_REWARDED_COUNT))
 
             RewardUsage.entries.forEach { usage ->
                 it[rewardedCountKey(usage)] = 0
             }
+        }
+    }
+
+    suspend fun setRewardDate(date: String) {
+        preference.edit {
+            it[stringPreferencesKey(KEY_REWARD_DATE)] = date
         }
     }
 
@@ -47,10 +46,6 @@ class RewardLogDataStore(
     }
 
     private fun rewardedCountKey(usage: RewardUsage) = intPreferencesKey("${KEY_REWARDED_COUNT}_${usage.storageKey}")
-
-    private fun currentDate(): String {
-        return clock.now().format("yyyy-MM-dd")
-    }
 
     companion object {
         private const val KEY_REWARDED_COUNT = "rewarded_count"

--- a/core/datastore/src/commonMain/kotlin/me/matsumo/fanbox/core/datastore/di/DataStoreModule.kt
+++ b/core/datastore/src/commonMain/kotlin/me/matsumo/fanbox/core/datastore/di/DataStoreModule.kt
@@ -46,7 +46,6 @@ val dataStoreModule = module {
     single {
         RewardLogDataStore(
             preferenceHelper = get(),
-            ioDispatcher = get(),
         )
     }
 

--- a/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/RewardUsage.kt
+++ b/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/RewardUsage.kt
@@ -1,0 +1,25 @@
+package me.matsumo.fanbox.core.model
+
+/** リワード広告で一時解放する機能の用途。 */
+enum class RewardUsage(
+    val storageKey: String,
+    val dailyLimit: Int,
+) {
+    /** クリエイター投稿の一括ダウンロード。 */
+    BulkDownload(
+        storageKey = "bulk_download",
+        dailyLimit = 1,
+    ),
+
+    /** クリエイター投稿検索。 */
+    CreatorSearch(
+        storageKey = "creator_search",
+        dailyLimit = 1,
+    ),
+
+    /** クリエイター概要の翻訳。 */
+    CreatorTranslation(
+        storageKey = "creator_translation",
+        dailyLimit = 1,
+    ),
+}

--- a/core/repository/build.gradle.kts
+++ b/core/repository/build.gradle.kts
@@ -1,3 +1,5 @@
+@file:Suppress("UnusedPrivateProperty")
+
 plugins {
     id("pixiview.primitive.kmp.common")
     id("pixiview.primitive.android.library")
@@ -9,6 +11,8 @@ plugins {
 kotlin {
     android {
         namespace = "me.matsumo.fanbox.core.repository"
+
+        withHostTest {}
     }
 
     sourceSets {
@@ -33,6 +37,12 @@ kotlin {
 
         iosMain.dependencies {
             api(libs.ktor.darwin)
+        }
+
+        val androidHostTest by getting {
+            dependencies {
+                implementation(kotlin("test-junit"))
+            }
         }
     }
 }

--- a/core/repository/src/androidHostTest/kotlin/me/matsumo/fanbox/core/repository/RewardRepositoryTest.kt
+++ b/core/repository/src/androidHostTest/kotlin/me/matsumo/fanbox/core/repository/RewardRepositoryTest.kt
@@ -49,7 +49,7 @@ class RewardRepositoryTest {
 
     @Test
     fun rewardCountsAreResetAfterDateChanges() = runBlocking {
-        val rewardLogDataStore = RewardLogDataStore(createPreferenceHelper(), clock)
+        val rewardLogDataStore = RewardLogDataStore(createPreferenceHelper())
         val rewardRepository = RewardRepositoryImpl(
             rewardLogDataStore = rewardLogDataStore,
             ioDispatcher = Dispatchers.Unconfined,
@@ -68,7 +68,7 @@ class RewardRepositoryTest {
     }
 
     private fun createRewardRepository(): RewardRepository {
-        val rewardLogDataStore = RewardLogDataStore(createPreferenceHelper(), clock)
+        val rewardLogDataStore = RewardLogDataStore(createPreferenceHelper())
 
         return RewardRepositoryImpl(
             rewardLogDataStore = rewardLogDataStore,

--- a/core/repository/src/androidHostTest/kotlin/me/matsumo/fanbox/core/repository/RewardRepositoryTest.kt
+++ b/core/repository/src/androidHostTest/kotlin/me/matsumo/fanbox/core/repository/RewardRepositoryTest.kt
@@ -1,0 +1,112 @@
+package me.matsumo.fanbox.core.repository
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.runBlocking
+import me.matsumo.fanbox.core.datastore.PreferenceHelper
+import me.matsumo.fanbox.core.datastore.RewardLogDataStore
+import me.matsumo.fanbox.core.model.RewardUsage
+import okio.Path.Companion.toPath
+import org.junit.After
+import org.junit.Test
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
+
+/** RewardRepository の用途別リワード視聴状態を検証するテスト。 */
+@OptIn(ExperimentalTime::class)
+class RewardRepositoryTest {
+
+    private val dataStoreScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    private val preferenceFiles = mutableListOf<File>()
+    private val clock = MutableClock(Instant.parse("2026-07-09T00:00:00Z"))
+
+    @After
+    fun tearDown() {
+        dataStoreScope.cancel()
+        preferenceFiles.forEach { it.delete() }
+    }
+
+    @Test
+    fun rewardedUsageDoesNotConsumeAnotherUsageOnSameDate() = runBlocking {
+        val rewardRepository = createRewardRepository()
+
+        rewardRepository.rewarded(RewardUsage.BulkDownload)
+
+        assertFalse(rewardRepository.isAbleToReward(RewardUsage.BulkDownload))
+        assertTrue(rewardRepository.isAbleToReward(RewardUsage.CreatorSearch))
+        assertTrue(rewardRepository.isAbleToReward(RewardUsage.CreatorTranslation))
+    }
+
+    @Test
+    fun rewardCountsAreResetAfterDateChanges() = runBlocking {
+        val rewardLogDataStore = RewardLogDataStore(createPreferenceHelper(), clock)
+        val rewardRepository = RewardRepositoryImpl(
+            rewardLogDataStore = rewardLogDataStore,
+            ioDispatcher = Dispatchers.Unconfined,
+            clock = clock,
+        )
+
+        rewardRepository.rewarded(RewardUsage.BulkDownload)
+        rewardRepository.rewarded(RewardUsage.CreatorSearch)
+        clock.instant = Instant.parse("2026-07-10T00:00:00Z")
+
+        assertTrue(rewardRepository.isAbleToReward(RewardUsage.BulkDownload))
+        assertEquals("2026-07-10", rewardLogDataStore.getRewardDate())
+        RewardUsage.entries.forEach { usage ->
+            assertEquals(0, rewardLogDataStore.getRewardedCount(usage))
+        }
+    }
+
+    private fun createRewardRepository(): RewardRepository {
+        val rewardLogDataStore = RewardLogDataStore(createPreferenceHelper(), clock)
+
+        return RewardRepositoryImpl(
+            rewardLogDataStore = rewardLogDataStore,
+            ioDispatcher = Dispatchers.Unconfined,
+            clock = clock,
+        )
+    }
+
+    private fun createPreferenceHelper(): PreferenceHelper {
+        return object : PreferenceHelper {
+            private val stores = mutableMapOf<String, DataStore<Preferences>>()
+
+            override fun create(name: String): DataStore<Preferences> {
+                return stores.getOrPut(name) { createDataStore(name) }
+            }
+
+            override fun delete(name: String) = Unit
+        }
+    }
+
+    private fun createDataStore(name: String): DataStore<Preferences> {
+        val preferenceFile = File.createTempFile(name, ".preferences_pb")
+        preferenceFile.delete()
+        preferenceFiles.add(preferenceFile)
+
+        return PreferenceDataStoreFactory.createWithPath(
+            corruptionHandler = null,
+            migrations = emptyList(),
+            scope = dataStoreScope,
+            produceFile = { preferenceFile.absolutePath.toPath() },
+        )
+    }
+
+    private class MutableClock(
+        var instant: Instant,
+    ) : Clock {
+        override fun now(): Instant {
+            return instant
+        }
+    }
+}

--- a/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/RewardRepository.kt
+++ b/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/RewardRepository.kt
@@ -14,9 +14,11 @@ interface RewardRepository {
     suspend fun isAbleToReward(usage: RewardUsage): Boolean
 }
 
+@OptIn(ExperimentalTime::class)
 class RewardRepositoryImpl(
     private val rewardLogDataStore: RewardLogDataStore,
     private val ioDispatcher: CoroutineDispatcher,
+    private val clock: Clock = Clock.System,
 ) : RewardRepository {
 
     override suspend fun rewarded(usage: RewardUsage) {
@@ -33,9 +35,8 @@ class RewardRepositoryImpl(
         }
     }
 
-    @OptIn(ExperimentalTime::class)
     private suspend fun resetIfNeeded() {
-        val date = Clock.System.now().format("yyyy-MM-dd")
+        val date = clock.now().format("yyyy-MM-dd")
         val lastRewardDate = rewardLogDataStore.getRewardDate()
 
         if (lastRewardDate != date) {

--- a/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/RewardRepository.kt
+++ b/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/RewardRepository.kt
@@ -1,17 +1,17 @@
 package me.matsumo.fanbox.core.repository
 
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import me.matsumo.fanbox.core.common.util.format
 import me.matsumo.fanbox.core.datastore.RewardLogDataStore
+import me.matsumo.fanbox.core.model.RewardUsage
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 
+/** リワード広告による一時機能解放の利用状況を扱う Repository。 */
 interface RewardRepository {
-    fun rewarded()
-    suspend fun isAbleToReward(): Boolean
+    suspend fun rewarded(usage: RewardUsage)
+    suspend fun isAbleToReward(usage: RewardUsage): Boolean
 }
 
 class RewardRepositoryImpl(
@@ -19,23 +19,18 @@ class RewardRepositoryImpl(
     private val ioDispatcher: CoroutineDispatcher,
 ) : RewardRepository {
 
-    private val scope = CoroutineScope(ioDispatcher + SupervisorJob())
-
-    init {
-        scope.launch {
+    override suspend fun rewarded(usage: RewardUsage) {
+        withContext(ioDispatcher) {
             resetIfNeeded()
+            rewardLogDataStore.rewarded(usage)
         }
     }
 
-    override fun rewarded() {
-        scope.launch {
-            rewardLogDataStore.rewarded()
+    override suspend fun isAbleToReward(usage: RewardUsage): Boolean {
+        return withContext(ioDispatcher) {
+            resetIfNeeded()
+            rewardLogDataStore.getRewardedCount(usage) < usage.dailyLimit
         }
-    }
-
-    override suspend fun isAbleToReward(): Boolean {
-        resetIfNeeded()
-        return rewardLogDataStore.getRewardedCount() < MAX_REWARD_COUNT
     }
 
     @OptIn(ExperimentalTime::class)
@@ -46,9 +41,5 @@ class RewardRepositoryImpl(
         if (lastRewardDate != date) {
             rewardLogDataStore.reset()
         }
-    }
-
-    companion object {
-        const val MAX_REWARD_COUNT = 1
     }
 }

--- a/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/RewardRepository.kt
+++ b/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/RewardRepository.kt
@@ -23,24 +23,30 @@ class RewardRepositoryImpl(
 
     override suspend fun rewarded(usage: RewardUsage) {
         withContext(ioDispatcher) {
-            resetIfNeeded()
+            val date = currentDate()
+
+            resetIfNeeded(date)
             rewardLogDataStore.rewarded(usage)
         }
     }
 
     override suspend fun isAbleToReward(usage: RewardUsage): Boolean {
         return withContext(ioDispatcher) {
-            resetIfNeeded()
+            resetIfNeeded(currentDate())
             rewardLogDataStore.getRewardedCount(usage) < usage.dailyLimit
         }
     }
 
-    private suspend fun resetIfNeeded() {
-        val date = clock.now().format("yyyy-MM-dd")
+    private suspend fun resetIfNeeded(date: String) {
         val lastRewardDate = rewardLogDataStore.getRewardDate()
 
         if (lastRewardDate != date) {
             rewardLogDataStore.reset()
+            rewardLogDataStore.setRewardDate(date)
         }
+    }
+
+    private fun currentDate(): String {
+        return clock.now().format("yyyy-MM-dd")
     }
 }

--- a/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/RewardRepository.kt
+++ b/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/RewardRepository.kt
@@ -23,9 +23,7 @@ class RewardRepositoryImpl(
 
     override suspend fun rewarded(usage: RewardUsage) {
         withContext(ioDispatcher) {
-            val date = currentDate()
-
-            resetIfNeeded(date)
+            resetIfNeeded(currentDate())
             rewardLogDataStore.rewarded(usage)
         }
     }

--- a/core/resources/src/commonMain/composeResources/values-ja/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-ja/strings.xml
@@ -170,10 +170,12 @@
     <string name="creator_recommended">おすすめのクリエイター</string>
     <string name="creator_following_pixiv">Pixivでフォロー中のクリエイター</string>
     <string name="creator_download_require_plus_title">投稿を一括ダウンロード</string>
-    <string name="creator_download_require_plus_message">一括ダウンロードは%1$s+専用機能です。\n\n%1$s+を購入するか、この機能用の広告を1日1回見ることで一時的に使用できます。</string>
     <string name="creator_download_require_plus_button">%1$s+を購入</string>
     <string name="creator_download_require_plus_button_ad">広告を見る</string>
     <string name="creator_download_require_plus_button_ad_over">広告視聴済み</string>
+    <string name="creator_reward_unlock_bulk_download_feature">一括ダウンロード</string>
+    <string name="creator_reward_unlock_creator_search_feature">投稿検索</string>
+    <string name="creator_reward_unlock_translation_feature">概要翻訳</string>
     <string name="creator_reward_unlock_search_title">クリエイターの投稿を検索</string>
     <string name="creator_reward_unlock_translation_title">クリエイター概要を翻訳</string>
     <string name="creator_reward_unlock_require_plus_message">%1$sは%2$s+専用機能です。\n\n%2$s+を購入するか、この機能用の広告を1日1回見ることで一時的に使用できます。</string>

--- a/core/resources/src/commonMain/composeResources/values-ja/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-ja/strings.xml
@@ -170,10 +170,13 @@
     <string name="creator_recommended">おすすめのクリエイター</string>
     <string name="creator_following_pixiv">Pixivでフォロー中のクリエイター</string>
     <string name="creator_download_require_plus_title">投稿を一括ダウンロード</string>
-    <string name="creator_download_require_plus_message">一括ダウンロードは%1$s+専用機能です。\n\n%1$s+を購入するか、1日1回のみ広告を見ることで一時的に機能を使用することができます。</string>
+    <string name="creator_download_require_plus_message">一括ダウンロードは%1$s+専用機能です。\n\n%1$s+を購入するか、この機能用の広告を1日1回見ることで一時的に使用できます。</string>
     <string name="creator_download_require_plus_button">%1$s+を購入</string>
     <string name="creator_download_require_plus_button_ad">広告を見る</string>
     <string name="creator_download_require_plus_button_ad_over">広告視聴済み</string>
+    <string name="creator_reward_unlock_search_title">クリエイターの投稿を検索</string>
+    <string name="creator_reward_unlock_translation_title">クリエイター概要を翻訳</string>
+    <string name="creator_reward_unlock_require_plus_message">%1$sは%2$s+専用機能です。\n\n%2$s+を購入するか、この機能用の広告を1日1回見ることで一時的に使用できます。</string>
 
     <!-- Bookmark -->
     <string name="bookmark_search_placeholder">ブックマークを検索</string>

--- a/core/resources/src/commonMain/composeResources/values-ko/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-ko/strings.xml
@@ -160,10 +160,13 @@
     <string name="creator_download_require_plus_title">게시물 일괄 다운로드</string>
     <string name="creator_download_require_plus_message">일괄 다운로드는 %1$s+ 전용 기능입니다. 
 
-%1$s+를 구매하거나 하루 1회만 광고를 시청하여 일시적으로 기능을 사용할 수 있습니다.</string>
+%1$s+를 구매하거나 이 기능용 광고를 하루 1회 시청하면 일시적으로 사용할 수 있습니다.</string>
     <string name="creator_download_require_plus_button">%1$s+ 구매</string>
     <string name="creator_download_require_plus_button_ad">광고 보기</string>
     <string name="creator_download_require_plus_button_ad_over">광고 시청 완료</string>
+    <string name="creator_reward_unlock_search_title">크리에이터 게시물 검색</string>
+    <string name="creator_reward_unlock_translation_title">크리에이터 설명 번역</string>
+    <string name="creator_reward_unlock_require_plus_message">%1$s은(는) %2$s+ 전용 기능입니다.\n\n%2$s+를 구매하거나 이 기능용 광고를 하루 1회 시청하면 일시적으로 사용할 수 있습니다.</string>
     <string name="bookmark_search_placeholder">북마크 검색</string>
     <string name="bookmark_empty_title">북마크가 없습니다</string>
     <string name="bookmark_empty_description">좋아하는 포스트를 찾아 북마크해보세요!</string>

--- a/core/resources/src/commonMain/composeResources/values-ko/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-ko/strings.xml
@@ -158,12 +158,12 @@
     <string name="creator_recommended">추천 크리에이터</string>
     <string name="creator_following_pixiv">pixiv에서 팔로우 중</string>
     <string name="creator_download_require_plus_title">게시물 일괄 다운로드</string>
-    <string name="creator_download_require_plus_message">일괄 다운로드는 %1$s+ 전용 기능입니다. 
-
-%1$s+를 구매하거나 이 기능용 광고를 하루 1회 시청하면 일시적으로 사용할 수 있습니다.</string>
     <string name="creator_download_require_plus_button">%1$s+ 구매</string>
     <string name="creator_download_require_plus_button_ad">광고 보기</string>
     <string name="creator_download_require_plus_button_ad_over">광고 시청 완료</string>
+    <string name="creator_reward_unlock_bulk_download_feature">일괄 다운로드</string>
+    <string name="creator_reward_unlock_creator_search_feature">게시물 검색</string>
+    <string name="creator_reward_unlock_translation_feature">설명 번역</string>
     <string name="creator_reward_unlock_search_title">크리에이터 게시물 검색</string>
     <string name="creator_reward_unlock_translation_title">크리에이터 설명 번역</string>
     <string name="creator_reward_unlock_require_plus_message">%1$s은(는) %2$s+ 전용 기능입니다.\n\n%2$s+를 구매하거나 이 기능용 광고를 하루 1회 시청하면 일시적으로 사용할 수 있습니다.</string>

--- a/core/resources/src/commonMain/composeResources/values-ru/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-ru/strings.xml
@@ -159,12 +159,12 @@
     <string name="creator_recommended">Рекомендуемые авторы</string>
     <string name="creator_following_pixiv">Подписки на pixiv</string>
     <string name="creator_download_require_plus_title">Скачивание множества публикации</string>
-    <string name="creator_download_require_plus_message">Пакетное скачивание – доступно только в %1$s+. 
-
-Функцию можно временно использовать, купив %1$s+ или посмотрев рекламу для этой функции один раз в день.</string>
     <string name="creator_download_require_plus_button">Купить %1$s+</string>
     <string name="creator_download_require_plus_button_ad">Посмотреть рекламу</string>
     <string name="creator_download_require_plus_button_ad_over">Реклама просмотрена</string>
+    <string name="creator_reward_unlock_bulk_download_feature">Пакетное скачивание</string>
+    <string name="creator_reward_unlock_creator_search_feature">Поиск публикаций</string>
+    <string name="creator_reward_unlock_translation_feature">Перевод описания</string>
     <string name="creator_reward_unlock_search_title">Поиск публикаций автора</string>
     <string name="creator_reward_unlock_translation_title">Перевод описания автора</string>
     <string name="creator_reward_unlock_require_plus_message">%1$s доступно только в %2$s+.\n\nФункцию можно временно использовать, купив %2$s+ или посмотрев рекламу для этой функции один раз в день.</string>

--- a/core/resources/src/commonMain/composeResources/values-ru/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-ru/strings.xml
@@ -161,10 +161,13 @@
     <string name="creator_download_require_plus_title">Скачивание множества публикации</string>
     <string name="creator_download_require_plus_message">Пакетное скачивание – доступно только в %1$s+. 
 
-Вы можете временно использовать эту функцию, купив %1$s+ или посмотрев рекламу всего 1 раз в день.</string>
+Функцию можно временно использовать, купив %1$s+ или посмотрев рекламу для этой функции один раз в день.</string>
     <string name="creator_download_require_plus_button">Купить %1$s+</string>
     <string name="creator_download_require_plus_button_ad">Посмотреть рекламу</string>
     <string name="creator_download_require_plus_button_ad_over">Реклама просмотрена</string>
+    <string name="creator_reward_unlock_search_title">Поиск публикаций автора</string>
+    <string name="creator_reward_unlock_translation_title">Перевод описания автора</string>
+    <string name="creator_reward_unlock_require_plus_message">%1$s доступно только в %2$s+.\n\nФункцию можно временно использовать, купив %2$s+ или посмотрев рекламу для этой функции один раз в день.</string>
     <string name="bookmark_search_placeholder">Найти в избранном</string>
     <string name="bookmark_empty_title">Нет избранных</string>
     <string name="bookmark_empty_description">Найдите и сохраните свои любимые публикации!</string>

--- a/core/resources/src/commonMain/composeResources/values-zh-rCN/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-zh-rCN/strings.xml
@@ -158,10 +158,13 @@
     <string name="creator_download_require_plus_title">批量下载投稿</string>
     <string name="creator_download_require_plus_message">批量下载是 %1$s+ 的独家功能。
 
-您可以通过购买 %1$s+ 或每天观看1次广告来暂时使用该功能。</string>
+您可以购买 %1$s+，或每天为此功能观看 1 次广告来临时使用。</string>
     <string name="creator_download_require_plus_button">购买 %1$s+</string>
     <string name="creator_download_require_plus_button_ad">观看广告</string>
     <string name="creator_download_require_plus_button_ad_over">已观看广告</string>
+    <string name="creator_reward_unlock_search_title">搜索创作者投稿</string>
+    <string name="creator_reward_unlock_translation_title">翻译创作者简介</string>
+    <string name="creator_reward_unlock_require_plus_message">%1$s 是 %2$s+ 的专属功能。\n\n您可以购买 %2$s+，或每天为此功能观看 1 次广告来临时使用。</string>
     <string name="bookmark_search_placeholder">搜索收藏</string>
     <string name="bookmark_empty_title">无收藏</string>
     <string name="bookmark_empty_description">查找并收藏您喜欢的投稿</string>

--- a/core/resources/src/commonMain/composeResources/values-zh-rCN/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values-zh-rCN/strings.xml
@@ -156,12 +156,12 @@
     <string name="creator_recommended">推荐的创作者</string>
     <string name="creator_following_pixiv">在Pixiv上关注的作者</string>
     <string name="creator_download_require_plus_title">批量下载投稿</string>
-    <string name="creator_download_require_plus_message">批量下载是 %1$s+ 的独家功能。
-
-您可以购买 %1$s+，或每天为此功能观看 1 次广告来临时使用。</string>
     <string name="creator_download_require_plus_button">购买 %1$s+</string>
     <string name="creator_download_require_plus_button_ad">观看广告</string>
     <string name="creator_download_require_plus_button_ad_over">已观看广告</string>
+    <string name="creator_reward_unlock_bulk_download_feature">批量下载</string>
+    <string name="creator_reward_unlock_creator_search_feature">投稿搜索</string>
+    <string name="creator_reward_unlock_translation_feature">简介翻译</string>
     <string name="creator_reward_unlock_search_title">搜索创作者投稿</string>
     <string name="creator_reward_unlock_translation_title">翻译创作者简介</string>
     <string name="creator_reward_unlock_require_plus_message">%1$s 是 %2$s+ 的专属功能。\n\n您可以购买 %2$s+，或每天为此功能观看 1 次广告来临时使用。</string>

--- a/core/resources/src/commonMain/composeResources/values/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values/strings.xml
@@ -171,10 +171,13 @@
     <string name="creator_recommended">Recommended creators</string>
     <string name="creator_following_pixiv">Following on pixiv</string>
     <string name="creator_download_require_plus_title">Download posts in bulk</string>
-    <string name="creator_download_require_plus_message">Bulk download is a %1$s+ exclusive feature. \n\nYou can temporarily use the feature by purchasing %1$s+ or by watching ads only 1 time a day.</string>
+    <string name="creator_download_require_plus_message">Bulk download is a %1$s+ exclusive feature. \n\nYou can temporarily use the feature by purchasing %1$s+ or watching an ad once per day for this feature.</string>
     <string name="creator_download_require_plus_button">Purchase %1$s+</string>
     <string name="creator_download_require_plus_button_ad">See Ad</string>
     <string name="creator_download_require_plus_button_ad_over">Ad watched</string>
+    <string name="creator_reward_unlock_search_title">Search creator posts</string>
+    <string name="creator_reward_unlock_translation_title">Translate creator description</string>
+    <string name="creator_reward_unlock_require_plus_message">%1$s is a %2$s+ exclusive feature.\n\nYou can temporarily use it by purchasing %2$s+ or watching an ad once per day for this feature.</string>
 
     <!-- Bookmark -->
     <string name="bookmark_search_placeholder">Search bookmark</string>

--- a/core/resources/src/commonMain/composeResources/values/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values/strings.xml
@@ -171,10 +171,12 @@
     <string name="creator_recommended">Recommended creators</string>
     <string name="creator_following_pixiv">Following on pixiv</string>
     <string name="creator_download_require_plus_title">Download posts in bulk</string>
-    <string name="creator_download_require_plus_message">Bulk download is a %1$s+ exclusive feature. \n\nYou can temporarily use the feature by purchasing %1$s+ or watching an ad once per day for this feature.</string>
     <string name="creator_download_require_plus_button">Purchase %1$s+</string>
     <string name="creator_download_require_plus_button_ad">See Ad</string>
     <string name="creator_download_require_plus_button_ad_over">Ad watched</string>
+    <string name="creator_reward_unlock_bulk_download_feature">Bulk download</string>
+    <string name="creator_reward_unlock_creator_search_feature">Post search</string>
+    <string name="creator_reward_unlock_translation_feature">Description translation</string>
     <string name="creator_reward_unlock_search_title">Search creator posts</string>
     <string name="creator_reward_unlock_translation_title">Translate creator description</string>
     <string name="creator_reward_unlock_require_plus_message">%1$s is a %2$s+ exclusive feature.\n\nYou can temporarily use it by purchasing %2$s+ or watching an ad once per day for this feature.</string>

--- a/feature/creator/build.gradle.kts
+++ b/feature/creator/build.gradle.kts
@@ -1,3 +1,5 @@
+@file:Suppress("UnusedPrivateProperty")
+
 plugins {
     id("pixiview.primitive.kmp.common")
     id("pixiview.primitive.android.library")
@@ -10,6 +12,8 @@ plugins {
 kotlin {
     android {
         namespace = "me.matsumo.fanbox.feature.creator"
+
+        withHostTest {}
     }
 
     sourceSets {
@@ -22,6 +26,12 @@ kotlin {
             implementation(project(":core:ui"))
             implementation(project(":core:logs"))
             implementation(project(":core:resources"))
+        }
+
+        val androidHostTest by getting {
+            dependencies {
+                implementation(kotlin("test-junit"))
+            }
         }
     }
 }

--- a/feature/creator/src/androidHostTest/kotlin/me/matsumo/fanbox/feature/creator/top/CreatorTopRewardUsageSaverTest.kt
+++ b/feature/creator/src/androidHostTest/kotlin/me/matsumo/fanbox/feature/creator/top/CreatorTopRewardUsageSaverTest.kt
@@ -13,7 +13,7 @@ class CreatorTopRewardUsageSaverTest {
         RewardUsage.entries.forEach { usage ->
             val savedKey = saveCreatorTopRewardUsage(usage)
 
-            assertEquals(usage.storageKey, savedKey)
+            assertEquals(usage.name, savedKey)
             assertEquals(usage, restoreCreatorTopRewardUsage(savedKey.orEmpty()))
         }
     }

--- a/feature/creator/src/androidHostTest/kotlin/me/matsumo/fanbox/feature/creator/top/CreatorTopRewardUsageSaverTest.kt
+++ b/feature/creator/src/androidHostTest/kotlin/me/matsumo/fanbox/feature/creator/top/CreatorTopRewardUsageSaverTest.kt
@@ -1,0 +1,26 @@
+package me.matsumo.fanbox.feature.creator.top
+
+import me.matsumo.fanbox.core.model.RewardUsage
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/** CreatorTopRewardUsageSaver の保存値と復元値を検証するテスト。 */
+class CreatorTopRewardUsageSaverTest {
+
+    @Test
+    fun pendingRewardUsageCanBeRestoredFromSavedKey() {
+        RewardUsage.entries.forEach { usage ->
+            val savedKey = saveCreatorTopRewardUsage(usage)
+
+            assertEquals(usage.storageKey, savedKey)
+            assertEquals(usage, restoreCreatorTopRewardUsage(savedKey.orEmpty()))
+        }
+    }
+
+    @Test
+    fun nullOrUnknownRewardUsageDoesNotRestoreUsage() {
+        assertNull(saveCreatorTopRewardUsage(null))
+        assertNull(restoreCreatorTopRewardUsage("unknown"))
+    }
+}

--- a/feature/creator/src/androidMain/kotlin/me/matsumo/fanbox/feature/creator/top/items/CreatorTopRewardAdDialog.android.kt
+++ b/feature/creator/src/androidMain/kotlin/me/matsumo/fanbox/feature/creator/top/items/CreatorTopRewardAdDialog.android.kt
@@ -33,8 +33,6 @@ import me.matsumo.fanbox.core.resources.Res
 import me.matsumo.fanbox.core.resources.creator_download_require_plus_button
 import me.matsumo.fanbox.core.resources.creator_download_require_plus_button_ad
 import me.matsumo.fanbox.core.resources.creator_download_require_plus_button_ad_over
-import me.matsumo.fanbox.core.resources.creator_download_require_plus_message
-import me.matsumo.fanbox.core.resources.creator_download_require_plus_title
 import me.matsumo.fanbox.core.ui.ads.RewardAdLoader
 import me.matsumo.fanbox.core.ui.ads.handleRewardAdShowResult
 import me.matsumo.fanbox.core.ui.appName
@@ -46,6 +44,8 @@ import org.koin.compose.koinInject
 @Suppress("UnstableCollections", "ModifierMissing")
 @Composable
 actual fun CreatorTopRewardAdDialog(
+    title: String,
+    message: String,
     isAbleToReward: Boolean,
     onRewarded: () -> Unit,
     onClickShowPlus: () -> Unit,
@@ -119,14 +119,14 @@ actual fun CreatorTopRewardAdDialog(
             ) {
                 Text(
                     modifier = Modifier.fillMaxWidth(),
-                    text = stringResource(Res.string.creator_download_require_plus_title),
+                    text = title,
                     style = MaterialTheme.typography.titleMedium.bold(),
                     color = MaterialTheme.colorScheme.onSurface,
                 )
 
                 Text(
                     modifier = Modifier.fillMaxWidth(),
-                    text = stringResource(Res.string.creator_download_require_plus_message, appName),
+                    text = message,
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )

--- a/feature/creator/src/androidMain/kotlin/me/matsumo/fanbox/feature/creator/top/items/CreatorTopRewardAdPreloader.android.kt
+++ b/feature/creator/src/androidMain/kotlin/me/matsumo/fanbox/feature/creator/top/items/CreatorTopRewardAdPreloader.android.kt
@@ -1,0 +1,22 @@
+package me.matsumo.fanbox.feature.creator.top.items
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import me.matsumo.fanbox.core.ui.ads.RewardAdLoader
+import me.matsumo.fanbox.core.ui.theme.LocalAdsSdkInitialized
+import org.koin.compose.koinInject
+
+@Composable
+actual fun CreatorTopRewardAdPreloader(shouldPreload: Boolean) {
+    val isAdsSdkInitialized = LocalAdsSdkInitialized.current
+    val rewardAdLoader = koinInject<RewardAdLoader>()
+
+    LaunchedEffect(
+        key1 = shouldPreload,
+        key2 = isAdsSdkInitialized,
+    ) {
+        if (shouldPreload) {
+            rewardAdLoader.loadRewardAdIfNeeded(isAdsSdkInitialized)
+        }
+    }
+}

--- a/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/top/CreatorTopRewardUsageSaver.kt
+++ b/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/top/CreatorTopRewardUsageSaver.kt
@@ -6,13 +6,13 @@ import me.matsumo.fanbox.core.model.RewardUsage
 /** Creator Top の未処理リワード用途を Activity 再生成後に復元する Saver。 */
 internal val CreatorTopRewardUsageSaver = Saver<RewardUsage?, String>(
     save = { usage -> saveCreatorTopRewardUsage(usage) },
-    restore = { storageKey -> restoreCreatorTopRewardUsage(storageKey) },
+    restore = { name -> restoreCreatorTopRewardUsage(name) },
 )
 
 internal fun saveCreatorTopRewardUsage(usage: RewardUsage?): String? {
-    return usage?.storageKey
+    return usage?.name
 }
 
-internal fun restoreCreatorTopRewardUsage(storageKey: String): RewardUsage? {
-    return RewardUsage.entries.firstOrNull { it.storageKey == storageKey }
+internal fun restoreCreatorTopRewardUsage(name: String): RewardUsage? {
+    return RewardUsage.entries.firstOrNull { it.name == name }
 }

--- a/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/top/CreatorTopRewardUsageSaver.kt
+++ b/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/top/CreatorTopRewardUsageSaver.kt
@@ -1,0 +1,18 @@
+package me.matsumo.fanbox.feature.creator.top
+
+import androidx.compose.runtime.saveable.Saver
+import me.matsumo.fanbox.core.model.RewardUsage
+
+/** Creator Top の未処理リワード用途を Activity 再生成後に復元する Saver。 */
+internal val CreatorTopRewardUsageSaver = Saver<RewardUsage?, String>(
+    save = { usage -> saveCreatorTopRewardUsage(usage) },
+    restore = { storageKey -> restoreCreatorTopRewardUsage(storageKey) },
+)
+
+internal fun saveCreatorTopRewardUsage(usage: RewardUsage?): String? {
+    return usage?.storageKey
+}
+
+internal fun restoreCreatorTopRewardUsage(storageKey: String): RewardUsage? {
+    return RewardUsage.entries.firstOrNull { it.storageKey == storageKey }
+}

--- a/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/top/CreatorTopScreen.kt
+++ b/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/top/CreatorTopScreen.kt
@@ -74,8 +74,11 @@ import me.matsumo.fanbox.core.model.TranslationState
 import me.matsumo.fanbox.core.resources.Res
 import me.matsumo.fanbox.core.resources.billing_plus_toast_require_plus
 import me.matsumo.fanbox.core.resources.creator_download_require_plus_title
+import me.matsumo.fanbox.core.resources.creator_reward_unlock_bulk_download_feature
+import me.matsumo.fanbox.core.resources.creator_reward_unlock_creator_search_feature
 import me.matsumo.fanbox.core.resources.creator_reward_unlock_require_plus_message
 import me.matsumo.fanbox.core.resources.creator_reward_unlock_search_title
+import me.matsumo.fanbox.core.resources.creator_reward_unlock_translation_feature
 import me.matsumo.fanbox.core.resources.creator_reward_unlock_translation_title
 import me.matsumo.fanbox.core.resources.creator_tab_plans
 import me.matsumo.fanbox.core.resources.creator_tab_posts
@@ -247,7 +250,7 @@ private fun CreatorTopScreen(
     onShowUnblockDialog: (SimpleAlertContents) -> Unit,
     onClickTranslateDescription: (String) -> Unit,
     onRevealCompleted: () -> Unit,
-    onRewarded: suspend (RewardUsage) -> Unit,
+    onRewarded: (RewardUsage) -> Unit,
     onTerminate: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -269,12 +272,10 @@ private fun CreatorTopScreen(
     var isShowMenuDialog by remember { mutableStateOf(false) }
     var isVisibleFAB by remember { mutableStateOf(false) }
 
-    val rewardPreloadCandidates = listOf(
-        !setting.canBulkDownload && rewardAvailability.bulkDownload,
-        !setting.hasPrivilege && rewardAvailability.creatorSearch,
-        !setting.hasPrivilege && rewardAvailability.creatorTranslation,
-    )
-    val shouldPreloadRewardAd = rewardPreloadCandidates.any { it }
+    val canRewardBulkDownload = !setting.canBulkDownload && rewardAvailability.bulkDownload
+    val canRewardCreatorSearch = !setting.hasPrivilege && rewardAvailability.creatorSearch
+    val canRewardCreatorTranslation = !setting.hasPrivilege && rewardAvailability.creatorTranslation
+    val shouldPreloadRewardAd = canRewardBulkDownload || canRewardCreatorSearch || canRewardCreatorTranslation
 
     val tabs = listOf(
         CreatorTab.POSTS,
@@ -480,16 +481,13 @@ private fun CreatorTopScreen(
             message = activeRewardUsage.rewardUnlockMessage(),
             isAbleToReward = rewardAvailability.isAbleToReward(activeRewardUsage),
             onRewarded = {
-                scope.launch {
-                    onRewarded.invoke(activeRewardUsage)
+                onRewarded.invoke(activeRewardUsage)
+                rewardUsage = null
 
-                    when (activeRewardUsage) {
-                        RewardUsage.BulkDownload -> onClickAllDownload.invoke(creatorDetail.creatorId)
-                        RewardUsage.CreatorSearch -> onClickSearch.invoke(creatorDetail.creatorId)
-                        RewardUsage.CreatorTranslation -> onClickTranslateDescription.invoke(creatorDetail.description)
-                    }
-
-                    rewardUsage = null
+                when (activeRewardUsage) {
+                    RewardUsage.BulkDownload -> onClickAllDownload.invoke(creatorDetail.creatorId)
+                    RewardUsage.CreatorSearch -> onClickSearch.invoke(creatorDetail.creatorId)
+                    RewardUsage.CreatorTranslation -> onClickTranslateDescription.invoke(creatorDetail.description)
                 }
             },
             onClickShowPlus = {
@@ -603,8 +601,19 @@ private fun RewardUsage.rewardUnlockTitle(): String {
 private fun RewardUsage.rewardUnlockMessage(): String {
     return stringResource(
         Res.string.creator_reward_unlock_require_plus_message,
-        rewardUnlockTitle(),
+        rewardUnlockFeatureName(),
         appName,
+    )
+}
+
+@Composable
+private fun RewardUsage.rewardUnlockFeatureName(): String {
+    return stringResource(
+        when (this) {
+            RewardUsage.BulkDownload -> Res.string.creator_reward_unlock_bulk_download_feature
+            RewardUsage.CreatorSearch -> Res.string.creator_reward_unlock_creator_search_feature
+            RewardUsage.CreatorTranslation -> Res.string.creator_reward_unlock_translation_feature
+        },
     )
 }
 

--- a/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/top/CreatorTopScreen.kt
+++ b/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/top/CreatorTopScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
@@ -263,7 +264,7 @@ private fun CreatorTopScreen(
     val plansListState = rememberLazyListState()
 
     var topAppBarHeight by remember { mutableStateOf(0.dp) }
-    var rewardUsage by remember { mutableStateOf<RewardUsage?>(null) }
+    var rewardUsage by rememberSaveable(stateSaver = CreatorTopRewardUsageSaver) { mutableStateOf<RewardUsage?>(null) }
     var isShowDescriptionDialog by remember { mutableStateOf(false) }
     var isShowMenuDialog by remember { mutableStateOf(false) }
     var isVisibleFAB by remember { mutableStateOf(false) }

--- a/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/top/CreatorTopScreen.kt
+++ b/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/top/CreatorTopScreen.kt
@@ -37,7 +37,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
@@ -67,11 +66,16 @@ import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import me.matsumo.fanbox.core.model.Destination
+import me.matsumo.fanbox.core.model.RewardUsage
 import me.matsumo.fanbox.core.model.Setting
 import me.matsumo.fanbox.core.model.SimpleAlertContents
 import me.matsumo.fanbox.core.model.TranslationState
 import me.matsumo.fanbox.core.resources.Res
 import me.matsumo.fanbox.core.resources.billing_plus_toast_require_plus
+import me.matsumo.fanbox.core.resources.creator_download_require_plus_title
+import me.matsumo.fanbox.core.resources.creator_reward_unlock_require_plus_message
+import me.matsumo.fanbox.core.resources.creator_reward_unlock_search_title
+import me.matsumo.fanbox.core.resources.creator_reward_unlock_translation_title
 import me.matsumo.fanbox.core.resources.creator_tab_plans
 import me.matsumo.fanbox.core.resources.creator_tab_posts
 import me.matsumo.fanbox.core.resources.reveal_creator_top_fab
@@ -94,6 +98,7 @@ import me.matsumo.fanbox.feature.creator.top.items.CreatorTopMenuDialog
 import me.matsumo.fanbox.feature.creator.top.items.CreatorTopPlansScreen
 import me.matsumo.fanbox.feature.creator.top.items.CreatorTopPostsScreen
 import me.matsumo.fanbox.feature.creator.top.items.CreatorTopRewardAdDialog
+import me.matsumo.fanbox.feature.creator.top.items.CreatorTopRewardAdPreloader
 import me.matsumo.fanbox.feature.creator.top.items.CreatorTopTopAppBar
 import me.matsumo.fankt.fanbox.domain.model.FanboxCreatorDetail
 import me.matsumo.fankt.fanbox.domain.model.FanboxCreatorPlan
@@ -155,7 +160,7 @@ internal fun CreatorTopRoute(
                 shouldShowReveal = uiState.shouldShowReveal,
                 isPosts = isPosts,
                 isBlocked = uiState.isBlocked,
-                isAbleToReward = uiState.isAbleToReward,
+                rewardAvailability = uiState.rewardAvailability,
                 setting = uiState.setting,
                 bookmarkedPostsIds = uiState.bookmarkedPostsIds.toImmutableList(),
                 creatorDetail = uiState.creatorDetail,
@@ -217,7 +222,7 @@ private fun CreatorTopScreen(
     revealState: RevealState,
     isPosts: Boolean,
     isBlocked: Boolean,
-    isAbleToReward: Boolean,
+    rewardAvailability: CreatorTopRewardAvailability,
     shouldShowReveal: Boolean,
     creatorDetail: FanboxCreatorDetail,
     setting: Setting,
@@ -241,7 +246,7 @@ private fun CreatorTopScreen(
     onShowUnblockDialog: (SimpleAlertContents) -> Unit,
     onClickTranslateDescription: (String) -> Unit,
     onRevealCompleted: () -> Unit,
-    onRewarded: () -> Unit,
+    onRewarded: suspend (RewardUsage) -> Unit,
     onTerminate: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -258,10 +263,17 @@ private fun CreatorTopScreen(
     val plansListState = rememberLazyListState()
 
     var topAppBarHeight by remember { mutableStateOf(0.dp) }
-    var isShowRewardAdDialog by rememberSaveable { mutableStateOf(false) }
+    var rewardUsage by remember { mutableStateOf<RewardUsage?>(null) }
     var isShowDescriptionDialog by remember { mutableStateOf(false) }
     var isShowMenuDialog by remember { mutableStateOf(false) }
     var isVisibleFAB by remember { mutableStateOf(false) }
+
+    val rewardPreloadCandidates = listOf(
+        !setting.canBulkDownload && rewardAvailability.bulkDownload,
+        !setting.hasPrivilege && rewardAvailability.creatorSearch,
+        !setting.hasPrivilege && rewardAvailability.creatorTranslation,
+    )
+    val shouldPreloadRewardAd = rewardPreloadCandidates.any { it }
 
     val tabs = listOf(
         CreatorTab.POSTS,
@@ -275,6 +287,8 @@ private fun CreatorTopScreen(
     LaunchedEffect(true) {
         isVisibleFAB = true
     }
+
+    CreatorTopRewardAdPreloader(shouldPreload = shouldPreloadRewardAd)
 
     LaunchedEffect(isBlocked) {
         if (isBlocked) {
@@ -420,7 +434,7 @@ private fun CreatorTopScreen(
                 if (setting.hasPrivilege) {
                     onClickSearch.invoke(creatorDetail.creatorId)
                 } else {
-                    onClickBillingPlus.invoke("search_post_by_creator")
+                    rewardUsage = RewardUsage.CreatorSearch
                 }
             },
         )
@@ -445,7 +459,7 @@ private fun CreatorTopScreen(
                     if (setting.canBulkDownload) {
                         onClickAllDownload.invoke(creatorDetail.creatorId)
                     } else {
-                        isShowRewardAdDialog = true
+                        rewardUsage = RewardUsage.BulkDownload
                     }
                 },
             ) {
@@ -457,19 +471,35 @@ private fun CreatorTopScreen(
         }
     }
 
-    if (isShowRewardAdDialog) {
+    val activeRewardUsage = rewardUsage
+
+    if (activeRewardUsage != null) {
         CreatorTopRewardAdDialog(
-            isAbleToReward = isAbleToReward,
+            title = activeRewardUsage.rewardUnlockTitle(),
+            message = activeRewardUsage.rewardUnlockMessage(),
+            isAbleToReward = rewardAvailability.isAbleToReward(activeRewardUsage),
             onRewarded = {
-                onRewarded.invoke()
-                onClickAllDownload.invoke(creatorDetail.creatorId)
-                isShowRewardAdDialog = false
+                scope.launch {
+                    onRewarded.invoke(activeRewardUsage)
+
+                    when (activeRewardUsage) {
+                        RewardUsage.BulkDownload -> onClickAllDownload.invoke(creatorDetail.creatorId)
+                        RewardUsage.CreatorSearch -> onClickSearch.invoke(creatorDetail.creatorId)
+                        RewardUsage.CreatorTranslation -> onClickTranslateDescription.invoke(creatorDetail.description)
+                    }
+
+                    rewardUsage = null
+                }
             },
             onClickShowPlus = {
-                onClickBillingPlus.invoke("all_download")
-                isShowRewardAdDialog = false
+                onClickBillingPlus.invoke(activeRewardUsage.billingPlusKey())
+                rewardUsage = null
+
+                if (activeRewardUsage == RewardUsage.CreatorTranslation) {
+                    isShowDescriptionDialog = false
+                }
             },
-            onDismissRequest = { isShowRewardAdDialog = false },
+            onDismissRequest = { rewardUsage = null },
         )
     }
 
@@ -489,8 +519,7 @@ private fun CreatorTopScreen(
                 if (setting.hasPrivilege) {
                     onClickTranslateDescription.invoke(it)
                 } else {
-                    onClickBillingPlus.invoke("translate")
-                    isShowDescriptionDialog = false
+                    rewardUsage = RewardUsage.CreatorTranslation
                 }
             },
             onDismissRequest = { isShowDescriptionDialog = false },
@@ -556,4 +585,32 @@ private fun RevealOverlayScope.RevealOverlayContent(
 private enum class CreatorTab(val titleRes: StringResource) {
     POSTS(Res.string.creator_tab_posts),
     PLANS(Res.string.creator_tab_plans),
+}
+
+@Composable
+private fun RewardUsage.rewardUnlockTitle(): String {
+    return stringResource(
+        when (this) {
+            RewardUsage.BulkDownload -> Res.string.creator_download_require_plus_title
+            RewardUsage.CreatorSearch -> Res.string.creator_reward_unlock_search_title
+            RewardUsage.CreatorTranslation -> Res.string.creator_reward_unlock_translation_title
+        },
+    )
+}
+
+@Composable
+private fun RewardUsage.rewardUnlockMessage(): String {
+    return stringResource(
+        Res.string.creator_reward_unlock_require_plus_message,
+        rewardUnlockTitle(),
+        appName,
+    )
+}
+
+private fun RewardUsage.billingPlusKey(): String {
+    return when (this) {
+        RewardUsage.BulkDownload -> "all_download"
+        RewardUsage.CreatorSearch -> "search_post_by_creator"
+        RewardUsage.CreatorTranslation -> "translate"
+    }
 }

--- a/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/top/CreatorTopViewModel.kt
+++ b/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/top/CreatorTopViewModel.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.launch
 import me.matsumo.fanbox.core.common.util.suspendRunCatching
 import me.matsumo.fanbox.core.model.Destination
 import me.matsumo.fanbox.core.model.Flag
+import me.matsumo.fanbox.core.model.RewardUsage
 import me.matsumo.fanbox.core.model.ScreenState
 import me.matsumo.fanbox.core.model.Setting
 import me.matsumo.fanbox.core.model.TranslationState
@@ -84,7 +85,7 @@ class CreatorTopViewModel(
                     setting = userData,
                     bookmarkedPostsIds = fanboxRepository.bookmarkedPostsIds.first(),
                     isBlocked = fanboxRepository.blockedCreators.first().contains(creatorId),
-                    isAbleToReward = rewardRepository.isAbleToReward(),
+                    rewardAvailability = getRewardAvailability(),
                     shouldShowReveal = flagRepository.getFlag(Flag.REVEAL_CREATOR_TOP, true),
                     creatorDetail = fanboxRepository.getCreatorDetail(creatorId),
                     creatorPlans = fanboxRepository.getCreatorPlans(creatorId),
@@ -182,9 +183,36 @@ class CreatorTopViewModel(
         }
     }
 
-    fun rewarded() {
-        viewModelScope.launch {
-            rewardRepository.rewarded()
+    suspend fun rewarded(usage: RewardUsage) {
+        rewardRepository.rewarded(usage)
+        val rewardAvailability = getRewardAvailability()
+
+        _screenState.updateWhenIdle {
+            it.copy(rewardAvailability = rewardAvailability)
+        }
+    }
+
+    private suspend fun getRewardAvailability(): CreatorTopRewardAvailability {
+        return CreatorTopRewardAvailability(
+            bulkDownload = rewardRepository.isAbleToReward(RewardUsage.BulkDownload),
+            creatorSearch = rewardRepository.isAbleToReward(RewardUsage.CreatorSearch),
+            creatorTranslation = rewardRepository.isAbleToReward(RewardUsage.CreatorTranslation),
+        )
+    }
+}
+
+/** Creator Top の用途別リワード広告利用可否。 */
+@Stable
+data class CreatorTopRewardAvailability(
+    val bulkDownload: Boolean,
+    val creatorSearch: Boolean,
+    val creatorTranslation: Boolean,
+) {
+    fun isAbleToReward(usage: RewardUsage): Boolean {
+        return when (usage) {
+            RewardUsage.BulkDownload -> bulkDownload
+            RewardUsage.CreatorSearch -> creatorSearch
+            RewardUsage.CreatorTranslation -> creatorTranslation
         }
     }
 }
@@ -198,7 +226,7 @@ data class CreatorTopUiState(
     val creatorTags: List<FanboxTag>,
     val creatorPostsPaging: Flow<PagingData<FanboxPost>>,
     val isBlocked: Boolean,
-    val isAbleToReward: Boolean,
+    val rewardAvailability: CreatorTopRewardAvailability,
     val shouldShowReveal: Boolean,
     val descriptionTransState: TranslationState<String> = TranslationState.None,
 )

--- a/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/top/CreatorTopViewModel.kt
+++ b/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/top/CreatorTopViewModel.kt
@@ -1,5 +1,6 @@
 package me.matsumo.fanbox.feature.creator.top
 
+import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.Stable
 import androidx.compose.ui.text.intl.Locale
 import androidx.lifecycle.SavedStateHandle
@@ -183,12 +184,16 @@ class CreatorTopViewModel(
         }
     }
 
-    suspend fun rewarded(usage: RewardUsage) {
-        rewardRepository.rewarded(usage)
-        val rewardAvailability = getRewardAvailability()
+    fun rewarded(usage: RewardUsage) {
+        viewModelScope.launch {
+            val rewardAvailability = suspendRunCatching {
+                rewardRepository.rewarded(usage)
+                getRewardAvailability()
+            }.getOrNull() ?: return@launch
 
-        _screenState.updateWhenIdle {
-            it.copy(rewardAvailability = rewardAvailability)
+            _screenState.updateWhenIdle {
+                it.copy(rewardAvailability = rewardAvailability)
+            }
         }
     }
 
@@ -202,7 +207,7 @@ class CreatorTopViewModel(
 }
 
 /** Creator Top の用途別リワード広告利用可否。 */
-@Stable
+@Immutable
 data class CreatorTopRewardAvailability(
     val bulkDownload: Boolean,
     val creatorSearch: Boolean,

--- a/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/top/items/CreatorTopRewardAdDialog.kt
+++ b/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/top/items/CreatorTopRewardAdDialog.kt
@@ -4,6 +4,8 @@ import androidx.compose.runtime.Composable
 
 @Composable
 expect fun CreatorTopRewardAdDialog(
+    title: String,
+    message: String,
     isAbleToReward: Boolean,
     onRewarded: () -> Unit,
     onClickShowPlus: () -> Unit,

--- a/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/top/items/CreatorTopRewardAdPreloader.kt
+++ b/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/top/items/CreatorTopRewardAdPreloader.kt
@@ -1,0 +1,6 @@
+package me.matsumo.fanbox.feature.creator.top.items
+
+import androidx.compose.runtime.Composable
+
+@Composable
+expect fun CreatorTopRewardAdPreloader(shouldPreload: Boolean)

--- a/feature/creator/src/iosMain/kotlin/me/matsumo/fanbox/feature/creator/top/items/CreatorTopRewardAdDialog.ios.kt
+++ b/feature/creator/src/iosMain/kotlin/me/matsumo/fanbox/feature/creator/top/items/CreatorTopRewardAdDialog.ios.kt
@@ -4,6 +4,8 @@ import androidx.compose.runtime.Composable
 
 @Composable
 actual fun CreatorTopRewardAdDialog(
+    title: String,
+    message: String,
     isAbleToReward: Boolean,
     onRewarded: () -> Unit,
     onClickShowPlus: () -> Unit,

--- a/feature/creator/src/iosMain/kotlin/me/matsumo/fanbox/feature/creator/top/items/CreatorTopRewardAdPreloader.ios.kt
+++ b/feature/creator/src/iosMain/kotlin/me/matsumo/fanbox/feature/creator/top/items/CreatorTopRewardAdPreloader.ios.kt
@@ -1,0 +1,6 @@
+package me.matsumo.fanbox.feature.creator.top.items
+
+import androidx.compose.runtime.Composable
+
+@Composable
+actual fun CreatorTopRewardAdPreloader(shouldPreload: Boolean) = Unit


### PR DESCRIPTION
## 関連 Issue

- Closes #84

## 実装目的

リワード広告の表示機会を増やすため、事前ロードと Creator Top 内の Plus ロック機能への reward unlock 導線を追加します。

## 実装内容

- reward usage を bulk download / creator search / translation の用途別 daily count に変更
- Creator Top 到達時の Android reward ad preload を追加
- 非 Plus ユーザー向けに creator posts search / description translation / bulk download の reward unlock 導線を追加
- Activity 再生成後も pending reward usage を復元できるようにし、reward result 消費と対象 action 実行を維持
- reward unlock dialog の機能名文言を title と分離し、未使用 string を削除
- reward count 記録を ViewModel scope に寄せ、DataStore 例外が reward action 実行を止めないように変更
- legacy rewarded count key の削除と reward date 生成元の Repository 集約を追加
- 既存の Plus ユーザー向け direct path と iOS の Plus fallback を維持
- 用途別 reward count / 日付 rollover / pending usage restore の host test を追加

## 検証

### エージェント検証済み

- [x] `rtk ./gradlew :core:ui:compileAndroidMain :feature:creator:compileAndroidMain :core:repository:compileKotlinMetadata :feature:creator:compileKotlinMetadata :core:ui:testAndroidHostTest :core:datastore:testAndroidHostTest :core:repository:testAndroidHostTest :feature:creator:testAndroidHostTest detekt --no-configuration-cache`（HEAD: 4f9e21fb）
- [x] `git diff --check`（HEAD: 4f9e21fb）

### 人間に確認してほしいこと

- [ ] 実機で、非 Plus ユーザーとして bulk download / creator search / translation の reward unlock 導線が表示・視聴・dismiss 後に 1 回だけ対象 action を実行すること
- [ ] 実 AdMob SDK runtime で preload 済み ad が dialog 表示時に使われること
- [ ] 実機で、広告表示中の Activity 再生成後も reward result が消費され、対象 action が 1 回だけ実行されること

## ドキュメント影響

なし（README grep 済み、docs/ なし）

## メモ

- iOS は reward ad 非対応のため、既存どおり Plus 誘導 fallback を維持しています。
- エージェントは実機検証、adb、logcat、device install/launch、monkey を実施していません。
