### PR TITLE
Normalize legacy bookmark ID JSON for fankt 0.1.0

### DIFF
--- a/core/datastore/src/androidHostTest/kotlin/me/matsumo/fanbox/core/datastore/BookmarkJsonMigrationTest.kt
+++ b/core/datastore/src/androidHostTest/kotlin/me/matsumo/fanbox/core/datastore/BookmarkJsonMigrationTest.kt
@@ -1,7 +1,6 @@
 package me.matsumo.fanbox.core.datastore
 
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -58,11 +57,7 @@ class BookmarkJsonMigrationTest {
         val result = normalizeBookmarkIdJson(legacyJson)
 
         assertIs<BookmarkJsonNormalization.Migrated>(result)
-
-        val migrated = Json.parseToJsonElement(result.json).jsonObject
-        val current = Json.parseToJsonElement(currentJson).jsonObject
-
-        assertEquals(current, JsonObject(migrated.filterKeys { it != "uniqueValue" }))
+        assertEquals(currentJson, result.json)
     }
 
     @Test
@@ -234,6 +229,24 @@ class BookmarkJsonMigrationTest {
             BookmarkJsonNormalization.Failure,
             normalizeBookmarkIdJson("""{"id":"1","user":{"userId":{"other":1},"name":"n"}}"""),
         )
+    }
+
+    @Test
+    fun malformedCreatorIdFails() {
+        assertEquals(
+            BookmarkJsonNormalization.Failure,
+            normalizeBookmarkIdJson("""{"id":"1","user":{"creatorId":{"other":1},"name":"n"}}"""),
+        )
+    }
+
+    @Test
+    fun idObjectWithNullValueUnwrapsToNull() {
+        val result = normalizeBookmarkIdJson("""{"id":{"value":null}}""")
+
+        assertIs<BookmarkJsonNormalization.Migrated>(result)
+
+        val id = Json.parseToJsonElement(result.json).jsonObject.getValue("id")
+        assertTrue(id is kotlinx.serialization.json.JsonNull)
     }
 
     @Test

--- a/core/datastore/src/androidHostTest/kotlin/me/matsumo/fanbox/core/datastore/BookmarkJsonMigrationTest.kt
+++ b/core/datastore/src/androidHostTest/kotlin/me/matsumo/fanbox/core/datastore/BookmarkJsonMigrationTest.kt
@@ -1,0 +1,248 @@
+package me.matsumo.fanbox.core.datastore
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * 保存済みブックマーク JSON の ID 正規化を検証するテスト。
+ *
+ * fixture は fankt v0.0.21 と 0.1.0 でそれぞれ実際に `Json.encodeToString` を実行して得た出力に基づく。
+ */
+class BookmarkJsonMigrationTest {
+
+    private val legacyJson = """
+        {"id":{"value":"1234567","uniqueValue":"post-1234567-fe1d64ca-0564-4001-a9a0-c7aa2a084aca"},"title":"sample title","cover":{"url":"https://example.com/cover.jpg","type":"cover_image"},"user":{"userId":{"value":999},"creatorId":{"value":"creator-abc"},"name":"sample user","iconUrl":"https://example.com/icon.jpg"},"excerpt":"sample excerpt","feeRequired":500,"hasAdultContent":true,"isLiked":false,"isRestricted":false,"likeCount":12,"commentCount":3,"tags":["tagA","tagB"],"publishedDatetime":"2026-01-02T03:04:05Z","updatedDatetime":"2026-01-03T04:05:06Z"}
+    """.trimIndent()
+
+    private val currentJson = """
+        {"id":"1234567","title":"sample title","cover":{"url":"https://example.com/cover.jpg","type":"cover_image"},"user":{"userId":999,"creatorId":"creator-abc","name":"sample user","iconUrl":"https://example.com/icon.jpg"},"excerpt":"sample excerpt","feeRequired":500,"hasAdultContent":true,"isLiked":false,"isRestricted":false,"likeCount":12,"commentCount":3,"tags":["tagA","tagB"],"publishedDatetime":"2026-01-02T03:04:05Z","updatedDatetime":"2026-01-03T04:05:06Z"}
+    """.trimIndent()
+
+    @Test
+    fun legacyJsonUnwrapsAllThreeIds() {
+        val result = normalizeBookmarkIdJson(legacyJson)
+
+        assertIs<BookmarkJsonNormalization.Migrated>(result)
+
+        val root = Json.parseToJsonElement(result.json).jsonObject
+        assertEquals("1234567", root.getValue("id").jsonPrimitive.content)
+
+        val user = root.getValue("user").jsonObject
+        assertEquals(999L, user.getValue("userId").jsonPrimitive.content.toLong())
+        assertEquals("creator-abc", user.getValue("creatorId").jsonPrimitive.content)
+    }
+
+    @Test
+    fun legacyUserIdKeepsNumericType() {
+        val result = normalizeBookmarkIdJson(legacyJson)
+
+        assertIs<BookmarkJsonNormalization.Migrated>(result)
+
+        val userId = Json.parseToJsonElement(result.json).jsonObject
+            .getValue("user").jsonObject
+            .getValue("userId")
+
+        assertTrue((userId as JsonPrimitive).isString.not())
+    }
+
+    @Test
+    fun legacyJsonBecomesByteIdenticalToCurrentFormat() {
+        val result = normalizeBookmarkIdJson(legacyJson)
+
+        assertIs<BookmarkJsonNormalization.Migrated>(result)
+
+        val migrated = Json.parseToJsonElement(result.json).jsonObject
+        val current = Json.parseToJsonElement(currentJson).jsonObject
+
+        assertEquals(current, JsonObject(migrated.filterKeys { it != "uniqueValue" }))
+    }
+
+    @Test
+    fun currentJsonIsReportedAsAlreadyCurrent() {
+        val result = normalizeBookmarkIdJson(currentJson)
+
+        assertIs<BookmarkJsonNormalization.AlreadyCurrent>(result)
+        assertEquals(currentJson, result.json)
+    }
+
+    @Test
+    fun nullUserIsPreserved() {
+        val json = """{"id":{"value":"1"},"title":"t","cover":null,"user":null,"tags":[]}"""
+
+        val result = normalizeBookmarkIdJson(json)
+
+        assertIs<BookmarkJsonNormalization.Migrated>(result)
+
+        val root = Json.parseToJsonElement(result.json).jsonObject
+        assertEquals("1", root.getValue("id").jsonPrimitive.content)
+        assertTrue(root.getValue("user") is kotlinx.serialization.json.JsonNull)
+    }
+
+    @Test
+    fun nullIdsInsideUserArePreserved() {
+        val json = """{"id":{"value":"1"},"user":{"userId":null,"creatorId":null,"name":"n","iconUrl":null}}"""
+
+        val result = normalizeBookmarkIdJson(json)
+
+        assertIs<BookmarkJsonNormalization.Migrated>(result)
+
+        val user = Json.parseToJsonElement(result.json).jsonObject.getValue("user").jsonObject
+        assertTrue(user.getValue("userId") is kotlinx.serialization.json.JsonNull)
+        assertTrue(user.getValue("creatorId") is kotlinx.serialization.json.JsonNull)
+        assertEquals("n", user.getValue("name").jsonPrimitive.content)
+    }
+
+    @Test
+    fun nullUserIdWithLegacyCreatorIdIsMigrated() {
+        val json = """{"id":"1","user":{"userId":null,"creatorId":{"value":"creator"},"name":"n"}}"""
+
+        val result = normalizeBookmarkIdJson(json)
+
+        assertIs<BookmarkJsonNormalization.Migrated>(result)
+
+        val user = Json.parseToJsonElement(result.json).jsonObject.getValue("user").jsonObject
+        assertTrue(user.getValue("userId") is kotlinx.serialization.json.JsonNull)
+        assertEquals("creator", user.getValue("creatorId").jsonPrimitive.content)
+    }
+
+    @Test
+    fun legacyUserIdWithNullCreatorIdIsMigrated() {
+        val json = """{"id":"1","user":{"userId":{"value":999},"creatorId":null,"name":"n"}}"""
+
+        val result = normalizeBookmarkIdJson(json)
+
+        assertIs<BookmarkJsonNormalization.Migrated>(result)
+
+        val user = Json.parseToJsonElement(result.json).jsonObject.getValue("user").jsonObject
+        assertEquals(999L, user.getValue("userId").jsonPrimitive.content.toLong())
+        assertTrue(user.getValue("creatorId") is kotlinx.serialization.json.JsonNull)
+    }
+
+    @Test
+    fun nullUserWithCurrentRootIdIsAlreadyCurrent() {
+        val json = """{"id":"1","user":null}"""
+
+        val result = normalizeBookmarkIdJson(json)
+
+        assertIs<BookmarkJsonNormalization.AlreadyCurrent>(result)
+        assertEquals(json, result.json)
+    }
+
+    @Test
+    fun mixedFormatIsMigratedPerField() {
+        val json = """{"id":"1","user":{"userId":{"value":999},"creatorId":"creator","name":"n"}}"""
+
+        val result = normalizeBookmarkIdJson(json)
+
+        assertIs<BookmarkJsonNormalization.Migrated>(result)
+
+        val root = Json.parseToJsonElement(result.json).jsonObject
+        assertEquals("1", root.getValue("id").jsonPrimitive.content)
+
+        val user = root.getValue("user").jsonObject
+        assertEquals(999L, user.getValue("userId").jsonPrimitive.content.toLong())
+        assertEquals("creator", user.getValue("creatorId").jsonPrimitive.content)
+    }
+
+    @Test
+    fun missingUserKeyIsNotAdded() {
+        val json = """{"id":{"value":"1"},"title":"t"}"""
+
+        val result = normalizeBookmarkIdJson(json)
+
+        assertIs<BookmarkJsonNormalization.Migrated>(result)
+
+        val root = Json.parseToJsonElement(result.json).jsonObject
+        assertTrue(!root.containsKey("user"))
+    }
+
+    @Test
+    fun missingIdKeyIsNotAdded() {
+        val json = """{"title":"t","user":{"userId":{"value":999},"name":"n"}}"""
+
+        val result = normalizeBookmarkIdJson(json)
+
+        assertIs<BookmarkJsonNormalization.Migrated>(result)
+
+        val root = Json.parseToJsonElement(result.json).jsonObject
+        assertTrue(!root.containsKey("id"))
+        assertEquals(999L, root.getValue("user").jsonObject.getValue("userId").jsonPrimitive.content.toLong())
+    }
+
+    @Test
+    fun unrelatedFieldsArePreserved() {
+        val result = normalizeBookmarkIdJson(legacyJson)
+
+        assertIs<BookmarkJsonNormalization.Migrated>(result)
+
+        val root = Json.parseToJsonElement(result.json).jsonObject
+        assertEquals("2026-01-02T03:04:05Z", root.getValue("publishedDatetime").jsonPrimitive.content)
+        assertEquals("2026-01-03T04:05:06Z", root.getValue("updatedDatetime").jsonPrimitive.content)
+        assertEquals(500, root.getValue("feeRequired").jsonPrimitive.content.toInt())
+        assertEquals(2, root.getValue("tags").let { it as kotlinx.serialization.json.JsonArray }.size)
+        assertEquals(
+            "https://example.com/cover.jpg",
+            root.getValue("cover").jsonObject.getValue("url").jsonPrimitive.content,
+        )
+    }
+
+    @Test
+    fun malformedJsonFails() {
+        assertEquals(BookmarkJsonNormalization.Failure, normalizeBookmarkIdJson("not json"))
+    }
+
+    @Test
+    fun nonObjectRootFails() {
+        assertEquals(BookmarkJsonNormalization.Failure, normalizeBookmarkIdJson("""["a"]"""))
+        assertEquals(BookmarkJsonNormalization.Failure, normalizeBookmarkIdJson(""""string""""))
+    }
+
+    @Test
+    fun idObjectWithoutValueFails() {
+        assertEquals(BookmarkJsonNormalization.Failure, normalizeBookmarkIdJson("""{"id":{"other":"1"}}"""))
+    }
+
+    @Test
+    fun idObjectWithNestedObjectValueFails() {
+        assertEquals(
+            BookmarkJsonNormalization.Failure,
+            normalizeBookmarkIdJson("""{"id":{"value":{"nested":"1"}}}"""),
+        )
+    }
+
+    @Test
+    fun idArrayFails() {
+        assertEquals(BookmarkJsonNormalization.Failure, normalizeBookmarkIdJson("""{"id":["1"]}"""))
+    }
+
+    @Test
+    fun nonObjectUserFails() {
+        assertEquals(BookmarkJsonNormalization.Failure, normalizeBookmarkIdJson("""{"id":"1","user":"u"}"""))
+    }
+
+    @Test
+    fun malformedIdInsideUserFails() {
+        assertEquals(
+            BookmarkJsonNormalization.Failure,
+            normalizeBookmarkIdJson("""{"id":"1","user":{"userId":{"other":1},"name":"n"}}"""),
+        )
+    }
+
+    @Test
+    fun migrateReturnsNullForMalformedJson() {
+        assertNull(migrateBookmarkJson("not json"))
+    }
+
+    @Test
+    fun migrateReturnsNullWhenRequiredFieldsAreMissing() {
+        assertNull(migrateBookmarkJson("""{"id":{"value":"1"}}"""))
+    }
+}

--- a/core/datastore/src/commonMain/kotlin/me/matsumo/fanbox/core/datastore/BookmarkJsonMigration.kt
+++ b/core/datastore/src/commonMain/kotlin/me/matsumo/fanbox/core/datastore/BookmarkJsonMigration.kt
@@ -46,8 +46,9 @@ internal sealed interface BookmarkJsonNormalization {
  * `"user":null` と `"userId":null` は正常な値としてそのまま保持する。フィールドの欠落も、null の
  * 補完はせず入力のまま残す。
  *
- * JSON object として解析できない入力、および ID が object でも primitive でも null でもない入力に
- * 対して [BookmarkJsonNormalization.Failure] を返す。
+ * JSON object として解析できない入力、ID が object でも primitive でも null でもない入力、および ID が
+ * `value` を持たない object か `value` が primitive でない object である入力に対して
+ * [BookmarkJsonNormalization.Failure] を返す。
  */
 internal fun normalizeBookmarkIdJson(json: String): BookmarkJsonNormalization {
     val root = runCatching { Json.parseToJsonElement(json) }.getOrNull() as? JsonObject
@@ -75,6 +76,8 @@ internal fun normalizeBookmarkIdJson(json: String): BookmarkJsonNormalization {
  * 正規化した要素と、入力から変化したかどうか。
  *
  * [element] が null のとき、その要素は入力に存在しなかったことを表す。呼び出し側はキーを追加しない。
+ * 存在しないキーが変換されることはないため、[element] が null なら [changed] は常に false である。
+ * 値が JSON の null である場合は [element] が [JsonNull] になり、Kotlin の null とは区別される。
  */
 private data class Normalized(val element: JsonElement?, val changed: Boolean)
 
@@ -111,8 +114,11 @@ private fun normalizeUser(user: JsonElement?): Normalized? {
  * 旧形式の `{"value": ...}` は内側の primitive へ展開する。既に primitive であるか [JsonNull] である
  * 場合、およびフィールド自体が存在しない場合は変換しない。
  *
- * それ以外の形（`value` を持たない object、`value` が primitive でない object、配列）に対して null を
- * 返す。
+ * [JsonNull] は [JsonPrimitive] のサブタイプであるため、`{"value":null}` は JSON の null へ展開される。
+ * 旧版の ID 型はいずれも `value` が非 nullable であり、この形は実データには現れない。
+ *
+ * それ以外の形（`value` を持たない object、`value` が object や配列である object、配列）に対して null
+ * を返す。
  */
 private fun normalizeId(id: JsonElement?): Normalized? {
     return when (id) {

--- a/core/datastore/src/commonMain/kotlin/me/matsumo/fanbox/core/datastore/BookmarkJsonMigration.kt
+++ b/core/datastore/src/commonMain/kotlin/me/matsumo/fanbox/core/datastore/BookmarkJsonMigration.kt
@@ -1,0 +1,145 @@
+package me.matsumo.fanbox.core.datastore
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import me.matsumo.fankt.fanbox.domain.model.FanboxPost
+
+/**
+ * 保存済みブックマークの JSON を、fankt 0.1.0 の serializer が読める形式へ正規化する。
+ *
+ * fankt 0.1.0 で ID 型が `data class` から `@JvmInline value class` へ変わったため、
+ * `FanboxPostId` / `FanboxUserId` / `FanboxCreatorId` の JSON 表現が object から primitive になった。
+ * 0.0.21 以前が書き込んだ JSON は 0.1.0 の serializer では読めず、`BookmarkDataStore.get()` は
+ * デコード失敗を握りつぶすため、変換しなければブックマークが黙って全件消える。
+ *
+ * 変換対象は `id` / `user.userId` / `user.creatorId` の 3 箇所に限られる。`FanboxPost` の他の
+ * フィールドは新旧で JSON 表現が変わらず、`publishedDatetime` / `updatedDatetime` はどちらも
+ * ISO-8601 文字列である。
+ */
+
+/** 正規化の結果。 */
+internal sealed interface BookmarkJsonNormalization {
+
+    /** 3 箇所とも既に primitive で、変換の必要がなかった。 */
+    data class AlreadyCurrent(val json: String) : BookmarkJsonNormalization
+
+    /** 1 箇所以上を primitive へ展開した。[json] は展開後の JSON。 */
+    data class Migrated(val json: String) : BookmarkJsonNormalization
+
+    /** JSON object として解析できないか、ID が想定外の形だった。 */
+    data object Failure : BookmarkJsonNormalization
+}
+
+/**
+ * 旧形式の ID を primitive へ展開する。
+ *
+ * 3 箇所の ID をそれぞれ独立に判定するため、一部だけが旧形式の JSON も正規化できる。
+ *
+ * この関数が保証するのは ID の shape だけで、[FanboxPost] として妥当かは判定しない。`FanboxPost` の
+ * 必須フィールドが欠けた JSON も、ID さえ正規化できれば成功する。妥当性の判定は
+ * [migrateBookmarkJson] が担う。
+ *
+ * `user` と `user` 配下の 2 つの ID はいずれも nullable で、既定の [Json] は null を明示的に書き出す。
+ * `"user":null` と `"userId":null` は正常な値としてそのまま保持する。フィールドの欠落も、null の
+ * 補完はせず入力のまま残す。
+ *
+ * JSON object として解析できない入力、および ID が object でも primitive でも null でもない入力に
+ * 対して [BookmarkJsonNormalization.Failure] を返す。
+ */
+internal fun normalizeBookmarkIdJson(json: String): BookmarkJsonNormalization {
+    val root = runCatching { Json.parseToJsonElement(json) }.getOrNull() as? JsonObject
+        ?: return BookmarkJsonNormalization.Failure
+
+    val id = normalizeId(root["id"]) ?: return BookmarkJsonNormalization.Failure
+    val user = normalizeUser(root["user"]) ?: return BookmarkJsonNormalization.Failure
+
+    if (!id.changed && !user.changed) {
+        return BookmarkJsonNormalization.AlreadyCurrent(json)
+    }
+
+    val normalized = JsonObject(
+        buildMap {
+            putAll(root)
+            id.element?.let { put("id", it) }
+            user.element?.let { put("user", it) }
+        },
+    )
+
+    return BookmarkJsonNormalization.Migrated(Json.encodeToString(JsonElement.serializer(), normalized))
+}
+
+/**
+ * 正規化した要素と、入力から変化したかどうか。
+ *
+ * [element] が null のとき、その要素は入力に存在しなかったことを表す。呼び出し側はキーを追加しない。
+ */
+private data class Normalized(val element: JsonElement?, val changed: Boolean)
+
+/**
+ * `user` を正規化する。`user` の欠落と [JsonNull] は変換せずそのまま扱う。
+ *
+ * `user` が object でも null でもない場合、および配下の ID を正規化できない場合に null を返す。
+ */
+private fun normalizeUser(user: JsonElement?): Normalized? {
+    if (user == null || user is JsonNull) return Normalized(user, changed = false)
+
+    val userObject = user as? JsonObject ?: return null
+    val userId = normalizeId(userObject["userId"]) ?: return null
+    val creatorId = normalizeId(userObject["creatorId"]) ?: return null
+
+    if (!userId.changed && !creatorId.changed) {
+        return Normalized(user, changed = false)
+    }
+
+    val normalized = JsonObject(
+        buildMap {
+            putAll(userObject)
+            userId.element?.let { put("userId", it) }
+            creatorId.element?.let { put("creatorId", it) }
+        },
+    )
+
+    return Normalized(normalized, changed = true)
+}
+
+/**
+ * 単一の ID を正規化する。
+ *
+ * 旧形式の `{"value": ...}` は内側の primitive へ展開する。既に primitive であるか [JsonNull] である
+ * 場合、およびフィールド自体が存在しない場合は変換しない。
+ *
+ * それ以外の形（`value` を持たない object、`value` が primitive でない object、配列）に対して null を
+ * 返す。
+ */
+private fun normalizeId(id: JsonElement?): Normalized? {
+    return when (id) {
+        null -> Normalized(null, changed = false)
+        is JsonNull -> Normalized(id, changed = false)
+        is JsonPrimitive -> Normalized(id, changed = false)
+        is JsonObject -> (id["value"] as? JsonPrimitive)?.let { Normalized(it, changed = true) }
+        else -> null
+    }
+}
+
+/**
+ * 保存済みの JSON を [FanboxPost] へ復元する。旧形式は新形式へ正規化してから復元する。
+ *
+ * 正規化できない JSON、および正規化しても [FanboxPost] として復元できない JSON に対して null を返す。
+ * 失敗したエントリの記録は呼び出し側が行う。
+ *
+ * fankt が 0.1.0 未満の間、この関数は正常な入力に対しても常に null を返す。0.0.21 の serializer は
+ * ID を object として読むため、正規化後の primitive を受け付けないためである。0.1.0 へ更新して初めて
+ * 意図した動作になる。
+ */
+internal fun migrateBookmarkJson(json: String): FanboxPost? {
+    val normalized = when (val normalization = normalizeBookmarkIdJson(json)) {
+        is BookmarkJsonNormalization.AlreadyCurrent -> normalization.json
+        is BookmarkJsonNormalization.Migrated -> normalization.json
+        BookmarkJsonNormalization.Failure -> return null
+    }
+
+    return runCatching { Json.decodeFromString(FanboxPost.serializer(), normalized) }.getOrNull()
+}


### PR DESCRIPTION
## 概要

fankt 0.1.0 が `FanboxPostId` / `FanboxUserId` / `FanboxCreatorId` を value class にしたことで、これらの JSON 表現が object から primitive へ変わった。0.0.21 以前が書き込んだブックマーク JSON は 0.1.0 の serializer では読めず、`BookmarkDataStore.get()` はデコード失敗を握りつぶすため、保存済みブックマークが黙って全件消える。

この PR は旧形式を新形式へ正規化する変換ロジックと、その単体テストを追加する。

Closes #117 の Step 0 部分（結線は別 PR）。

## スコープ

fankt は 0.0.21 のまま変更しない。`BookmarkDataStore` への結線も行わない。

追加した 2 つの関数は `internal` で、この PR 時点では呼び出し元が存在しない。fankt 0.0.21 の serializer は正規化後の primitive ID を読めないため、`migrateBookmarkJson` はあらゆる正常入力に対して null を返す。0.1.0 へ更新して初めて意図した動作になる。この制約は KDoc に明記した。

データ損失を防ぐ変更を fankt 0.1.0 追従の大きな PR（10 件以上の変更を含む）に混ぜるとレビューでも動作確認でも埋もれるため、最も壊れやすい変換ロジックだけを先に確定させる意図で分離した。

## 設計

OpenSpec は未導入のため、設計はこの description に直書きする。

### 変換対象

実測により、旧新で JSON 表現が変わるのは次の 3 箇所だけと確認した。

| フィールド | 旧 (0.0.21) | 新 (0.1.0) |
|---|---|---|
| `id` | `{"value":"1234567","uniqueValue":"post-1234567-<uuid>"}` | `"1234567"` |
| `user.userId` | `{"value":999}` | `999` |
| `user.creatorId` | `{"value":"creator-abc"}` | `"creator-abc"` |

`FanboxPost` の他のフィールドは新旧で変化がなく、`publishedDatetime` / `updatedDatetime` はどちらも ISO-8601 文字列である。

非互換の原因は `uniqueValue` の有無ではなく `data class` から `value class` への変更そのものである。`FanboxUserId` / `FanboxCreatorId` は `uniqueValue` を持たないが、`data class` である以上 object 形式でシリアライズされていた。

### 構成

2 層に分けている。

- `normalizeBookmarkIdJson(String): BookmarkJsonNormalization` — `JsonElement` レベルで ID を展開する。fankt の型に依存しないため、0.1.0 へ更新した後もテストが有効であり続ける
- `migrateBookmarkJson(String): FanboxPost?` — 正規化してから復元する

`BookmarkJsonNormalization` は `AlreadyCurrent` / `Migrated` / `Failure` を区別する。呼び出し側が「変換が起きたエントリだけ書き戻す」判断をするために必要である。`FanboxPost` だけを返す設計では、入力が旧形式だったかの情報が失われ、全件を毎回書き戻すことになる。`BookmarkDataStore.save()` は `notify()` を呼び、`notify()` は `get()` を呼ぶため、読み込みのたびに全件保存する実装は再帰的な呼び出しになる。

### 判定の粒度

3 箇所の ID をそれぞれ独立に判定する。root の `id` だけで「既に新形式」と判定すると、`id` が primitive で `user.userId` が object の混在 JSON を取り違え、0.1.0 でのデコードが nested ID で失敗する。

### null の扱い

`user` および `user` 配下の 2 つの ID はいずれも nullable で、既定の `Json` は `explicitNulls = true` のため null を明示的に書き出す。`"user":null` と `"userId":null` は正常なデータとして実際に出現するため、変換せずそのまま保持する。フィールドの欠落も null で補完せず入力のまま残す。

### 内部層の契約

`normalizeBookmarkIdJson` が保証するのは ID の shape だけで、`FanboxPost` として妥当かは判定しない。`FanboxPost` の必須フィールドが欠けた JSON も、ID さえ正規化できれば成功する。妥当性の判定は `migrateBookmarkJson` の責務である。fankt 非依存を保つために schema を複製しない選択である。

## 検証

最終 HEAD `3c5e38d` で実行した。

| コマンド | 結果 | scope |
|---|---|---|
| `./gradlew :core:datastore:testAndroidHostTest :core:datastore:detekt :core:datastore:compileAndroidHostTest --rerun-tasks` | BUILD SUCCESSFUL / 24 tests, 0 failures | `core:datastore` |

`./gradlew :core:datastore:detektAndroidMain`（type resolution 版）は `androidCompileClasspath` の variant ambiguity で失敗する。ただしこれはこの PR の変更を退避した clean な作業ツリーでも同じく再現するため、既存の環境問題であり、この変更に起因しない。CI が実行するのは type resolution なしの `detekt` タスクであり、そちらは成功する。

### テストの fixture

fixture は fankt v0.0.21 と現行 0.1.0 でそれぞれ実際に `Json.encodeToString` を実行して得た出力に基づく。理論上の想定ではなく実測値である。検証手順と生の出力は #117 のコメントに記録した。

### production call path

この PR は結線を含まないため、本番エントリポイントからの経路は存在しない。結線と実機での旧データ読み出し確認は fankt 0.1.0 へ更新する PR で行う。

## 人間に確認してほしいこと

### 設計判断（agent 仮決め）

- **失敗の記録先** — `Napier.e` によるログ出力は変換関数側ではなく結線側（`BookmarkDataStore`）で行う想定にした。変換関数自体は純粋に保っている。issue の受け入れ条件「変換できなかったエントリの件数が観測できる」は結線時に満たす
- **`BookmarkJsonNormalization` の粒度** — `Failure` に理由を持たせていない。呼び出し側が理由で分岐する要件が現時点で無いため

### 後続 PR での必須事項

fankt 0.1.0 へ更新する PR で次を行う必要がある。この PR だけではユーザーのブックマークは救われない。

- `BookmarkDataStore.get()` を `migrateBookmarkJson` 経由にする
- `Migrated` だったエントリのみ新形式で書き戻す。`save()` は `notify()` → `get()` を呼ぶため writeback には流用せず、DataStore を直接一括 `edit` する
- 変換に失敗した件数をログに残す
- 実測した旧形式 fixture が 0.1.0 で `FanboxPost` へ復元できることをテストする
- 旧バージョンで保存 → 新バージョンへ更新 → ブックマークが残ることを実機で確認する

## ドキュメント影響: なし

公開 API を追加していない（両関数とも `internal`）。ユーザー向けドキュメントに記載する挙動の変更もない。

