### PR TITLE
Stop the delivered guest route from Remote Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,13 @@ The bundle is verified against a public key compiled into the app. One that fail
 not executed. When the delivery target cannot be reached, the app parses responses with its own
 built-in path, exactly as it did before this mechanism existed.
 
+Execution can also be stopped remotely, independently of what is published at the delivery target.
+The app reads a flag from Firebase Remote Config when it starts, and skips the delivered bundle
+entirely while that flag is set. Until that flag has been read at least once — on a first launch, or
+on a device that cannot reach Remote Config — the app runs the delivered bundle, so losing access to
+the flag never costs you the fix it carries. Stopping is therefore not immediate: the flag reaches a
+device on its next fetch, and applies the next time the app starts.
+
 ## Contribute
 
 This app uses Gradle's Convention Plugins to standardize the build logic, and all the logic is written in a module called `build-logic`. For information on this approach, see [nowinandroid](https://github.com/matsumo0922/nowinandroid/tree/main/build-logic).

--- a/core/repository/src/androidMain/kotlin/me/matsumo/fanbox/core/repository/FanboxFactory.android.kt
+++ b/core/repository/src/androidMain/kotlin/me/matsumo/fanbox/core/repository/FanboxFactory.android.kt
@@ -1,6 +1,10 @@
 package me.matsumo.fanbox.core.repository
 
+import com.google.firebase.Firebase
+import com.google.firebase.remoteconfig.remoteConfig
+import com.google.firebase.remoteconfig.remoteConfigSettings
 import kotlinx.coroutines.CoroutineDispatcher
+import me.matsumo.fanbox.core.common.util.recordException
 import me.matsumo.fankt.fanbox.Fanbox
 import me.matsumo.fankt.fanbox.FanboxCookieStorage
 import me.matsumo.fankt.fanbox.FanboxLogLevel
@@ -32,15 +36,46 @@ internal const val GUEST_TRUSTED_ED25519_PUBLIC_KEY_HEX =
     "5c45794e6a3c11de4ad637bbfc1714071eb3c8a9bb7139f4a3f88dc75a36146e"
 
 /**
- * 配信先と公開鍵を渡して [Fanbox] を生成する。これにより投稿詳細の解析が配信済みの guest で実行され、
- * FANBOX の仕様変更への追従がアプリの更新を経ずに届く。配信先へ到達できない場合は fankt が guest を
- * 経由しない直接経路へ退避する。
+ * guest を起動しないことを指示する Remote Config のキー。
+ *
+ * 「停止」の向きで定義している。Remote Config は活性化済みの値も既定値も無い boolean に `false` を
+ * 返すため、この向きなら値を一度も取得できていない端末がそのまま「停止していない」になる。既定値の
+ * 登録が要らず、その完了を待たずに値を読む競合も生じない。
+ *
+ * 綴りが Firebase コンソールの設定と食い違うと、症状は「フラグを倒しても止まらない」という無言の
+ * 失敗になる。変更する際はコンソールの表示と実際に照合すること。
+ */
+private const val GUEST_ROUTE_KILL_SWITCH_KEY = "android_guest_route_kill_switch"
+
+/**
+ * Remote Config を取得しに行く最短の間隔。
+ *
+ * Firebase の既定は 12 時間で、停止を決めてから端末へ届くまでの遅延がそのぶん延びる。停止スイッチは
+ * 障害対応の道具であるため 1 時間へ縮める。
+ */
+private const val REMOTE_CONFIG_FETCH_INTERVAL_SECONDS = 3600L
+
+/**
+ * 停止フラグが立っていない限り、配信先と公開鍵を渡して [Fanbox] を生成する。これにより投稿詳細の解析が
+ * 配信済みの guest で実行され、FANBOX の仕様変更への追従がアプリの更新を経ずに届く。配信先へ到達
+ * できない場合は fankt が guest を経由しない直接経路へ退避する。
+ *
+ * 停止フラグが立っている場合は配信先も公開鍵も渡さない。配信先への取得そのものが起きないため、配信元を
+ * 操作できない場合や manifest の取得が返らない場合でも guest を止められる。
  */
 internal actual fun createFanbox(
     logLevel: FanboxLogLevel,
     ioDispatcher: CoroutineDispatcher,
     cookieStorage: FanboxCookieStorage,
 ): Fanbox {
+    if (isGuestRouteKilled()) {
+        return Fanbox(
+            logLevel = logLevel,
+            ioDispatcher = ioDispatcher,
+            cookieStorage = cookieStorage,
+        )
+    }
+
     return Fanbox(
         guestManifestUrl = GUEST_MANIFEST_URL,
         guestTrustedKeyName = GUEST_TRUSTED_KEY_NAME,
@@ -49,4 +84,27 @@ internal actual fun createFanbox(
         ioDispatcher = ioDispatcher,
         cookieStorage = cookieStorage,
     )
+}
+
+/**
+ * 活性化済みの停止フラグを読む。取得は背景で始め、取得した値は次回の起動で読まれる。
+ *
+ * 参照が失敗した場合は guest を起動する側へ倒す。guest 経路は「どの失敗も直接経路へ退避する」で
+ * 一貫しており、停止スイッチ自身がアプリを落とすとこの一貫性が反転して Firebase の不調がアプリの
+ * 起動不能になる。記録の呼び出しも守るのは、記録先の Crashlytics が Remote Config と同じ既定の
+ * FirebaseApp を要し、参照が失敗する状況では記録もまた失敗するため。
+ */
+private fun isGuestRouteKilled(): Boolean = runCatching {
+    val remoteConfig = Firebase.remoteConfig
+
+    remoteConfig.setConfigSettingsAsync(
+        remoteConfigSettings {
+            minimumFetchIntervalInSeconds = REMOTE_CONFIG_FETCH_INTERVAL_SECONDS
+        },
+    ).addOnCompleteListener { remoteConfig.fetchAndActivate() }
+
+    remoteConfig.getBoolean(GUEST_ROUTE_KILL_SWITCH_KEY)
+}.getOrElse { failure ->
+    runCatching { recordException(failure) }
+    false
 }

--- a/openspec/changes/add-guest-route-kill-switch/.openspec.yaml
+++ b/openspec/changes/add-guest-route-kill-switch/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-14

--- a/openspec/changes/add-guest-route-kill-switch/design.md
+++ b/openspec/changes/add-guest-route-kill-switch/design.md
@@ -1,0 +1,123 @@
+# 設計
+
+## 現状の把握
+
+| 事実 | 確認箇所 |
+| --- | --- |
+| `Fanbox` は `FanboxRepositoryImpl` の構築時に一度だけ生成される | `FanboxRepository.kt:239` |
+| `FanboxRepositoryImpl` は `single`（`createdAtStart` なし）で、最初の注入時に構築される | `di/RepositoryModule.kt:41`。リポジトリ全体に `createdAtStart` の使用は無い |
+| `FirebaseApp` は `Application.onCreate()` の手動初期化でのみ生成される | `PixiViewApplication.kt:37`, `PixiViewApplication.kt:74`。`FirebaseInitProvider` は `androidApp/src/main/AndroidManifest.xml:98` で `tools:node="remove"` により除去されている |
+| Koin の設定は `KoinStartup` により androidx App Startup 経由で走り、`Application.onCreate()` より前に完了する | `PixiViewApplication.kt:26`, `PixiViewApplication.kt:41` |
+| guest 用と直接経路用でコンストラクタが分かれており、生成は `androidMain` / `iosMain` に委ねられている | `FanboxFactory.android.kt` / `FanboxFactory.ios.kt` |
+| `firebase-config` は依存に含まれ、`core:common` の `androidMain` が `api` で公開している | `libs.versions.toml:193`, `core/common/build.gradle.kts` |
+| Kotlin から Remote Config を参照している箇所は無い | `firebase-config` は依存にあるが未使用 |
+| guest bundle のローカルキャッシュは存在しない | `ZiplineGuestLoader.newLoader` が `ZiplineLoader` に `withCache` を渡していない。`FreshnessChecker` も `AlwaysStale` |
+
+Koin の設定自体は `Application.onCreate()` より前に完了するが、`single` は遅延構築であり、`FanboxRepositoryImpl` は最初の注入時に初めて構築される。リポジトリ全体に `createdAtStart` の使用は無く、`androidApp` に Koin から `FanboxRepository` を取り出す eager な Initializer も無いため、最初の注入は UI からの取得、すなわち `Application.onCreate()` 完了後に起きる。したがって `createFanbox` の時点で `FirebaseApp` は初期化済みである。
+
+この成立条件は将来の変更で崩れうる。`createdAtStart = true` の付与や、Koin へ依存する新しい Initializer の追加により `createFanbox` が `Application.onCreate()` より前に走ると、`FirebaseInitProvider` を除去している以上 `FirebaseApp` は存在せず、Remote Config の参照は例外になる。D5 によりアプリは落ちないが、停止フラグは常に「立っていない」と判定され、停止スイッチが無言で効かなくなる。D5 の失敗は記録に残すが、この劣化に限っては記録も届かない。記録先の Crashlytics も既定の `FirebaseApp` を要するため、`FirebaseApp` が無い状態では記録する手段そのものが無い。記録が効くのは `FirebaseApp` が初期化済みで参照だけが失敗する場合である。
+
+## 決定
+
+### D1: 停止フラグは `createFanbox` の中で読む（構造の判断）
+
+停止の対象は「配信先と公開鍵を渡した `Fanbox` を作ること」そのものである。判断を生成箇所に置けば、分岐は `if` ひとつで済み、`FanboxRepositoryImpl` にも `commonMain` にも新しい引数・インターフェース・注入経路が要らない。フラグを `commonMain` へ持ち上げると iOS 側に意味のない `actual` が生まれる。
+
+### D2: 反映は次回のアプリ起動時とする（ユーザー確認済み）
+
+`createFanbox` は Remote Config の**活性化済みの値を同期的に読み**、同じ関数で取得を背景に走らせる。取得した値は次回の起動で読まれる。
+
+同一セッション内での差し替えを採らない理由は次のとおり。`fanbox` は `FanboxRepositoryImpl` の `val` であり、差し替えるには可変化、進行中の呼び出しとの競合の扱い、古いインスタンスの `close` の時機、`cookieStorage` の共有の 4 点を新たに設計することになる。停止スイッチが対応する 3 つの事象（proposal 参照）はいずれも「アプリを開き直せば直る」で実害が収まる。取得が返らない事象では利用者はどのみち再起動する。
+
+### D3: フラグは「停止」を表す boolean とし、既定値の設定を持たない（ユーザー確認済み）
+
+キー名を `android_guest_route_kill_switch` とし、値 `true` を「guest を起動しない」の意味に割り当てる。
+
+Remote Config は、活性化済みの値も `setDefaults` の値も無い boolean に対して静的既定の `false` を返す（Firebase Android SDK の `FirebaseRemoteConfig.getBoolean` の規定。BOM `34.14.1` の `firebase-config` を使用）。キーを「停止」の向きで定義すると、この静的既定がそのまま「停止していない = guest を起動する」になる。`setDefaultsAsync` を呼ぶ必要が無くなり、その完了を待たずに `getBoolean` を読む競合も生じない。
+
+この静的既定は SDK の挙動であり、本リポジトリからは検証できない。誤っていれば「フラグを一度も取得していない端末で guest が起動しない」という形で現れる。新規インストール直後の初回起動で guest が起動することを実機で確認し、前提の成立を確かめる。
+
+**取得前および取得失敗時は guest を起動する側へ倒す**。これが本 change で唯一のリスク許容の判断であり、ユーザーが確定した。
+
+- 倒さない側（既定で停止）を採ると、Remote Config を一度も取得できていない端末——新規インストールの初回起動、および Firebase へ到達できない端末——で guest が起動しなくなる。`fanbox-guest-route` が成立する条件が「Firebase の取得に成功していること」になり、#138 で有効化した配信が Firebase の障害で全端末から失われる
+- 倒す側の残余リスクは、停止を決めてから各端末の次回起動まで壊れた bundle が実行され続けることである。ただし配信元の巻き戻しが同時に使え、そちらは端末側の状態に依存せず即座に効く。停止スイッチは配信元が使えない場合の手段であり、第一の手段ではない
+
+採らなかった選択肢と分岐条件：guest の誤動作がデータの破壊や外部への送信を伴い得るなら、既定で停止する側（`android_guest_route_enabled` を `setDefaultsAsync` で `false`、取得成功後にのみ有効化）へ倒す。現在の guest の職掌は `post.info` の要求組み立てと応答解析に限られ、書き込みも送信も行わないため、この条件には当たらないと判断した。
+
+### D4: 取得間隔は 1 時間とする（ユーザー確認済み）
+
+`minimumFetchIntervalInSeconds` の Firebase 既定は 12 時間である。停止スイッチの反映までの遅延は「取得間隔 + 次回起動まで」であり、12 時間は障害対応の道具として長い。1 時間へ短縮する。
+
+設定は永続化されるため、設定の書き込みと取得の順序が最初の 1 回だけ問題になる。`setConfigSettingsAsync` の完了後に取得を開始することで、この 1 回も既定の 12 時間で走らないようにする。
+
+### D5: Remote Config の参照が例外を投げてもアプリを落とさない（構造の判断）
+
+guest 経路の設計は「どの失敗も直接経路へ退避する」で一貫している（`FanboxGuestHost.guestOrNull` は `Throwable` を捕捉する）。停止スイッチ自身がアプリを落とすと、この一貫性が反転し、Firebase の不調がアプリの起動不能になる。参照全体を `runCatching` で包み、失敗時は D3 の既定（guest を起動する）へ倒す。
+
+退避と同時に失敗を記録する。`FanboxGuestHost` は退避のたびに `diagnosticSink` へ報告しており、記録の無い退避はこの経路だけが例外になる。停止スイッチの失敗は「停止フラグを倒しても止まらない」という無言の症状しか出さないため、記録が無いと原因に到達できない。記録には `core:common` の `recordException` を使う。`FanboxRepositoryImpl` が既に使っており、新しい仕組みを要さない。
+
+## 実装の形
+
+```kotlin
+private const val GUEST_ROUTE_KILL_SWITCH_KEY = "android_guest_route_kill_switch"
+private const val REMOTE_CONFIG_FETCH_INTERVAL_SECONDS = 3600L
+
+internal actual fun createFanbox(
+    logLevel: FanboxLogLevel,
+    ioDispatcher: CoroutineDispatcher,
+    cookieStorage: FanboxCookieStorage,
+): Fanbox {
+    if (isGuestRouteKilled()) {
+        return Fanbox(
+            logLevel = logLevel,
+            ioDispatcher = ioDispatcher,
+            cookieStorage = cookieStorage,
+        )
+    }
+
+    return Fanbox(
+        guestManifestUrl = GUEST_MANIFEST_URL,
+        guestTrustedKeyName = GUEST_TRUSTED_KEY_NAME,
+        guestTrustedEd25519PublicKey = GUEST_TRUSTED_ED25519_PUBLIC_KEY_HEX.hexToByteArray(),
+        logLevel = logLevel,
+        ioDispatcher = ioDispatcher,
+        cookieStorage = cookieStorage,
+    )
+}
+
+private fun isGuestRouteKilled(): Boolean = runCatching {
+    val remoteConfig = Firebase.remoteConfig
+
+    remoteConfig.setConfigSettingsAsync(
+        remoteConfigSettings {
+            minimumFetchIntervalInSeconds = REMOTE_CONFIG_FETCH_INTERVAL_SECONDS
+        },
+    ).addOnCompleteListener { remoteConfig.fetchAndActivate() }
+
+    remoteConfig.getBoolean(GUEST_ROUTE_KILL_SWITCH_KEY)
+}.getOrElse { failure ->
+    runCatching { recordException(failure) }
+    false
+}
+```
+
+記録そのものも守る。`recordException` の Android 実装は `Firebase.crashlytics` を解決するため、`Firebase.remoteConfig` と同じ理由——既定の `FirebaseApp` が無い——で失敗する。守らずに置くと、D5 が最も要る場面、すなわち `FirebaseApp` が未初期化のまま `createFanbox` が走る場面でだけ、退避のための記録がそのままクラッシュになる。
+
+`getBoolean` は活性化済みの値を返し、取得の完了を待たない。取得は次回の起動へ効く。
+
+## 残余リスク
+
+- **`FirebaseApp` が無い状態は観測できない**。`createFanbox` が `Application.onCreate()` より前に走るようになった場合、停止スイッチは無言で効かなくなり、記録先も同時に失われるため痕跡が残らない。現状この経路は存在しないが、成立条件はコードで強制されておらず、`createdAtStart` の付与や Koin へ依存する Initializer の追加で崩れる
+- **停止の反映に遅延がある**。停止を決めてから、各端末で「取得間隔 1 時間」の経過と次回起動の両方が起きるまで、guest は実行され続ける。即座に全端末へ効かせる手段は本 change に含まれない
+- **Firebase コンソール側の設定は本リポジトリの外にある**。キー名 `android_guest_route_kill_switch` の綴りがコンソールの設定と食い違っても、症状は「停止スイッチを倒しても止まらない」という無言の失敗になる。倒した後に実機で停止を確認する手順を受け入れ条件に置く
+- **`getBoolean` が初回に同期のディスク読み出しを起こしうる**。`createFanbox` は最初の注入時に呼ばれ、呼び出しスレッドは Koin の注入元に従う。アプリは起動時に DataStore の読み出しを既に行っており、新たな種類の負荷ではない
+- **debug ビルドと release ビルドが同じ Firebase プロジェクトの別 application id を使う**。両方を同時に止めたい場合は、コンソールの条件をアプリ単位ではなくプロジェクト既定として設定する必要がある
+
+## 検証
+
+Remote Config は端末上の Firebase サービスに依存し、`androidHostTest`（JVM）からは動かせない。本 change の分岐は `if (停止フラグ) 直接経路 else guest` の 1 段であり、単体テストで固定できるのはこの自明な対応だけになるため、テストは追加しない。
+
+検証は次の 2 つで行う。
+
+1. リリースビルドが通ること（`./gradlew :androidApp:assembleRelease` 相当）
+2. 実機で、Firebase コンソールのフラグを `true` へ倒した後にアプリを再起動すると guest が起動しないこと、`false` へ戻して再起動すると guest が起動すること。guest の起動有無は debug ビルドの `FanboxDiagnosticSink` の出力で判別する

--- a/openspec/changes/add-guest-route-kill-switch/proposal.md
+++ b/openspec/changes/add-guest-route-kill-switch/proposal.md
@@ -1,0 +1,51 @@
+# 配信済み guest 経路の停止スイッチを Remote Config に置く
+
+## Why
+
+Android は投稿詳細の解析を配信済みの guest bundle で実行する（`fanbox-guest-route`）。遠隔から取得したコードを実行する以上、アプリの更新を待たずに実行そのものを止める手段が要る。
+
+現状の停止手段は配信元（fankt 側の GitHub Pages）の操作だけである。これで足りない場合が 3 つ残る。
+
+1. **manifest の取得が返らない**。`ZiplineGuestLoader` は manifest の取得に明示的なタイムアウトを設定しておらず、待ち時間はプラットフォームの既定値に従う（`fanbox-guest-route` の既存 spec に記載済み）。配信先が応答を返さない状態では manifest を 404 にしても取得の試行そのものは起きるため、配信元の操作では止められない。止めるには取得を試みないことが要る
+2. **配信元を操作できない**。ホスティングの障害、権限の喪失、誤設定の巻き戻しに時間を要する状況では、配信元は制御面として使えない
+3. **guest を止める判断が配信物と無関係に降りてくる**。ストアや規約の要請で遠隔コード実行そのものを直ちに停止する場合、配信物を差し替えても要請は満たせない
+
+Firebase Remote Config は PixiView の Android に既に導入済みの Firebase 上で動き、配信元とは独立した制御面になる。上の 3 つはいずれも「アプリ側が guest を起動しないことを選ぶ」ことで閉じる。
+
+### issue #139 の前提の訂正
+
+issue には「暫定手段は manifest へ到達できる端末にのみ届く。到達できない端末を含めて確実に停止するには本 issue の対応が要る」とある。`ZiplineGuestLoader` は `ZiplineLoader` に `withCache` を渡しておらず、bundle のローカルキャッシュは存在しない。したがって manifest へ到達できない端末は guest を起動できず、既に直接経路で動作している。停止スイッチが埋めるのは「キャッシュ済みの壊れた bundle」ではなく、上の 3 つである。
+
+## What Changes
+
+- Android の `createFanbox` が Remote Config の停止フラグを参照し、立っている場合は配信先と公開鍵を渡さずに `Fanbox` を生成する
+- 同じ関数が Remote Config の取得を背景で走らせ、次回のアプリ起動に反映させる
+- 停止スイッチの存在、既定値、反映までの遅延を README に記載する
+
+## 受け入れ条件との対応
+
+issue #139 の受け入れ条件は、#143 による Android 限定化を受けて issue のコメントで改訂されている。改訂後の対応は次のとおり。
+
+| 受け入れ条件 | 対応 |
+| --- | --- |
+| Android で Remote Config を参照し guest 経路の有効・無効を決める | 本 change |
+| `FanboxRepositoryImpl` の `Fanbox` 生成へ配線する | 本 change |
+| fetch 前および fetch 失敗時の既定値を決める | 本 change（design.md に記載し README へ反映） |
+| リリースビルドが通る | 本 change |
+| iOS へ Firebase SDK を導入する（改訂前の条件） | non-goal。iOS は guest を起動しないため停止スイッチの対象にならない |
+
+issue の title は改訂前の「Firebase を iOS に導入し」のままである。本 change の範囲は Android に限る。
+
+## Impact
+
+- Affected specs: `fanbox-guest-route`
+- Affected code: `core/repository/src/androidMain/kotlin/me/matsumo/fanbox/core/repository/FanboxFactory.android.kt`, `README.md`
+- 依存の追加なし。`firebase-config` は `libs.bundles.firebase` に含まれ、`core:common` の `androidMain` が `api` で公開しているため `core:repository` の `androidMain` から参照できる
+- iOS への影響なし。`FanboxFactory.ios.kt` は変更しない
+
+## Non-goals
+
+- iOS への Firebase SDK 導入（#139 の改訂で範囲外へ移動）
+- 同一セッション内での即時反映。反映は次回のアプリ起動時とする
+- 同梱 fallback bundle（#140）
+- 停止スイッチ以外の Remote Config 利用

--- a/openspec/changes/add-guest-route-kill-switch/specs/fanbox-guest-route/spec.md
+++ b/openspec/changes/add-guest-route-kill-switch/specs/fanbox-guest-route/spec.md
@@ -1,0 +1,78 @@
+# fanbox-guest-route Delta
+
+## MODIFIED Requirements
+
+### Requirement: 投稿詳細の取得に配信済み guest を使う
+
+Android では、遠隔の停止フラグが立っていない限り、アプリは配信先の manifest URL、信頼する鍵名、Ed25519 公開鍵を伴って `Fanbox` を生成しなければならない（MUST）。これにより `post.info` の要求組み立てと応答解析が、配信された guest bundle で実行される。
+
+iOS では、アプリはこれらを伴わずに `Fanbox` を生成しなければならない（MUST）。guest は起動せず、`post.info` は組み込みの直接経路で処理される。
+
+これらを伴わずに生成した `Fanbox` は guest を起動しないため、宣言そのものが本 capability の成立条件である。
+
+配信先と鍵は Android の source set に置き、iOS のバイナリへ含めない。
+
+#### Scenario: 配信先と公開鍵を伴って生成する
+
+- **WHEN** Android で、遠隔の停止フラグが立っていない状態で `FanboxRepositoryImpl` が `Fanbox` を生成する
+- **THEN** アプリは配信先の manifest URL、信頼する鍵名、Ed25519 公開鍵を渡す
+
+#### Scenario: iOS で guest を起動しない
+
+- **WHEN** iOS で `FanboxRepositoryImpl` が `Fanbox` を生成する
+- **THEN** アプリは配信先も公開鍵も渡さず、`post.info` は直接経路で処理される
+
+#### Scenario: 公開鍵が Ed25519 の鍵長を満たす
+
+- **WHEN** 埋め込んだ公開鍵を復号する
+- **THEN** 32 バイトになる
+
+### Requirement: 遠隔からの解析処理の取得を README に記載する
+
+アプリが遠隔から解析処理を取得して実行することと、その用途、対象が Android であること、および遠隔から実行を停止できることを README に記載しなければならない（MUST）。停止スイッチの記載には、取得前および取得失敗時に guest を起動する側へ倒すこと、および停止が各端末へ届くまでに遅延があることを含めなければならない（MUST）。
+
+Privacy Policy は本リポジトリの外（`https://www.matsumo.me/application/pixiview/privacy_policy`）にあるため、本 change では変更できない。記載の要否の判断と反映は人間へ引き継ぐ。
+
+#### Scenario: README を読む
+
+- **WHEN** README を読む
+- **THEN** 遠隔から解析処理を取得する旨、用途を FANBOX の仕様変更への追従に限る旨、対象が Android である旨、および遠隔から実行を停止できる旨とその既定値・遅延が記載されている
+
+## ADDED Requirements
+
+### Requirement: 配信済み guest の実行を遠隔から停止できる
+
+Android では、アプリは Firebase Remote Config の boolean フラグ `android_guest_route_kill_switch` を参照し、値が `true` の場合は配信先と公開鍵を渡さずに `Fanbox` を生成しなければならない（MUST）。この場合 `post.info` は組み込みの直接経路で処理され、配信先への取得は試みられない。
+
+これは配信元（manifest の巻き戻しや削除）とは独立した停止手段である。配信元が応答を返さない場合、配信元を操作できない場合、および配信物と無関係に遠隔コードの実行を止める必要が生じた場合に、アプリ側の判断だけで guest の起動を止める。
+
+参照は `Fanbox` の生成時に一度だけ行い、活性化済みの値を同期的に読む。フラグの取得は背景で行い、取得した値は次回のアプリ起動時に反映される。したがって停止を決めてから端末へ届くまでには、取得間隔の経過と次回起動の両方を要する遅延がある。
+
+活性化済みの値が無い場合、および参照が失敗した場合、アプリは guest を起動する側へ倒さなければならない（MUST）。フラグを「停止」の向きで定義することで、値が無い boolean に Remote Config が返す `false` がそのまま「停止していない」を意味する。これにより Remote Config へ到達できない端末でも配信済みの guest は成立し続ける。
+
+参照が失敗した場合、アプリはその失敗を記録しなければならない（MUST）。この失敗の症状は「停止フラグを倒しても止まらない」であり、記録が無ければ観測できない。記録そのものが失敗した場合も、アプリはその失敗を伝播させてはならない（MUST NOT）。
+
+#### Scenario: 停止フラグが立っている
+
+- **WHEN** Android で `android_guest_route_kill_switch` が `true` として活性化されている状態で `Fanbox` を生成する
+- **THEN** アプリは配信先も公開鍵も渡さず、`post.info` は直接経路で処理される
+
+#### Scenario: 停止フラグを一度も取得できていない
+
+- **WHEN** Android で Remote Config の活性化済みの値が無い状態で `Fanbox` を生成する
+- **THEN** アプリは配信先と公開鍵を渡し、guest を起動する
+
+#### Scenario: Remote Config の参照が失敗する
+
+- **WHEN** Android で Remote Config の参照が例外を送出する
+- **THEN** アプリはその例外を伝播させず、失敗を記録したうえで配信先と公開鍵を渡して guest を起動する
+
+#### Scenario: 参照の失敗を記録できない
+
+- **WHEN** Android で Remote Config の参照が失敗し、その失敗の記録もまた例外を送出する
+- **THEN** アプリはいずれの例外も伝播させず、配信先と公開鍵を渡して guest を起動する
+
+#### Scenario: 停止フラグを倒した後に再起動する
+
+- **WHEN** 停止フラグを `true` へ倒し、取得間隔の経過後にアプリを再起動する
+- **THEN** アプリは guest を起動しない

--- a/openspec/changes/add-guest-route-kill-switch/tasks.md
+++ b/openspec/changes/add-guest-route-kill-switch/tasks.md
@@ -16,5 +16,5 @@
 - [x] 3.1 `./gradlew :core:repository:testAndroidHostTest :core:repository:detekt` を通す（AGP 9 の KMP では `test` ではなくこのタスク名）
 - [x] 3.2 リリースビルドが通ることを確認する
 - [x] 3.3 Firebase コンソールに `android_guest_route_kill_switch` を boolean として作成する（リポジトリ外の作業。人間が行う）
-- [ ] 3.4 実機で、フラグを `true` へ倒して再起動すると guest が起動しないこと、`false` へ戻して再起動すると起動することを確認する（人間が行う）
-- [ ] 3.5 実機で、新規インストール直後の初回起動（Remote Config を一度も取得していない状態）で guest が起動することを確認する。design.md D3 が依拠する「値の無い boolean は `false` を返す」の成立確認（人間が行う）
+- [x] 3.4 実機で、フラグを `true` へ倒して再起動すると guest が起動しないこと、`false` へ戻して再起動すると起動することを確認する（人間が行う）
+- [x] 3.5 実機で、新規インストール直後の初回起動（Remote Config を一度も取得していない状態）で guest が起動することを確認する。design.md D3 が依拠する「値の無い boolean は `false` を返す」の成立確認（人間が行う）

--- a/openspec/changes/add-guest-route-kill-switch/tasks.md
+++ b/openspec/changes/add-guest-route-kill-switch/tasks.md
@@ -1,0 +1,20 @@
+# Tasks
+
+## 1. 停止スイッチの参照を実装する
+
+- [ ] 1.1 `FanboxFactory.android.kt` に停止フラグのキーと取得間隔の定数を追加する
+- [ ] 1.2 Remote Config を参照する private 関数を追加する。`setConfigSettingsAsync` の完了後に `fetchAndActivate` を開始し、活性化済みの値を `getBoolean` で読む。参照全体を `runCatching` で包み、失敗時は `recordException` で記録したうえで `false`（guest を起動する）へ倒す。`recordException` の呼び出し自体も `runCatching` で守る（`Firebase.crashlytics` の解決が同じ理由で失敗しうるため）
+- [ ] 1.3 `createFanbox` を、停止フラグが立っている場合に配信先と公開鍵を渡さない分岐に変える
+
+## 2. ドキュメントを更新する
+
+- [ ] 2.1 README の `Remote parsing updates` に停止スイッチを追記する。停止できること、既定は guest を起動する側であること、反映までに取得間隔と次回起動を要すること
+- [ ] 2.2 `docs/` と README を `guest` / `Remote Config` / `kill switch` で grep し、誤りになった記述が無いことを確認する
+
+## 3. 検証する
+
+- [ ] 3.1 `./gradlew :core:repository:testAndroidHostTest :core:repository:detekt` を通す（AGP 9 の KMP では `test` ではなくこのタスク名）
+- [ ] 3.2 リリースビルドが通ることを確認する
+- [ ] 3.3 Firebase コンソールに `android_guest_route_kill_switch` を boolean として作成する（リポジトリ外の作業。人間が行う）
+- [ ] 3.4 実機で、フラグを `true` へ倒して再起動すると guest が起動しないこと、`false` へ戻して再起動すると起動することを確認する（人間が行う）
+- [ ] 3.5 実機で、新規インストール直後の初回起動（Remote Config を一度も取得していない状態）で guest が起動することを確認する。design.md D3 が依拠する「値の無い boolean は `false` を返す」の成立確認（人間が行う）

--- a/openspec/changes/add-guest-route-kill-switch/tasks.md
+++ b/openspec/changes/add-guest-route-kill-switch/tasks.md
@@ -2,19 +2,19 @@
 
 ## 1. 停止スイッチの参照を実装する
 
-- [ ] 1.1 `FanboxFactory.android.kt` に停止フラグのキーと取得間隔の定数を追加する
-- [ ] 1.2 Remote Config を参照する private 関数を追加する。`setConfigSettingsAsync` の完了後に `fetchAndActivate` を開始し、活性化済みの値を `getBoolean` で読む。参照全体を `runCatching` で包み、失敗時は `recordException` で記録したうえで `false`（guest を起動する）へ倒す。`recordException` の呼び出し自体も `runCatching` で守る（`Firebase.crashlytics` の解決が同じ理由で失敗しうるため）
-- [ ] 1.3 `createFanbox` を、停止フラグが立っている場合に配信先と公開鍵を渡さない分岐に変える
+- [x] 1.1 `FanboxFactory.android.kt` に停止フラグのキーと取得間隔の定数を追加する
+- [x] 1.2 Remote Config を参照する private 関数を追加する。`setConfigSettingsAsync` の完了後に `fetchAndActivate` を開始し、活性化済みの値を `getBoolean` で読む。参照全体を `runCatching` で包み、失敗時は `recordException` で記録したうえで `false`（guest を起動する）へ倒す。`recordException` の呼び出し自体も `runCatching` で守る（`Firebase.crashlytics` の解決が同じ理由で失敗しうるため）
+- [x] 1.3 `createFanbox` を、停止フラグが立っている場合に配信先と公開鍵を渡さない分岐に変える
 
 ## 2. ドキュメントを更新する
 
-- [ ] 2.1 README の `Remote parsing updates` に停止スイッチを追記する。停止できること、既定は guest を起動する側であること、反映までに取得間隔と次回起動を要すること
-- [ ] 2.2 `docs/` と README を `guest` / `Remote Config` / `kill switch` で grep し、誤りになった記述が無いことを確認する
+- [x] 2.1 README の `Remote parsing updates` に停止スイッチを追記する。停止できること、既定は guest を起動する側であること、反映までに取得間隔と次回起動を要すること
+- [x] 2.2 `docs/` と README を `guest` / `Remote Config` / `kill switch` で grep し、誤りになった記述が無いことを確認する
 
 ## 3. 検証する
 
-- [ ] 3.1 `./gradlew :core:repository:testAndroidHostTest :core:repository:detekt` を通す（AGP 9 の KMP では `test` ではなくこのタスク名）
-- [ ] 3.2 リリースビルドが通ることを確認する
-- [ ] 3.3 Firebase コンソールに `android_guest_route_kill_switch` を boolean として作成する（リポジトリ外の作業。人間が行う）
+- [x] 3.1 `./gradlew :core:repository:testAndroidHostTest :core:repository:detekt` を通す（AGP 9 の KMP では `test` ではなくこのタスク名）
+- [x] 3.2 リリースビルドが通ることを確認する
+- [x] 3.3 Firebase コンソールに `android_guest_route_kill_switch` を boolean として作成する（リポジトリ外の作業。人間が行う）
 - [ ] 3.4 実機で、フラグを `true` へ倒して再起動すると guest が起動しないこと、`false` へ戻して再起動すると起動することを確認する（人間が行う）
 - [ ] 3.5 実機で、新規インストール直後の初回起動（Remote Config を一度も取得していない状態）で guest が起動することを確認する。design.md D3 が依拠する「値の無い boolean は `false` を返す」の成立確認（人間が行う）


### PR DESCRIPTION
Closes #139

## 概要

Android の `createFanbox` が Firebase Remote Config の停止フラグ `android_guest_route_kill_switch` を参照し、立っている場合は配信先と公開鍵を渡さずに `Fanbox` を生成する。配信先への取得そのものが起きないため、配信元（fankt 側の GitHub Pages）を操作できない状況でも guest を止められる。

設計の意図と決定は `openspec/changes/add-guest-route-kill-switch/` にある。

## issue #139 の前提の訂正

issue は「暫定手段（manifest の巻き戻し・404）は manifest へ到達できる端末にのみ届く」としているが、これは成立しない。fankt の `ZiplineGuestLoader.newLoader()` は `ZiplineLoader` に `withCache` を渡しておらず、`FreshnessChecker` も `AlwaysStale` であるため、bundle のローカルキャッシュが存在しない。到達できない端末は guest を起動できず、既に直接経路で動作している。

停止スイッチが実際に埋めるのは次の 3 つで、proposal.md に記載した。

1. manifest の取得が返らない（fankt は明示的なタイムアウトを設定していないため、404 にしても取得の試行自体は起きる）
2. 配信元を操作できない
3. 配信物と無関係に遠隔コード実行の停止が必要になる

## 受け入れ条件との対応

issue の受け入れ条件は #143 による Android 限定化を受けて issue のコメントで改訂されている。

| 改訂後の受け入れ条件 | 状態 |
| --- | --- |
| Android で Remote Config を参照し guest 経路の有効・無効を決める | 本 PR |
| `FanboxRepositoryImpl` の `Fanbox` 生成へ配線する | 本 PR |
| fetch 前および fetch 失敗時の既定値を決める | 本 PR（design.md D3、README へ反映） |
| リリースビルドが通る | 検証済み |
| iOS へ Firebase SDK を導入する（改訂前の条件） | non-goal。iOS は guest を起動しない |

issue の title は改訂前の「Firebase を iOS に導入し」のままである。

## 検証

HEAD `a94a8ee43dbc3e3ebe9b9509670163298fa66425` で実行。

| コマンド | 結果 |
| --- | --- |
| `./gradlew :core:repository:testAndroidHostTest :core:repository:detekt :androidApp:assembleRelease` | BUILD SUCCESSFUL（2m 1s）。detekt の指摘 0 件 |

Scenario ごとの証明は次のとおり。

| Scenario | 証明 |
| --- | --- |
| 停止フラグが立っている | 該当なし。Remote Config は端末上の Firebase サービスに依存し `androidHostTest`（JVM）から動かせない。分岐は `if (停止フラグ) 直接経路 else guest` の 1 段で、単体テストで固定できるのはこの自明な対応だけになる |
| 停止フラグを一度も取得できていない | 同上。実機確認へ委ねる（下記） |
| Remote Config の参照が失敗する | 同上 |
| 参照の失敗を記録できない | 同上 |
| 停止フラグを倒した後に再起動する | 同上 |
| 公開鍵が Ed25519 の鍵長を満たす | `GuestDeliveryKeyTest.trustedPublicKeyDecodesToAnEd25519Key`（既存、本 PR で変更なし） |
| README を読む | docs 変更のため最小チェック不要 |

## 独立反証

clean context の falsifier（gpt-5.6-sol / high）で 2 往復。blocking は最終的にゼロ。

| # | 内容 | 結果 |
| --- | --- | --- |
| 1-A | `KoinStartup` が `Application.onCreate()` より前に走る事実が設計の根拠に含まれていない | CLOSED（design.md に追記。結論自体は不変） |
| 3-A | `runCatching` の失敗が無言で、`FanboxGuestHost` の報告パターンと不整合 | CLOSED（`recordException` を追加） |
| NEW | 3-A の修正で追加した `recordException` が `runCatching` の外側にあり、`FirebaseApp` 未初期化時に D5 の invariant を破る | CLOSED（記録呼び出しも `runCatching` で保護） |
| — | D3 が依拠する SDK 挙動に出典が無い | CLOSED（出典を追記し、実機確認を tasks 3.5 に追加） |

NEW の発動条件は 1-A が指摘した将来劣化のシナリオそのものだった。`FirebaseApp` が未初期化なら `Firebase.remoteConfig` も `Firebase.crashlytics` も同じ理由で例外を投げるため、退避のための記録がクラッシュになっていた。

## 人間に確認してほしいこと

- **実機確認 2 件が未実施**（tasks 3.4 / 3.5）。`minimumFetchIntervalInSeconds = 3600` のため、同じ端末で値を変えても最大 1 時間反映されない。手順のあいだはアプリをアンインストールして入れ直すとカウンタごとリセットされる
  - 3.4: コンソールで `true` へ倒して再起動すると guest が起動しない。`false` へ戻して再起動すると起動する
  - 3.5: 新規インストール直後の初回起動で guest が起動する。design.md D3 が依拠する「活性化済みの値も既定値も無い boolean に Remote Config は `false` を返す」の成立確認。この前提は本リポジトリからは検証できない
- **Firebase コンソールのキー名との一致**。`android_guest_route_kill_switch` の綴りが食い違うと、症状は「フラグを倒しても止まらない」という無言の失敗になる
- **`FirebaseApp` が無い状態は観測できない**。`createFanbox` が `Application.onCreate()` より前に走るようになると、停止スイッチは無言で効かなくなり記録先も同時に失われる。現状この経路は存在しない（`createdAtStart` 不使用、Koin へ依存する eager Initializer 不在）が、成立条件はコードで強制されていない
- **Privacy Policy への記載の要否**。リポジトリ外（`https://www.matsumo.me/application/pixiview/privacy_policy`）にあり本 PR では変更できない
- **issue の title が改訂前のまま**。「Firebase を iOS に導入し Remote Config で guest 経路の kill switch を実装する」だが、本 PR の範囲は Android のみ

## ドキュメント影響

あり（`README.md` の `Remote parsing updates` 節）。`docs/` は存在しない。

## archive

本 PR は単一 PR 配送のため change の archive を含まない。merge 後に `openspec archive add-guest-route-kill-switch --yes` の差分だけを載せた `chore:` PR で回収する。

## レビュー結果と残指摘

clean context の reviewer（Opus 5）で 1 pass。検証記録の SHA と HEAD の一致を照合したうえでレビューされている。

| severity | 件数 | 裁定 |
| --- | --- | --- |
| must-fix | 0 | — |
| should | 0 | — |
| nit | 1 | 過剰（記録のみ）。`FanboxFactory.android.kt` の 2 つの `return Fanbox(...)` が共通の 3 引数を重複して書いている。`FanboxFactory.ios.kt` と既存の直接経路も同じ形であり、揃えて残す |

reviewer が checked で閉じた主な論点は次のとおり。

- `runCatching` が `CancellationException` を飲む点。`createFanbox` は non-suspend で、`isGuestRouteKilled()` 内にサスペンションポイントが無いため cancellation 伝播を要する文脈が存在しない
- `setConfigSettingsAsync(...).addOnCompleteListener { fetchAndActivate() }` の順序。listener は settings 書き込みの完了後にのみ発火するため、初回でも既定の 12 時間で fetch が走る競合は起きない
- iOS への影響漏れ。Firebase の参照は `androidMain` にのみ現れ、`commonMain` / `iosMain` に一切入っていない
- `createFanbox` の呼び出し元は `FanboxRepository.kt:239` の 1 箇所のみ。2 つのコンストラクタは同一インターフェースを返し、`ioDispatcher` と `cookieStorage` は両分岐で同一インスタンスを渡す。下流（paging source、cache、cookie storage）に guest か直接経路かで分岐する既存コードは無い

isolated_unverified で閉じた観点が 2 件ある。いずれも Firebase SDK の内部挙動で本リポジトリからは検証できず、design.md の残余リスク節に記録済みである。

- `addOnCompleteListener` の実行スレッド
- `getBoolean` が初回に同期のディスク読み出しを起こす可能性

## 実機確認

Pixel 10 Pro XL（Android 17）に debug ビルドを入れ、`FanboxZipline` スレッドの有無で guest の起動を判別した。このスレッドは配信設定を伴って `Fanbox` を生成した場合にのみ張られる（`FanboxGuestHost` の `newSingleThreadContext("FanboxZipline")`）。アプリが実際に読んだ値は端末上の Remote Config の保存先で照合した。

```
adb shell "run-as caios.android.fanbox.debug cat files/frc_1:561281916572:android:85a0c0e2e341d0fdab1759_firebase_activate.json"
```

| 状態 | 活性化済みの値 | `FanboxZipline` スレッド | 判定 |
| --- | --- | --- | --- |
| 停止フラグ `false` | `false` | あり | guest が起動する |
| データ削除直後の起動 | 値なし | あり | 活性化済みの値が無い状態で guest が起動する |
| 上記の状態から再起動 | `true` | なし | guest が起動しない |

いずれも投稿詳細を開いたうえで観測した。guest は最初の `post.info` で遅延ロードされるため、起動しただけではスレッドは張られない。

2 行目が design.md D3 の前提「活性化済みの値も既定値も無い boolean に Remote Config は `false` を返す」の成立を示す。この前提は本リポジトリからは検証できないと記載していたが、実測で埋まった。

3 行目が停止スイッチの反映が次回起動時であること（design.md D2）と合わせて成立している。データ削除は取得間隔をリセットすると同時に活性化済みの値も消すため、削除直後の起動は必ず guest 側から始まる。

診断ログ（`Napier.w` 経由）はいずれの状態でも出力されなかった。fankt が診断を報告するのは失敗と退避のときだけであり、正常に読み込めた guest は何も出力しない。ログの不在は経路の判別に使えない。

## 終了状態

**APPROVED。**

G1 から G5 がすべて成立している。

- G1: `openspec validate --strict` 通過。独立反証の blocking はゼロ
- G2: 受け入れ条件を満たす実装があり、Scenario の証明は上記の実機確認が担う
- G3: 妥当と裁定した must-fix / should はゼロ
- G4: 未確認だった実機確認 2 件が観測可能な証拠で checked へ再判定された
- G5: CI の required checks が green

full validation は `a94a8ee4` で実施済み（`./gradlew :core:repository:testAndroidHostTest :core:repository:detekt :androidApp:assembleRelease` → BUILD SUCCESSFUL）。以降の差分は `tasks.md` のチェックのみで、コードと設定を含まない。

