### PR TITLE
fix: register billing plan nav type on iOS

### DIFF
--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -50,6 +50,10 @@ kotlin {
             }
         }
 
+        commonTest.dependencies {
+            implementation(kotlin("test"))
+        }
+
         val androidHostTest by getting {
             dependencies {
                 implementation(kotlin("test-junit"))

--- a/core/ui/src/commonMain/kotlin/me/matsumo/fanbox/core/ui/NavTypes.kt
+++ b/core/ui/src/commonMain/kotlin/me/matsumo/fanbox/core/ui/NavTypes.kt
@@ -5,6 +5,7 @@ import androidx.savedstate.SavedState
 import androidx.savedstate.read
 import androidx.savedstate.write
 import kotlinx.serialization.json.Json
+import me.matsumo.fanbox.core.model.BillingPlan
 import me.matsumo.fanbox.core.model.Destination
 import me.matsumo.fanbox.core.model.SimpleAlertContents
 import me.matsumo.fankt.fanbox.domain.model.id.FanboxCreatorId
@@ -31,11 +32,18 @@ val postDetailPagingTypeNavType = provideNavType<Destination.PostDetail.PagingTy
     decode = { Destination.PostDetail.PagingType.valueOf(it) },
 )
 
+val billingPlanTypeNavType = provideNavType<BillingPlan.Type>(
+    encode = { it.name },
+    decode = { BillingPlan.Type.valueOf(it) },
+    isNullableAllowed = true,
+)
+
 val customNavTypes = mapOf(
     typeOf<FanboxPostId>() to PostIdNavType,
     typeOf<FanboxCreatorId>() to creatorIdNavType,
     typeOf<SimpleAlertContents>() to simpleAlertContentsNavType,
     typeOf<Destination.PostDetail.PagingType>() to postDetailPagingTypeNavType,
+    typeOf<BillingPlan.Type?>() to billingPlanTypeNavType,
 )
 
 private inline fun <reified T> provideNavType(

--- a/core/ui/src/commonMain/kotlin/me/matsumo/fanbox/core/ui/NavTypes.kt
+++ b/core/ui/src/commonMain/kotlin/me/matsumo/fanbox/core/ui/NavTypes.kt
@@ -32,9 +32,9 @@ val postDetailPagingTypeNavType = provideNavType<Destination.PostDetail.PagingTy
     decode = { Destination.PostDetail.PagingType.valueOf(it) },
 )
 
-val billingPlanTypeNavType = provideNavType<BillingPlan.Type>(
-    encode = { it.name },
-    decode = { BillingPlan.Type.valueOf(it) },
+val billingPlanTypeNavType = provideNavType<BillingPlan.Type?>(
+    encode = { it?.name ?: "null" },
+    decode = { if (it == "null") null else BillingPlan.Type.valueOf(it) },
     isNullableAllowed = true,
 )
 

--- a/core/ui/src/commonMain/kotlin/me/matsumo/fanbox/core/ui/component/sheet/BottomSheetNavGraphBuilder.kt
+++ b/core/ui/src/commonMain/kotlin/me/matsumo/fanbox/core/ui/component/sheet/BottomSheetNavGraphBuilder.kt
@@ -49,6 +49,7 @@ fun NavGraphBuilder.bottomSheet(
 }
 
 inline fun <reified T : Any> NavGraphBuilder.bottomSheet(
+    typeMap: Map<KType, @JvmSuppressWildcards NavType<*>> = emptyMap(),
     deepLinks: List<NavDeepLink> = emptyList(),
     noinline onDismissed: (NavBackStackEntry) -> Unit = {},
     noinline content: @Composable ColumnScope.(backstackEntry: NavBackStackEntry) -> Unit,
@@ -57,7 +58,7 @@ inline fun <reified T : Any> NavGraphBuilder.bottomSheet(
         BottomSheetNavigatorDestinationBuilder(
             navigator = provider[BottomSheetNavigator::class],
             route = T::class,
-            typeMap = emptyMap(),
+            typeMap = typeMap,
             content = content,
             onDismissed = onDismissed,
         )

--- a/core/ui/src/commonTest/kotlin/me/matsumo/fanbox/core/ui/NavTypesTest.kt
+++ b/core/ui/src/commonTest/kotlin/me/matsumo/fanbox/core/ui/NavTypesTest.kt
@@ -1,0 +1,57 @@
+package me.matsumo.fanbox.core.ui
+
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.ModalBottomSheetState
+import androidx.compose.material.ModalBottomSheetValue
+import androidx.compose.ui.unit.Density
+import androidx.navigation.NavType
+import me.matsumo.fanbox.core.model.BillingPlan
+import me.matsumo.fanbox.core.model.Destination
+import me.matsumo.fanbox.core.ui.component.sheet.BottomSheetNavigator
+import me.matsumo.fanbox.core.ui.component.sheet.BottomSheetNavigatorDestinationBuilder
+import kotlin.reflect.typeOf
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/** Navigation で使用するカスタム型の変換を検証するテスト。 */
+class NavTypesTest {
+
+    @Test
+    fun customNavTypesContainsNullableBillingPlanType() {
+        val navType = assertNotNull(customNavTypes[typeOf<BillingPlan.Type?>()])
+
+        assertTrue(navType.isNullableAllowed)
+    }
+
+    @Test
+    fun billingPlanTypeNavTypeRoundTripsAllValues() {
+        @Suppress("UNCHECKED_CAST")
+        val navType = assertNotNull(customNavTypes[typeOf<BillingPlan.Type?>()]) as NavType<BillingPlan.Type>
+
+        BillingPlan.Type.entries.forEach { planType ->
+            val serializedValue = navType.serializeAsValue(planType)
+
+            assertEquals(planType, navType.parseValue(serializedValue))
+        }
+    }
+
+    @OptIn(ExperimentalMaterialApi::class)
+    @Test
+    fun billingPlusBottomSheetDestinationAcceptsNullableBillingPlanType() {
+        val sheetState = ModalBottomSheetState(
+            initialValue = ModalBottomSheetValue.Hidden,
+            density = Density(1f),
+        )
+        val navigator = BottomSheetNavigator(sheetState)
+
+        BottomSheetNavigatorDestinationBuilder(
+            navigator = navigator,
+            route = Destination.BillingPlusBottomSheet::class,
+            typeMap = customNavTypes,
+            content = {},
+            onDismissed = {},
+        ).build()
+    }
+}

--- a/core/ui/src/commonTest/kotlin/me/matsumo/fanbox/core/ui/NavTypesTest.kt
+++ b/core/ui/src/commonTest/kotlin/me/matsumo/fanbox/core/ui/NavTypesTest.kt
@@ -5,6 +5,10 @@ import androidx.compose.material.ModalBottomSheetState
 import androidx.compose.material.ModalBottomSheetValue
 import androidx.compose.ui.unit.Density
 import androidx.navigation.NavType
+import androidx.navigation.serialization.generateRouteWithArgs
+import androidx.savedstate.SavedState
+import androidx.savedstate.read
+import androidx.savedstate.write
 import me.matsumo.fanbox.core.model.BillingPlan
 import me.matsumo.fanbox.core.model.Destination
 import me.matsumo.fanbox.core.ui.component.sheet.BottomSheetNavigator
@@ -18,6 +22,25 @@ import kotlin.test.assertTrue
 /** Navigation で使用するカスタム型の変換を検証するテスト。 */
 class NavTypesTest {
 
+    private val referrerNavType = object : NavType<String>(isNullableAllowed = false) {
+
+        override fun get(bundle: SavedState, key: String): String? {
+            return bundle.read { getStringOrNull(key) }
+        }
+
+        override fun parseValue(value: String): String {
+            return value
+        }
+
+        override fun put(bundle: SavedState, key: String, value: String) {
+            bundle.write { putString(key, value) }
+        }
+
+        override fun serializeAsValue(value: String): String {
+            return value
+        }
+    }
+
     @Test
     fun customNavTypesContainsNullableBillingPlanType() {
         val navType = assertNotNull(customNavTypes[typeOf<BillingPlan.Type?>()])
@@ -28,13 +51,43 @@ class NavTypesTest {
     @Test
     fun billingPlanTypeNavTypeRoundTripsAllValues() {
         @Suppress("UNCHECKED_CAST")
-        val navType = assertNotNull(customNavTypes[typeOf<BillingPlan.Type?>()]) as NavType<BillingPlan.Type>
+        val navType = assertNotNull(customNavTypes[typeOf<BillingPlan.Type?>()]) as NavType<BillingPlan.Type?>
 
         BillingPlan.Type.entries.forEach { planType ->
             val serializedValue = navType.serializeAsValue(planType)
 
             assertEquals(planType, navType.parseValue(serializedValue))
         }
+    }
+
+    @Test
+    fun billingPlanTypeNavTypeRoundTripsNull() {
+        @Suppress("UNCHECKED_CAST")
+        val navType = assertNotNull(customNavTypes[typeOf<BillingPlan.Type?>()]) as NavType<BillingPlan.Type?>
+
+        assertEquals("null", navType.serializeAsValue(null))
+        assertEquals(null, navType.parseValue("null"))
+    }
+
+    @Test
+    fun billingPlusBottomSheetRouteAcceptsDefaultPlanType() {
+        val route = generateBillingPlusBottomSheetRoute(
+            Destination.BillingPlusBottomSheet(referrer = "drawer"),
+        )
+
+        assertTrue(route.endsWith("/drawer?initialPlanType=null"))
+    }
+
+    @Test
+    fun billingPlusBottomSheetRouteAcceptsAnnualPlanType() {
+        val route = generateBillingPlusBottomSheetRoute(
+            Destination.BillingPlusBottomSheet(
+                referrer = "retention",
+                initialPlanType = BillingPlan.Type.ANNUAL,
+            ),
+        )
+
+        assertTrue(route.endsWith("/retention?initialPlanType=ANNUAL"))
     }
 
     @OptIn(ExperimentalMaterialApi::class)
@@ -53,5 +106,15 @@ class NavTypesTest {
             content = {},
             onDismissed = {},
         ).build()
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun generateBillingPlusBottomSheetRoute(route: Destination.BillingPlusBottomSheet): String {
+        val typeMap = mapOf(
+            "referrer" to referrerNavType as NavType<Any?>,
+            "initialPlanType" to billingPlanTypeNavType as NavType<Any?>,
+        )
+
+        return generateRouteWithArgs(route, typeMap)
     }
 }

--- a/feature/about/src/commonMain/kotlin/me/matsumo/fanbox/feature/about/billing/BillingNavigation.kt
+++ b/feature/about/src/commonMain/kotlin/me/matsumo/fanbox/feature/about/billing/BillingNavigation.kt
@@ -10,12 +10,15 @@ import me.matsumo.fanbox.core.logs.category.BillingLog
 import me.matsumo.fanbox.core.logs.logger.send
 import me.matsumo.fanbox.core.model.Destination
 import me.matsumo.fanbox.core.ui.component.sheet.bottomSheet
+import me.matsumo.fanbox.core.ui.customNavTypes
 
 @OptIn(ExperimentalComposeUiApi::class)
 fun NavGraphBuilder.billingPlusBottomSheet(
     terminate: () -> Unit,
 ) {
-    bottomSheet<Destination.BillingPlusBottomSheet> { entry ->
+    bottomSheet<Destination.BillingPlusBottomSheet>(
+        typeMap = customNavTypes,
+    ) { entry ->
         val args = entry.toRoute<Destination.BillingPlusBottomSheet>()
 
         BackHandler {


### PR DESCRIPTION
## 概要

PR #97 のリテンション導線追加後、iOS で `Destination.BillingPlusBottomSheet` の NavGraph 構築時に発生する起動クラッシュを修正します。

## 原因

`initialPlanType` を `BillingPlan.Type?` に型安全化しましたが、Navigation 2.9.2 の non-Android 実装は nullable enum の `NavType` を自動解決しません。また、独自の `bottomSheet<T>` DSL が destination builder へ常に空の `typeMap` を渡していました。

加えて、nullable 対応のカスタム `NavType` は、Navigation が null を文字列 `"null"` として扱う規約に合わせて null を encode / decode する必要があります。

## 変更内容

- `BillingPlan.Type?` 用の nullable 対応 `NavType` を `customNavTypes` に登録
- null と `"null"` を相互変換する codec を実装
- 独自 `bottomSheet<T>` DSL に `typeMap` 引数を追加し、destination builder へ伝播
- Billing Plus BottomSheet で `customNavTypes` を指定
- enum 全値と null の round-trip、null / ANNUAL の実 route 生成、BottomSheet destination builder 構築の回帰テストを追加

## 検証

- `./gradlew :core:ui:testAndroidHostTest :core:ui:detekt --console=plain`
- `./gradlew :core:ui:iosSimulatorArm64Test --console=plain`

Android host test に加え、iOS 18.6 / iPhone 16 Pro Simulator で commonTest の実行成功を確認しています。

ドキュメント影響: なし