### PR TITLE
Restrict the delivered guest route to Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,9 +129,12 @@ graph LR
 
 ## Remote parsing updates
 When FANBOX changes the shape of its responses, the app stops being able to read them, and a fix
-would otherwise reach you only through a store update. To close that gap, the app fetches a signed
-bundle that builds and interprets the post detail request, and runs that instead of the parsing
-built into the release.
+would otherwise reach you only through a store update. To close that gap, the Android app fetches a
+signed bundle that builds and interprets the post detail request, and runs that instead of the
+parsing built into the release.
+
+This applies to Android only. iOS parses responses with the code shipped in the release, so a fix
+reaches iOS through a store update.
 
 This is used only to keep up with changes to the FANBOX API. It does not add features, and it does
 not change what the app does with your data.

--- a/core/repository/src/androidMain/kotlin/me/matsumo/fanbox/core/repository/FanboxFactory.android.kt
+++ b/core/repository/src/androidMain/kotlin/me/matsumo/fanbox/core/repository/FanboxFactory.android.kt
@@ -1,0 +1,52 @@
+package me.matsumo.fanbox.core.repository
+
+import kotlinx.coroutines.CoroutineDispatcher
+import me.matsumo.fankt.fanbox.Fanbox
+import me.matsumo.fankt.fanbox.FanboxCookieStorage
+import me.matsumo.fankt.fanbox.FanboxLogLevel
+
+/**
+ * 投稿詳細の解析処理を配信する manifest の所在。
+ *
+ * パスに含まれる版は host と guest のあいだの API の版であり、この版のあいだは互換な bundle だけが
+ * 配信される。版が上がった配信物は別のパスへ置かれるため、更新前のアプリが解釈できない bundle を
+ * 受け取ることはない。
+ */
+private const val GUEST_MANIFEST_URL =
+    "https://matsumo0922.github.io/fankt/zipline/v1/manifest.zipline.json"
+
+/** 配信物の署名に使う鍵の名前。fankt 側の署名設定と一致している必要がある。 */
+private const val GUEST_TRUSTED_KEY_NAME = "fanboxGuest"
+
+/**
+ * 配信物の署名を検証する Ed25519 公開鍵。
+ *
+ * 秘匿を要さないが、リリースへ焼き込まれるためアプリの更新なしには変更できない。入れ替える際は、
+ * 移行期に新旧の双方で署名した manifest を配信し、旧鍵を埋め込んだリリースが使われなくなってから
+ * 旧鍵を廃止する。
+ *
+ * 配信中の manifest と対応しない鍵を置くと、guest は一度も起動しないまま直接経路で動作し続ける。
+ * 症状が「従来どおり動く」であるため、入れ替えの際は配信中の manifest の署名を実際に検証すること。
+ */
+internal const val GUEST_TRUSTED_ED25519_PUBLIC_KEY_HEX =
+    "5c45794e6a3c11de4ad637bbfc1714071eb3c8a9bb7139f4a3f88dc75a36146e"
+
+/**
+ * 配信先と公開鍵を渡して [Fanbox] を生成する。これにより投稿詳細の解析が配信済みの guest で実行され、
+ * FANBOX の仕様変更への追従がアプリの更新を経ずに届く。配信先へ到達できない場合は fankt が guest を
+ * 経由しない直接経路へ退避する。
+ */
+internal actual fun createFanbox(
+    logLevel: FanboxLogLevel,
+    ioDispatcher: CoroutineDispatcher,
+    cookieStorage: FanboxCookieStorage,
+): Fanbox {
+    return Fanbox(
+        guestManifestUrl = GUEST_MANIFEST_URL,
+        guestTrustedKeyName = GUEST_TRUSTED_KEY_NAME,
+        guestTrustedEd25519PublicKey = GUEST_TRUSTED_ED25519_PUBLIC_KEY_HEX.hexToByteArray(),
+        logLevel = logLevel,
+        ioDispatcher = ioDispatcher,
+        cookieStorage = cookieStorage,
+    )
+}

--- a/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/FanboxRepository.kt
+++ b/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/FanboxRepository.kt
@@ -31,6 +31,7 @@ import me.matsumo.fanbox.core.repository.paging.SearchPostsPagingSource
 import me.matsumo.fanbox.core.repository.paging.SupportedPostsPagingSource
 import me.matsumo.fankt.fanbox.Fanbox
 import me.matsumo.fankt.fanbox.FanboxCookieRecord
+import me.matsumo.fankt.fanbox.FanboxCookieStorage
 import me.matsumo.fankt.fanbox.FanboxException
 import me.matsumo.fankt.fanbox.FanboxListItemSchemaMismatch
 import me.matsumo.fankt.fanbox.FanboxLogLevel
@@ -209,30 +210,17 @@ interface FanboxRepository {
 }
 
 /**
- * 投稿詳細の解析処理を配信する manifest の所在。
+ * [Fanbox] を生成する。
  *
- * パスに含まれる版は host と guest のあいだの API の版であり、この版のあいだは互換な bundle だけが
- * 配信される。版が上がった配信物は別のパスへ置かれるため、更新前のアプリが解釈できない bundle を
- * 受け取ることはない。
+ * 配信済みの guest を使うかどうかはプラットフォームによって異なり、fankt は guest 用と直接経路用で
+ * 別のコンストラクタを持つ。引数の有無ではなく呼び分けが要るため、生成そのものをプラットフォーム側へ
+ * 委ねる。配信先と鍵を Android の source set に置くことで、iOS のバイナリへも含まれない。
  */
-private const val GUEST_MANIFEST_URL =
-    "https://matsumo0922.github.io/fankt/zipline/v1/manifest.zipline.json"
-
-/** 配信物の署名に使う鍵の名前。fankt 側の署名設定と一致している必要がある。 */
-private const val GUEST_TRUSTED_KEY_NAME = "fanboxGuest"
-
-/**
- * 配信物の署名を検証する Ed25519 公開鍵。
- *
- * 秘匿を要さないが、リリースへ焼き込まれるためアプリの更新なしには変更できない。入れ替える際は、
- * 移行期に新旧の双方で署名した manifest を配信し、旧鍵を埋め込んだリリースが使われなくなってから
- * 旧鍵を廃止する。
- *
- * 配信中の manifest と対応しない鍵を置くと、guest は一度も起動しないまま直接経路で動作し続ける。
- * 症状が「従来どおり動く」であるため、入れ替えの際は配信中の manifest の署名を実際に検証すること。
- */
-internal const val GUEST_TRUSTED_ED25519_PUBLIC_KEY_HEX =
-    "5c45794e6a3c11de4ad637bbfc1714071eb3c8a9bb7139f4a3f88dc75a36146e"
+internal expect fun createFanbox(
+    logLevel: FanboxLogLevel,
+    ioDispatcher: CoroutineDispatcher,
+    cookieStorage: FanboxCookieStorage,
+): Fanbox
 
 class FanboxRepositoryImpl(
     private val bookmarkDataStore: BookmarkDataStore,
@@ -246,15 +234,9 @@ class FanboxRepositoryImpl(
 
     private val scope = CoroutineScope(SupervisorJob() + ioDispatcher)
 
-    // 配信先と公開鍵を渡すことで、投稿詳細の解析が配信済みの guest で実行される。渡さない限り guest
-    // は起動しない。配信先へ到達できない場合は fankt が直接経路へ退避する。
-    //
     // fankt は NONE 以外の logLevel でスキーマ不一致ごとに応答本文の断片を出力する。断片には
     // FANBOX と利用者のデータが残るため、リリースビルドでは NONE にして出力経路ごと閉じる。
-    private val fanbox = Fanbox(
-        guestManifestUrl = GUEST_MANIFEST_URL,
-        guestTrustedKeyName = GUEST_TRUSTED_KEY_NAME,
-        guestTrustedEd25519PublicKey = GUEST_TRUSTED_ED25519_PUBLIC_KEY_HEX.hexToByteArray(),
+    private val fanbox = createFanbox(
         logLevel = if (pixiViewConfig.isDebug) FanboxLogLevel.INFO else FanboxLogLevel.NONE,
         ioDispatcher = ioDispatcher,
         cookieStorage = cookieStorage,

--- a/core/repository/src/iosMain/kotlin/me/matsumo/fanbox/core/repository/FanboxFactory.ios.kt
+++ b/core/repository/src/iosMain/kotlin/me/matsumo/fanbox/core/repository/FanboxFactory.ios.kt
@@ -1,0 +1,24 @@
+package me.matsumo.fanbox.core.repository
+
+import kotlinx.coroutines.CoroutineDispatcher
+import me.matsumo.fankt.fanbox.Fanbox
+import me.matsumo.fankt.fanbox.FanboxCookieStorage
+import me.matsumo.fankt.fanbox.FanboxLogLevel
+
+/**
+ * 配信先を渡さずに [Fanbox] を生成する。guest は起動せず、投稿詳細は組み込みの直接経路で処理される。
+ *
+ * 遠隔コードの実行を停止する手段が iOS には無いため、配信の対象を Android に限っている。FANBOX の
+ * 仕様変更への追従は、iOS ではアプリの更新で届く。
+ */
+internal actual fun createFanbox(
+    logLevel: FanboxLogLevel,
+    ioDispatcher: CoroutineDispatcher,
+    cookieStorage: FanboxCookieStorage,
+): Fanbox {
+    return Fanbox(
+        logLevel = logLevel,
+        ioDispatcher = ioDispatcher,
+        cookieStorage = cookieStorage,
+    )
+}

--- a/openspec/changes/restrict-guest-route-to-android/.openspec.yaml
+++ b/openspec/changes/restrict-guest-route-to-android/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-13

--- a/openspec/changes/restrict-guest-route-to-android/design.md
+++ b/openspec/changes/restrict-guest-route-to-android/design.md
@@ -1,0 +1,66 @@
+# 設計: guest 経路の有効化を Android 限定にする
+
+## Context
+
+`FanboxRepositoryImpl` は `core/repository/src/commonMain` にあり、`Fanbox` を 1 つ保持する。生成箇所は 1 箇所で、配信先・鍵名・公開鍵を渡す guest コンストラクタを呼んでいる。プラットフォームによる分岐は無い。
+
+`core/repository` は `androidMain` と `iosMain` の source set を持ち、`di/RepositoryModule.kt` の `expect val repositorySubModule: Module` を各プラットフォームで `actual` として実装している。プラットフォーム差を表現する手段が既にある。
+
+## Goals / Non-Goals
+
+### Goals
+
+- Android のみで guest を起動する
+- 配信先と鍵を iOS のバイナリへ含めない
+- 実行時のフラグを増やさない
+
+### Non-Goals
+
+- kill switch（#139）
+- 同梱 fallback bundle（#140）
+- iOS で guest を動かすための仕組み
+
+## Decisions
+
+### D1: `Fanbox` の生成を `expect` / `actual` の関数へ移す（agent 仮決め）
+
+`Fanbox` は guest 用と直接経路用で別のコンストラクタを持つため、引数の有無ではなく呼び分けが要る。生成そのものをプラットフォーム側へ委ねる。
+
+```kotlin
+// commonMain
+internal expect fun createFanbox(
+    logLevel: FanboxLogLevel,
+    ioDispatcher: CoroutineDispatcher,
+    cookieStorage: FanboxCookieStorage,
+): Fanbox
+```
+
+代替として検討した実行時フラグ（`PixiViewConfig` へ Boolean を足し、`if` で 2 つのコンストラクタを呼び分ける）は、共通の引数を 2 箇所へ書くことになり、かつ配信先と鍵が `commonMain` に残るため iOS のバイナリからも消えない。`expect` / `actual` はこの 2 点を同時に解決する。
+
+同モジュールの `repositorySubModule` が既に同じ仕組みを使っており、新しい表現を持ち込まない。
+
+### D2: 配信先・鍵名・公開鍵を `androidMain` へ移す（agent 仮決め）
+
+iOS では参照しないため、`commonMain` に置く理由がない。Android の source set へ移すことで、iOS のバイナリへ含まれないことが配置から保証される。
+
+公開鍵の定数を検証するテストは `androidHostTest` にあり、`androidMain` の `internal` を参照できるため、移動後もそのまま成立する。
+
+### D3: iOS の挙動は #138 以前と同じにする（ユーザー確認済み）
+
+iOS は guest を伴わないコンストラクタで `Fanbox` を生成する。`logLevel` / `ioDispatcher` / `cookieStorage` の渡し方は #138 以前と同じである。
+
+## Risks / Trade-offs
+
+**iOS に解析の修正が OTA で届かなくなる** → FANBOX の仕様変更時、iOS はストア審査を経た更新でのみ修正が届く。これは #138 以前と同じ状態であり、退行ではない。適用範囲を Android に限る方針に伴う既知の帰結である。
+
+**プラットフォームで挙動が分かれる** → 同じ FANBOX の仕様変更に対し、Android は配信で直り iOS は直らない期間が生じる。障害調査の際、どちらのプラットフォームかで解析経路が異なることを踏まえる必要がある。
+
+**`expect` / `actual` の追加でプラットフォーム側の実装が 2 つに増える** → 生成の引数が変わるたび 3 箇所（expect と actual 2 つ）を直す。呼び分けが必要である以上避けられず、同モジュールの既存の `repositorySubModule` と同じ構造に収まる。
+
+## Migration Plan
+
+差し戻しは `createFanbox` の iOS 実装を guest コンストラクタへ変え、定数を `commonMain` へ戻すだけで足りる。データの移行を伴わない。
+
+## Open Questions
+
+- **実機での動作確認**。Android で guest が動くこと、iOS で guest が起動しないことの確認は人間が行う

--- a/openspec/changes/restrict-guest-route-to-android/proposal.md
+++ b/openspec/changes/restrict-guest-route-to-android/proposal.md
@@ -1,0 +1,56 @@
+# guest 経路の有効化を Android 限定にする
+
+## Why
+
+`FanboxRepositoryImpl` は `commonMain` にあり、プラットフォームによる分岐を持たない。このため現在は Android と iOS の双方で配信済み guest が実行される。
+
+OTA 配信の適用範囲を当面 Android に限る方針となった。この方針のもとで kill switch（#139）を Android 限定に実装すると、iOS には遠隔コードを実行しながらアプリ側から停止する手段が無い状態が残る。停止手段を持たないプラットフォームで遠隔コードを実行し続ける理由がないため、iOS を直接経路へ戻す。
+
+## What Changes
+
+- `Fanbox` の生成をプラットフォーム側へ委ね、Android のみが配信先と公開鍵を渡す
+- 配信先の manifest URL、鍵名、Ed25519 公開鍵を Android の source set へ移す
+- iOS は guest を伴わないコンストラクタで `Fanbox` を生成する
+
+`core/repository` は `androidMain` と `iosMain` の source set を既に持ち、`repositorySubModule` で `expect` / `actual` を使っている。実行時のフラグではなくこの仕組みで表現する。
+
+破壊的変更はない。iOS の挙動は #138 以前と同じになる。
+
+## Capabilities
+
+### New Capabilities
+
+なし。
+
+### Modified Capabilities
+
+- `fanbox-guest-route`: guest を使う対象を Android に限る。iOS では guest を起動せず直接経路で処理することを定める
+
+## Impact
+
+### 変更するコード
+
+- `core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/FanboxRepository.kt`
+- `core/repository/src/androidMain/kotlin/me/matsumo/fanbox/core/repository/FanboxFactory.android.kt`（新規）
+- `core/repository/src/iosMain/kotlin/me/matsumo/fanbox/core/repository/FanboxFactory.ios.kt`（新規）
+- `README.md`
+
+### 実行時の挙動
+
+Android は変わらない。iOS は `post.info` の解析が直接経路へ戻り、配信済みの修正が届かなくなる。FANBOX の仕様変更が起きた場合、iOS はストア審査を経た更新でのみ修正が届く。
+
+## 対象範囲
+
+- guest 経路の対象を Android に限ること
+- 配信先と鍵を Android の source set へ閉じること
+- README の記載を実態に合わせること
+
+## 非対象範囲
+
+- Remote Config による kill switch（#139）
+- 同梱 fallback bundle（#140）
+- iOS で guest を動かすための検討。方針が変わった時点で改めて扱う
+
+## ドキュメント影響
+
+あり。`README.md` の「Remote parsing updates」に対象が Android である旨を加える。

--- a/openspec/changes/restrict-guest-route-to-android/specs/fanbox-guest-route/spec.md
+++ b/openspec/changes/restrict-guest-route-to-android/specs/fanbox-guest-route/spec.md
@@ -1,0 +1,39 @@
+# fanbox-guest-route
+
+## MODIFIED Requirements
+
+### Requirement: 投稿詳細の取得に配信済み guest を使う
+
+Android では、アプリは配信先の manifest URL、信頼する鍵名、Ed25519 公開鍵を伴って `Fanbox` を生成しなければならない（MUST）。これにより `post.info` の要求組み立てと応答解析が、配信された guest bundle で実行される。
+
+iOS では、アプリはこれらを伴わずに `Fanbox` を生成しなければならない（MUST）。guest は起動せず、`post.info` は組み込みの直接経路で処理される。
+
+これらを伴わずに生成した `Fanbox` は guest を起動しないため、宣言そのものが本 capability の成立条件である。
+
+配信先と鍵は Android の source set に置き、iOS のバイナリへ含めない。
+
+#### Scenario: Android で配信先と公開鍵を伴って生成する
+
+- **WHEN** Android で `FanboxRepositoryImpl` が `Fanbox` を生成する
+- **THEN** アプリは配信先の manifest URL、信頼する鍵名、Ed25519 公開鍵を渡す
+
+#### Scenario: iOS で guest を起動しない
+
+- **WHEN** iOS で `FanboxRepositoryImpl` が `Fanbox` を生成する
+- **THEN** アプリは配信先も公開鍵も渡さず、`post.info` は直接経路で処理される
+
+#### Scenario: 公開鍵が Ed25519 の鍵長を満たす
+
+- **WHEN** 埋め込んだ公開鍵を復号する
+- **THEN** 32 バイトになる
+
+### Requirement: 遠隔からの解析処理の取得を README に記載する
+
+アプリが遠隔から解析処理を取得して実行することと、その用途、および対象が Android であることを README に記載しなければならない（MUST）。
+
+Privacy Policy は本リポジトリの外（`https://www.matsumo.me/application/pixiview/privacy_policy`）にあるため、本 change では変更できない。記載の要否の判断と反映は人間へ引き継ぐ。
+
+#### Scenario: README を読む
+
+- **WHEN** README を読む
+- **THEN** 遠隔から解析処理を取得する旨、用途を FANBOX の仕様変更への追従に限る旨、および対象が Android である旨が記載されている

--- a/openspec/changes/restrict-guest-route-to-android/tasks.md
+++ b/openspec/changes/restrict-guest-route-to-android/tasks.md
@@ -2,21 +2,21 @@
 
 ## 1. 生成をプラットフォーム側へ委ねる
 
-- [ ] 1.1 `commonMain` に `createFanbox` の `expect` 宣言を置く
-- [ ] 1.2 `androidMain` に `actual` を置き、配信先・鍵名・公開鍵の定数を `FanboxRepository.kt` から移す
-- [ ] 1.3 `iosMain` に `actual` を置き、guest を伴わないコンストラクタで生成する
-- [ ] 1.4 `FanboxRepositoryImpl` の生成を `createFanbox` の呼び出しへ差し替える
+- [x] 1.1 `commonMain` に `createFanbox` の `expect` 宣言を置く
+- [x] 1.2 `androidMain` に `actual` を置き、配信先・鍵名・公開鍵の定数を `FanboxRepository.kt` から移す
+- [x] 1.3 `iosMain` に `actual` を置き、guest を伴わないコンストラクタで生成する
+- [x] 1.4 `FanboxRepositoryImpl` の生成を `createFanbox` の呼び出しへ差し替える
 
 ## 2. 定数が iOS へ届かないことの確認
 
-- [ ] 2.1 `commonMain` と `iosMain` に配信先 URL・鍵名・公開鍵が残っていないことを確認する
+- [x] 2.1 `commonMain` と `iosMain` に配信先 URL・鍵名・公開鍵が残っていないことを確認する
 
 ## 3. ドキュメント
 
-- [ ] 3.1 `README.md` の「Remote parsing updates」に対象が Android である旨を加える
+- [x] 3.1 `README.md` の「Remote parsing updates」に対象が Android である旨を加える
 
 ## 4. 検証
 
-- [ ] 4.1 `detekt` と単体テストを実行する
-- [ ] 4.2 Android のリリースビルドが通ることを確認する
-- [ ] 4.3 iOS 向けのコンパイルが通ることを確認する
+- [x] 4.1 `detekt` と単体テストを実行する
+- [x] 4.2 Android のリリースビルドが通ることを確認する
+- [x] 4.3 iOS 向けのコンパイルが通ることを確認する

--- a/openspec/changes/restrict-guest-route-to-android/tasks.md
+++ b/openspec/changes/restrict-guest-route-to-android/tasks.md
@@ -1,0 +1,22 @@
+# Tasks
+
+## 1. 生成をプラットフォーム側へ委ねる
+
+- [ ] 1.1 `commonMain` に `createFanbox` の `expect` 宣言を置く
+- [ ] 1.2 `androidMain` に `actual` を置き、配信先・鍵名・公開鍵の定数を `FanboxRepository.kt` から移す
+- [ ] 1.3 `iosMain` に `actual` を置き、guest を伴わないコンストラクタで生成する
+- [ ] 1.4 `FanboxRepositoryImpl` の生成を `createFanbox` の呼び出しへ差し替える
+
+## 2. 定数が iOS へ届かないことの確認
+
+- [ ] 2.1 `commonMain` と `iosMain` に配信先 URL・鍵名・公開鍵が残っていないことを確認する
+
+## 3. ドキュメント
+
+- [ ] 3.1 `README.md` の「Remote parsing updates」に対象が Android である旨を加える
+
+## 4. 検証
+
+- [ ] 4.1 `detekt` と単体テストを実行する
+- [ ] 4.2 Android のリリースビルドが通ることを確認する
+- [ ] 4.3 iOS 向けのコンパイルが通ることを確認する


### PR DESCRIPTION
Closes #143

## 概要

配信済み guest の適用範囲を Android に限り、iOS を直接経路へ戻す。

#141 の実装は `commonMain` にあったため、Android と iOS の双方で guest が動作していた。OTA 配信の適用範囲を当面 Android に限る方針となったため、iOS では guest を起動しない。

kill switch（#139）を Android 限定に実装すると、iOS には遠隔コードを実行しながらアプリ側から停止する手段が無い状態が残る。停止手段を持たないプラットフォームで遠隔コードを実行し続ける理由がないため、iOS を戻す。

設計は `openspec/changes/restrict-guest-route-to-android/` にある。

## 変更

| ファイル | 内容 |
| --- | --- |
| `core/repository/.../FanboxRepository.kt` | `Fanbox` の生成を `expect fun createFanbox` へ委ね、定数を撤去 |
| `core/repository/src/androidMain/.../FanboxFactory.android.kt` | 新規。配信先・鍵名・公開鍵を保持し、guest コンストラクタで生成 |
| `core/repository/src/iosMain/.../FanboxFactory.ios.kt` | 新規。guest を伴わないコンストラクタで生成 |
| `README.md` | 対象が Android である旨を追記 |

実行時のフラグではなく source set の差で表現した。`core/repository` は `di/RepositoryModule.kt` の `expect val repositorySubModule` で同じ仕組みを既に使っている。

この形を採った決め手は、配信先 URL と公開鍵が iOS のバイナリへ含まれなくなること。実行時フラグでは定数が `commonMain` に残る。

## 検証

コードに影響する検証はすべて HEAD `86dd85e9` で実行した。現在の HEAD は `91f7d2ad` で、差分は change artifact の `tasks.md` のチェックボックスのみである（`git diff --stat 86dd85e9 HEAD` で確認できる）。コンパイル対象に触れないため再実行していない。CI の detekt は `91f7d2ad` で pass している。

| 対象 | コマンド | 結果 |
| --- | --- | --- |
| lint | `./gradlew detekt` | BUILD SUCCESSFUL |
| 単体テスト | `./gradlew testAndroidHostTest` | 142 tests / 0 failures / 0 errors |
| リリースビルド | `./gradlew :androidApp:assembleRelease` | BUILD SUCCESSFUL |
| iOS コンパイル | `./gradlew :shared:compileKotlinIosSimulatorArm64` | BUILD SUCCESSFUL |

Scenario「公開鍵が Ed25519 の鍵長を満たす」の証明は `GuestDeliveryKeyTest.trustedPublicKeyDecodesToAnEd25519Key`（1 test / 0 failures）。定数を `androidMain` へ移したあとも `androidHostTest` から参照して成立する。

受け入れ条件「配信先・鍵名・公開鍵が iOS のバイナリへ含まれない」は配置で保証される。`commonMain` と `iosMain` に対する grep が 0 件であることを確認した。

## 反証

独立 falsifier による反証を 1 巡実施し、blocking 反例はゼロだった。

触れていない 2 つの Requirement（「配信先へ到達できなくても投稿詳細の取得は成立する」「guest 経路の失敗は既存のエラー分類を変えない」）については、iOS では WHEN 節の前提が成立しなくなるが、これは要件が破れるのではなく空虚に真になるものであり、退行ではないと確認された。

iOS の `actual` が #141 以前（`a0682ffe`）の生成と引数まで一致することも確認されている。

## 人間に確認してほしいこと

1. **実機での動作確認**。Android で guest が動くこと、iOS で guest が起動しないことは自動検証の対象外である
2. **iOS に修正が届かなくなること**（ユーザー確認済み）。FANBOX の仕様変更時、iOS はストア審査を経た更新でのみ修正が届く。#138 以前と同じ状態であり退行ではないが、プラットフォームで追従の速さが分かれる
3. **`expect` / `actual` の保守**（agent 仮決め）。生成の引数が変わるたび 3 箇所を直す。片方だけ直すと当該プラットフォームがコンパイルエラーになるため、無言の不整合にはならない

## 範囲外

- Remote Config による kill switch（#139）
- 同梱 fallback bundle（#140）
- iOS で guest を動かすための検討

## ドキュメント影響

あり（`README.md`）。

## follow-up

change の archive は本 PR に含めない。merge 後に `openspec archive restrict-guest-route-to-android --yes` の差分のみの `chore:` PR で回収する。
