### PR TITLE
Stop storing pixiv OAuth cookies and logging cookie values

### DIFF
--- a/feature/welcome/src/commonMain/kotlin/me/matsumo/fanbox/feature/welcome/web/WelcomeWebScreen.kt
+++ b/feature/welcome/src/commonMain/kotlin/me/matsumo/fanbox/feature/welcome/web/WelcomeWebScreen.kt
@@ -63,8 +63,9 @@ internal fun WelcomeWebScreen(
     viewModel: WelcomeWebViewModel = koinViewModel(),
     snackExtension: ToastExtension = koinInject(),
 ) {
-    val fanboxUrl = "https://www.fanbox.cc/login"
-    val fanboxRedirectUrl = "https://www.fanbox.cc/creators/find"
+    val fanboxOrigin = "https://www.fanbox.cc"
+    val fanboxUrl = "$fanboxOrigin/login"
+    val fanboxRedirectUrl = "$fanboxOrigin/creators/find"
 
     val webViewState = rememberWebViewState("$fanboxUrl?return_to=$fanboxRedirectUrl")
     val scope = rememberCoroutineScope()
@@ -102,14 +103,17 @@ internal fun WelcomeWebScreen(
     }
 
     LaunchedEffect(webViewState.lastLoadedUrl) {
-        val oauthCookies = webViewState.cookieManager.getCookies("https://oauth.secure.pixiv.net")
-        val fanboxCookies = webViewState.cookieManager.getCookies("https://www.fanbox.cc")
+        // FANBOX オリジンの Cookie だけを保持する。ログインは oauth.secure.pixiv.net を経由するが、
+        // そのオリジンの Cookie は FANBOX のリクエストに不要であり、保存すると以降のすべての
+        // リクエストに送信され続ける。
+        val fanboxCookies = webViewState.cookieManager.getCookies(fanboxOrigin)
 
         currentCookies.clear()
-        currentCookies.addAll(fanboxCookies + oauthCookies)
+        currentCookies.addAll(fanboxCookies)
 
         if (webViewState.lastLoadedUrl == fanboxRedirectUrl) {
-            Napier.d { "try login. current url: ${webViewState.lastLoadedUrl}, cookies: $currentCookies" }
+            // Cookie の値は認証情報そのものであり、logcat に残すと他経路から読み取られうるため出力しない。
+            Napier.d { "try login. current url: ${webViewState.lastLoadedUrl}, cookies: ${currentCookies.map { it.name }}" }
             tryLogin()
         }
     }


### PR DESCRIPTION
## 概要

Web ログイン処理の 2 つのセキュリティ問題に対応する。fankt のバージョンには依存しない。

Closes #106

## スタック

この PR は #123 の上に積まれている。base は `agent/issue-117-bookmark-json-migration` である。

コード上の依存関係はない（#123 は bookmark JSON、この PR は Cookie 処理）。fankt 0.1.0 追従の前段作業という括りでスタックにしている。レビューは #123 → #124 の順で行うと差分が最小になる。

## 変更内容

### pixiv OAuth Cookie の保存をやめる

ログインは `oauth.secure.pixiv.net` を経由するが、そのオリジンの Cookie を FANBOX のものと結合して `fanboxRepository.setCookies()` へ渡していた。fankt の Cookie ストアはリクエスト URL とのマッチングを行わないため、FANBOX へのすべてのリクエストに pixiv の Cookie が送信され続けていた。

`getCookies("https://oauth.secure.pixiv.net")` の呼び出し自体を削除した。この Cookie は保存以外に使われておらず（`checkSessionId` も `saveCookies` を経由する）、保持する理由がない。取得しなければ、`currentCookies` を参照する他の経路にも流れない。

### Cookie 値のログ出力をやめる

ログイン成功時のログ行が FANBOXSESSID を含む全 Cookie を平文で出力していた。debug ビルドでは logcat に残り、バグレポート経由で端末外へ出うる。Cookie の名前のみを出力するよう変更した。

## 設計判断

### allowlist の粒度

name 単位ではなくオリジン単位で絞っている。`www.fanbox.cc` の Cookie はすべて渡す。

issue は「最低限 `FANBOXSESSID`。関連する `cf_clearance` 等 Cloudflare 系 Cookie が必要かは実機確認」としている。name 単位の allowlist を作ると、必要な Cookie を落としてログインが壊れるリスクがあり、その判定には実機確認が要る。オリジン単位であれば pixiv の Cookie を確実に排除しつつ、FANBOX が必要とする Cookie は取りこぼさない。

### 実装層

`WelcomeWebScreen` の取得段階で絞っている。`WelcomeWebViewModel.toKtorCookies()` でフィルタする案もあるが、そちらは fankt の Ktor-free 化（#112）で書き換える対象であり、手戻りが出る。取得段階に閉じておけば #112 と干渉しない。

## 検証

HEAD `fd2b19d` で実行した。

| コマンド | 結果 |
|---|---|
| `./gradlew :feature:welcome:compileAndroidMain :feature:welcome:detekt` | BUILD SUCCESSFUL |

### 自動テストがない理由

`feature/welcome` にテスト source set が存在せず、この PR でも追加していない。変更対象は WebView の実機挙動に依存する Composable で、`cookieManager.getCookies()` を差し替える土台がこの module にない。テスト基盤の新規構築はこの issue の範囲を超えるため行わなかった。

したがって受け入れ条件 3 件はいずれも実機確認でしか閉じられない。

## 人間に確認してほしいこと

### 実機確認が必要（受け入れ条件）

- [ ] ログイン後、fankt の Cookie ストアに pixiv.net ドメインの Cookie が入っていない
- [ ] logcat に FANBOXSESSID の値が出力されない
- [ ] Web ログイン → API 呼び出しが従来どおり成功する

3 番目が最も重要である。`cf_clearance` 等の Cloudflare 系 Cookie は `www.fanbox.cc` オリジンに属するため今回の変更では落ちないはずだが、実際にログインが通ることの確認が必要である。

### 範囲外として報告する問題

`WelcomeWebDialog` が Cookie の値を平文で UI に表示している。

- `WelcomeWebScreen.kt:180` が `currentCookies.map { "${it.name}=${it.value}" }` を渡す
- `WelcomeWebDialog.kt:90` が `"URL: $currentUrl\nCookies: $currentCookies"` として描画する

この PR の変更により表示対象から pixiv の Cookie は消えるが、FANBOXSESSID の値は依然として表示される。issue #106 の受け入れ条件には含まれず、ユーザーがヘルプから意図的に開くダイアログであり logcat とはリスクの性質が異なるため、この PR では修正していない。対応要否の判断を求める。

## ドキュメント影響: なし

公開 API の変更はなく、ユーザー向けドキュメントに記載された挙動も変わらない。
