### PR TITLE
Propose app-owned FANBOX models to replace fankt domain models

### DIFF
--- a/openspec/changes/replace-fankt-models-with-app-owned/.openspec.yaml
+++ b/openspec/changes/replace-fankt-models-with-app-owned/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-17

--- a/openspec/changes/replace-fankt-models-with-app-owned/design.md
+++ b/openspec/changes/replace-fankt-models-with-app-owned/design.md
@@ -1,0 +1,113 @@
+## Context
+
+`FanboxRepository` は fankt の domain model をそのまま返し、`feature/*` と `core/ui` はそれを直接描画している。`me.matsumo.fankt` を参照するファイルは 102、import 行は約 260（うち `domain.model.*` が 219）。fankt のモデルが変わると UI 層まで一斉に壊れる。
+
+fankt 側の domain model は 24 ファイル / 749 行で、大半は素朴な `data class` である。例外は `FanboxPostDetail`（272 行）で、記事本文を表す `Body` の sealed 階層と派生プロパティ（`browserUrl` / `Body.imageItems` / `Block.Embed.url` / `FileItem.asImageItem()`）を持つ。
+
+`core/datastore` の 11 ファイルも fankt を参照するが、内訳は cookie / session の基盤契約（`FanboxCookieStorage` / `FanboxCookieRecord`）が大半で、domain model を使うのは `BookmarkDataStore`（`FanboxPost` を JSON で丸ごと保存）と `BlockDataStore`（`FanboxCreatorId`）の 2 本である。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- `FanboxRepository` の public API、`feature/*`、`core/ui`、`core/model`、`shared` から `me.matsumo.fankt` の型を外す
+- 既存ユーザーのブックマークとブロック設定が、更新後も同じように読める
+- fankt のモデルが変わったとき、修正が `core/repository` の変換層で止まる
+
+**Non-Goals:**
+
+- `core/datastore` から fankt を外すこと。cookie / session 系は fankt が要求する基盤契約であり、domain model ではない
+- `FanboxException` / `FanboxErrorKind` / `FanboxListItemSchemaMismatch` の置き換え。これらは例外と診断の契約で、`fanbox-error-classification` と `fanbox-schema-diagnostics` が既に規定している
+- fankt のバージョン更新
+- app-owned モデルへの独自フィールド追加。今回は fankt のモデルと 1:1 の写像に限る
+
+## Decisions
+
+### D1 命名は `me.matsumo.fanbox.core.model.fanbox.*` で `Fanbox` prefix を持たない（ユーザー確認済み）
+
+`Post` / `PostDetail` / `CreatorDetail` / `PostId` のように書く。fankt 型と同名にすると import の取り違えがコンパイルを通ってしまうため、名前で区別できる状態を選ぶ。`core/model` の既存型（`Setting` / `Flag` / `Version`）とも揃う。
+
+採らなかった案：`FanboxPost` のまま package だけ変える。`core/model` の既存 `FanboxDownloadItems` / `FanboxErrorKind` とは揃うが、同名の型が 2 つ存在する状態を全 102 ファイルへ持ち込む。
+
+### D2 ID は value class を維持する（ユーザー確認済み）
+
+`@JvmInline value class PostId(val value: String)` として fankt と 1:1 に対応させる。`PostId` と `CreatorId` の取り違えをコンパイラが検出できる状態を保つ。`value` が `String` である点も fankt と同じなので、`NavTypes.kt` の URL エンコード（`encode = { it.value }`）と `BlockDataStore` の `stringSetPreferencesKey` はどちらも表現が変わらない。
+
+採らなかった案：素の `String`。変換層は消えるが、参照数の多い `PostId`（142）と `CreatorId`（140）で型の取り違えが起きうる。
+
+### D3 永続化の形式は変えない（ユーザー確認済み）
+
+`BookmarkDataStore` は `Json.encodeToString(FanboxPost.serializer(), post)` で fankt の `FanboxPost` を丸ごと保存している。この serializer を使い続け、`core/datastore` は変更しない。`FanboxRepositoryImpl` が app-owned の `Post` と fankt の `FanboxPost` を相互変換して datastore へ渡す。
+
+保存済み JSON に触らないため migration は発生しない。#117（bookmark の JSON 非互換）と同種のリスクを持ち込まない。
+
+採らなかった案：app-owned モデルで保存し直す。fankt から完全に切れるが、既存ユーザーのブックマークに対する migration が必要になる。
+
+**この決定の帰結（residual risk）**：app-owned の `Post` に fankt へ存在しないフィールドを足すと、その値は保存されない。今回の Non-Goals で 1:1 写像に限っているため現時点では顕在化しないが、将来 `Post` を拡張する際はこの制約に当たる。
+
+### D4 変換層は `core/repository` 内の `mapper` package へ置く（agent 仮決め）
+
+`me.matsumo.fanbox.core.repository.mapper` に fankt → app の拡張関数を置く。専用 module を作らない。`core/repository` は既に fankt と `core/model` の両方に依存しており、新しい依存も新しいビルド設定も要らない。
+
+issue #137 の未決事項「変換層の置き場所（`core/repository` 内か、専用 module か）」への回答である。
+
+### D5 変換は fankt → app を全型に用意し、app → fankt は必要な 4 種に限る（agent 仮決め）
+
+逆方向が要るのは次の経路だけである。
+
+| 逆変換が要る型 | 理由 |
+| --- | --- |
+| `PostId` / `CreatorId` / `UserId` / `CommentId` | `FanboxRepository` の引数を fankt の API へ渡す |
+| `Post` | `BookmarkDataStore.save` / `remove` が fankt の serializer を使う（D3） |
+| `Cursor` | paging で fankt へ次ページ位置を渡す |
+
+`PostDetail` / `CreatorDetail` / `Comment` / `Bell` などは表示専用で、アプリから fankt へ戻す経路がない。使われない逆変換を書かない。
+
+### D6 ページング型もアプリ所有にする（agent 仮決め）
+
+`PageCursorInfo<T>` / `PageNumberInfo<T>` / `PageOffsetInfo<T>` / `FanboxCursor` は `me.matsumo.fankt.fanbox.domain` にあり、`FanboxRepository` の戻り値に現れる。受け入れ条件が `me.matsumo.fankt` の型全般を対象にしているため、これらも `core/model/fanbox` へ写す（`PageCursorInfo` / `PageNumberInfo` / `PageOffsetInfo` / `Cursor`）。
+
+### D7 派生プロパティは app-owned モデルへ移植する（agent 仮決め）
+
+`FanboxPostDetail.browserUrl`、`Body.imageItems` / `fileItems`、`Block.Embed.url`、`Body.Video.url`、`FileItem.asImageItem()` / `asVideoItem()` は fankt 側で計算されている。app-owned モデルへ同じ実装を移す。
+
+これは意図した重複である。分離の目的は「fankt が変わってもアプリが壊れない」ことであり、これらの派生ロジックが fankt 側で変わってもアプリは追随しなくてよい。逆に、FANBOX の URL 形式が変わった場合はアプリ側も直す必要がある。
+
+### D8 `FanboxDownloadItems.RequestType.Post` を `WholePost` へ改名する（agent 仮決め）
+
+`RequestType.Post` は `val post: FanboxPost?` を持つ。app-owned 型を `Post` にすると、この入れ子クラスの本体では `Post` が自分自身へ解決され、フィールドの型を書けない。
+
+`RequestType.WholePost` へ改名する。参照は 5 ファイル 12 箇所で、いずれも `FanboxDownloadItems.RequestType.Post` の形で完全に修飾されている。
+
+採らなかった案：この 1 ファイルだけ import alias を使う。型の別名がファイルごとに異なる状態を作るため採らない。
+
+`Destination.PostDetail` と `PostsLog.Comment` も新しいモデル名と重なるが、どちらも所有クラス経由（`Destination.PostDetail`）で参照されており衝突しない。
+
+### D9 `kotlin.time.Instant` はそのまま使う（agent 仮決め）
+
+fankt の日時は `kotlin.time.Instant`（stdlib）である。アプリ独自の日時型は作らない。fankt が別の日時型へ移った場合は変換層で吸収する。
+
+### D10 配送は 4 段の Stack とする（agent 仮決め）
+
+`FanboxRepository` の戻り値型を変えた瞬間に全呼び出し元がコンパイルを失うため、変換層の導入と呼び出し元の置換は 1 つのコミット単位から分けられない。分離できるのはモデル定義だけである。
+
+| 段 | branch | 内容 |
+| --- | --- | --- |
+| 1 | `feature/app-owned-fanbox-models` | proposal / delta spec / design / tasks |
+| 2 | `feature/app-owned-fanbox-models-defs` | `core/model/fanbox/*` のモデル定義と変換層、変換のテスト（純追加。既存コードに触れない） |
+| 3 | `feature/app-owned-fanbox-models-swap` | `FanboxRepository` の public API と全呼び出し元の置換（atomic） |
+| 4 | `feature/app-owned-fanbox-models-archive` | main spec への同期と archive |
+
+2 段目は 3 段目が無ければ誰にも使われないが、「fankt のモデルと形が一致しているか」「変換が値を落としていないか」を 3 段目の機械的な置換 90 ファイルと切り離してレビューできる。この分離が Stack を選ぶ理由である。
+
+## Risks / Trade-offs
+
+- **変換でフィールドを取り違える** → 変換のテストで全フィールドを固定する。取り違えは「値が入れ替わって表示される」形で出るため、コンパイルでは捕まらない
+- **`Body` の sealed 階層の variant を取りこぼす** → `when` を exhaustive に書き、全 variant を通す変換テストを置く。`Unknown` variant（`rawJson` / `rawBodyJson`）の保持も含める
+- **`BookmarkDataStore` の JSON 保存形式が意図せず変わる** → `core/datastore` を変更しないことで構造的に防ぐ。保存済み JSON を読んで `Post` として返せることをテストで固定する
+- **90 ファイルの機械的置換で挙動が変わる** → 置換は import と型名の差し替えに限り、ロジックへ触れない。既存テストの通過と両プラットフォームのコンパイルで担保する
+- **fankt の派生ロジック（D7）がアプリ側と乖離する** → 意図した乖離である。fankt が `Embed.url` の対応サービスを増やしてもアプリは追随しない。追随が要る場合は変換層ではなくアプリ側のモデルを直す
+
+## Open Questions
+
+なし。issue #137 の未決事項 3 件（変換層の置き場所 / ID の表現 / 段階移行の可否）は D4 / D2 / D10 で解決した。

--- a/openspec/changes/replace-fankt-models-with-app-owned/design.md
+++ b/openspec/changes/replace-fankt-models-with-app-owned/design.md
@@ -31,7 +31,9 @@ fankt 側の domain model は 24 ファイル / 749 行で、大半は素朴な 
 
 ### D2 ID は value class を維持する（ユーザー確認済み）
 
-`@JvmInline value class PostId(val value: String)` として fankt と 1:1 に対応させる。`PostId` と `CreatorId` の取り違えをコンパイラが検出できる状態を保つ。`value` が `String` である点も fankt と同じなので、`NavTypes.kt` の URL エンコード（`encode = { it.value }`）と `BlockDataStore` の `stringSetPreferencesKey` はどちらも表現が変わらない。
+`@JvmInline value class PostId(val value: String)` として fankt と 1:1 に対応させる。`PostId` と `CreatorId` の取り違えをコンパイラが検出できる状態を保つ。
+
+内側の型は fankt に合わせる。`UserId` だけが `Long` で、残りの 6 種（`PostId` / `PostItemId` / `CreatorId` / `CommentId` / `PlanId` / `NewsLetterId`）は `String` である。`NavTypes.kt` が符号化するのは `PostId` と `CreatorId` の 2 種で、どちらも `encode = { it.value }` の独自ラムダを通るため、`@Serializable` の有無によらず符号化文字列は変わらない。`BlockDataStore` の `stringSetPreferencesKey` も `CreatorId.value` をそのまま使う。
 
 採らなかった案：素の `String`。変換層は消えるが、参照数の多い `PostId`（142）と `CreatorId`（140）で型の取り違えが起きうる。
 
@@ -63,15 +65,44 @@ issue #137 の未決事項「変換層の置き場所（`core/repository` 内か
 
 `PostDetail` / `CreatorDetail` / `Comment` / `Bell` などは表示専用で、アプリから fankt へ戻す経路がない。使われない逆変換を書かない。
 
+**`core/repository` には `FanboxRepository` 以外にも、fankt 型を公開シグネチャに持ち `feature/*` から呼ばれるものが 2 つある。** どちらも逆変換を必要とせず、型の差し替えだけで済む。
+
+| 対象 | 公開シグネチャ | 逆変換が不要な理由 |
+| --- | --- | --- |
+| `TranslationRepository.translate` | `FanboxPostDetail` / `PageOffsetInfo<FanboxComment>` を受けて同じ型を返す | 翻訳 API へ送る payload はアプリ所有の `TransPostDetail` / `TransComments` であり、fankt の型は serialize されない。`core/model/translation` の `toTrans()` / `toFanboxPostDetail()` / `toFanboxComments()` をアプリ所有のモデルへ差し替えれば、fankt へ戻す経路は消える |
+| `DownloadPostsRepository` | `requestDownloadPost(post: FanboxPost, …)` / `requestDownloadImages(…, images: List<FanboxPostDetail.ImageItem>)` / `getSaveDirectory(requestType: …)` | 受け取った投稿は保存先ディレクトリ名（`post.user?.name`）と一覧表示にしか使わず、fankt の API へは渡らない |
+
+`core/model/translation` は受け入れ条件が名指しする `core/model` の一部であるため、`Trans*` に fankt 型を残す選択肢は取れない。
+
 ### D6 ページング型もアプリ所有にする（agent 仮決め）
 
 `PageCursorInfo<T>` / `PageNumberInfo<T>` / `PageOffsetInfo<T>` / `FanboxCursor` は `me.matsumo.fankt.fanbox.domain` にあり、`FanboxRepository` の戻り値に現れる。受け入れ条件が `me.matsumo.fankt` の型全般を対象にしているため、これらも `core/model/fanbox` へ写す（`PageCursorInfo` / `PageNumberInfo` / `PageOffsetInfo` / `Cursor`）。
 
-### D7 派生プロパティは app-owned モデルへ移植する（agent 仮決め）
+### D7 派生メンバーは、アプリが呼ぶものだけを移植する（agent 仮決め）
 
-`FanboxPostDetail.browserUrl`、`Body.imageItems` / `fileItems`、`Block.Embed.url`、`Body.Video.url`、`FileItem.asImageItem()` / `asVideoItem()` は fankt 側で計算されている。app-owned モデルへ同じ実装を移す。
+fankt 0.1.3 の domain model が持つ派生メンバーは次の 13 個である（`model/*.kt` と `FanboxCursor.kt` の全数）。
 
-これは意図した重複である。分離の目的は「fankt が変わってもアプリが壊れない」ことであり、これらの派生ロジックが fankt 側で変わってもアプリは追随しなくてよい。逆に、FANBOX の URL 形式が変わった場合はアプリ側も直す必要がある。
+| # | 派生メンバー | 移植 |
+| --- | --- | --- |
+| 1 | `FanboxPostDetail.browserUrl` | する |
+| 2 | `FanboxPostDetail.Body.imageItems` | する |
+| 3 | `FanboxPostDetail.Body.fileItems` | する |
+| 4 | `FanboxPostDetail.Body.Article.Block.Embed.url` | する |
+| 5 | `FanboxPostDetail.Body.Video.url` | する |
+| 6 | `FanboxPostDetail.FileItem.asImageItem()` | する |
+| 7 | `FanboxPostDetail.FileItem.asVideoItem()` | する |
+| 8 | `FanboxCreatorDetail.supportingBrowserUrl` | する |
+| 9 | `FanboxCreatorDetail.ProfileItem.Video.url` | する |
+| 10 | `FanboxCreatorPlan.planBrowserUrl` | する |
+| 11 | `FanboxCreatorPlan.supportingBrowserUrl` | する |
+| 12 | `FanboxCreatorDetail.Platform.fromUrl(url)` | しない |
+| 13 | `FanboxPaymentMethod.fromString(string)` | しない |
+
+12 と 13 は fankt がレスポンスからモデルを組み立てるための companion factory で、アプリからの呼び出しは 1 件もない。アプリが受け取るのは組み立て済みの `ProfileLink.link` と `paymentMethod` である。移植すると使われないコードになるうえ、`Platform.fromUrl` は fankt の `internal` な `FanboxUrlParts` に依存するため、アプリ側では URL パーサを新たに用意することになる。書かない。
+
+`FanboxCursor.kt` の `String.translateToCursor()` も `internal` で、fankt が `nextUrl` を解釈するための関数である。アプリの公開契約には現れない。
+
+1〜11 は意図した重複である。分離の目的は「fankt が変わってもアプリが壊れない」ことであり、これらの派生ロジックが fankt 側で変わってもアプリは追随しなくてよい。逆に、FANBOX の URL 形式が変わった場合はアプリ側も直す必要がある。
 
 ### D8 `FanboxDownloadItems.RequestType.Post` を `WholePost` へ改名する（agent 仮決め）
 

--- a/openspec/changes/replace-fankt-models-with-app-owned/proposal.md
+++ b/openspec/changes/replace-fankt-models-with-app-owned/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+PixiView は fankt の domain model（`me.matsumo.fankt.fanbox.domain.model.*`）を `FanboxRepository` の public API、`feature/*`、`core/ui`、`core/model` へそのまま露出している。fankt のモデルが変わるたびに UI 層まで修正が波及し、fankt 0.1.0 への追従（#122）では #114 / #115 / #119 / #120 と UI 層に及ぶ追従 issue が 4 本立った。
+
+アプリが所有するモデルへ変換する層を repository に置き、fankt のモデルをアプリの公開契約から外す。
+
+## What Changes
+
+- `core/model` に app-owned のモデル（`me.matsumo.fanbox.core.model.fanbox.*`）を定義する。fankt の domain model 24 ファイル / 749 行に対応する
+- `core/repository` に fankt モデル ↔ app-owned モデルの変換層を置く
+- **BREAKING**（アプリ内部の契約）：`FanboxRepository` の public API の型が app-owned モデルへ変わる。`feature/*`、`core/ui`、`core/model`、`shared` の呼び出し元をすべて追随させる
+- `core/datastore` は変更しない。ブックマークの JSON 保存形式は fankt の `FanboxPost.serializer()` のままとし、変換は repository 層で行う
+
+## Capabilities
+
+### New Capabilities
+
+- `app-owned-fanbox-models`: アプリが所有する FANBOX モデルと、fankt モデルとの変換層。アプリの公開契約から fankt 型を外すこと、変換が値を落とさないこと、既存の永続化データが読めることを規定する
+
+### Modified Capabilities
+
+なし。既存 spec（`fanbox-guest-route` / `fanbox-error-classification` / `fanbox-list-tolerance` / `fanbox-schema-diagnostics` / `fanbox-session-recovery`）が参照するのは `FanboxRepositoryImpl` / `Fanbox` / `FanboxException` であり、いずれも本変更の対象外である。
+
+## Impact
+
+- **新規**：`core/model/src/commonMain/.../core/model/fanbox/`（app-owned モデル）、`core/repository/src/commonMain/.../repository/mapper/`（変換層）
+- **変更**：`core/repository`（`FanboxRepository` と実装、`paging/*` 5 本）、`feature/post` 27 / `feature/creator` 21 / `feature/library` 14 / `core/ui` 6 / `core/model` 6 / `feature/setting` 3 / `shared` 1 / `feature/welcome` 1
+- **変更しない**：`core/datastore`（11 ファイル）。cookie / session 系（`FanboxCookieStorage` / `FanboxCookieRecord` / `FanboxSessionId`）は domain model ではなく fankt が要求する基盤契約であり、本 issue の対象外
+- **依存**：fankt 0.1.3。バージョンは変えない
+- **ドキュメント影響**：あり（`README.md` の Architecture 節、`core/model` と `core/repository` の責務記述）
+
+## 受け入れ条件との対応
+
+| issue #137 の受け入れ条件 | 対応 |
+| --- | --- |
+| `FanboxRepository` の public API、`feature/*`、`core/ui`、`core/model` に `me.matsumo.fankt` の型が現れない | この change |
+| 永続化済みデータが移行後も読める（または migration が実装されている） | この change（保存形式を変えないことで満たす） |
+| 既存のテストが通る | この change |

--- a/openspec/changes/replace-fankt-models-with-app-owned/proposal.md
+++ b/openspec/changes/replace-fankt-models-with-app-owned/proposal.md
@@ -15,7 +15,7 @@ PixiView は fankt の domain model（`me.matsumo.fankt.fanbox.domain.model.*`�
 
 ### New Capabilities
 
-- `app-owned-fanbox-models`: アプリが所有する FANBOX モデルと、fankt モデルとの変換層。アプリの公開契約から fankt 型を外すこと、変換が値を落とさないこと、既存の永続化データが読めることを規定する
+- `app-owned-fanbox-models`: アプリが所有する FANBOX モデルと、fankt モデルとの変換層。アプリの公開契約から fankt の domain model を外すこと、変換が値を落とさないこと、既存の永続化データが読めることを規定する
 
 ### Modified Capabilities
 
@@ -24,8 +24,8 @@ PixiView は fankt の domain model（`me.matsumo.fankt.fanbox.domain.model.*`�
 ## Impact
 
 - **新規**：`core/model/src/commonMain/.../core/model/fanbox/`（app-owned モデル）、`core/repository/src/commonMain/.../repository/mapper/`（変換層）
-- **変更**：`core/repository`（`FanboxRepository` と実装、`paging/*` 5 本、`TranslationRepository`、`DownloadPostsRepository` の interface と android / ios 実装）、`feature/post` 27 / `feature/creator` 21 / `feature/library` 14 / `core/ui` 6 / `core/model` 6 / `feature/setting` 3 / `shared` 1 / `feature/welcome` 1
-- **変更しない**：`core/datastore`（11 ファイル）。cookie / session 系（`FanboxCookieStorage` / `FanboxCookieRecord` / `FanboxSessionId`）は domain model ではなく fankt が要求する基盤契約であり、本 issue の対象外
+- **変更**：`core/repository`（`FanboxRepository` と実装、`paging/*` 5 本、`TranslationRepository`、`DownloadPostsRepository` の interface と android / ios 実装）、`feature/post` / `feature/creator` / `feature/library` / `core/ui` / `core/model` の既存ファイル / `feature/setting` / `shared`
+- **変更しない**：`core/datastore`（11 ファイル）、`core/model/FanboxErrorKind.kt`、`feature/welcome/WebViewCookieConverter.kt`。cookie / session 系（`FanboxCookieStorage` / `FanboxCookieRecord` / `FanboxSessionId`）と例外（`FanboxException`）は domain model ではなく fankt が要求する契約であり、本 issue の対象外
 - **依存**：fankt 0.1.3。バージョンは変えない
 - **ドキュメント影響**：あり（`README.md` の Architecture 節、`core/model` と `core/repository` の責務記述）
 

--- a/openspec/changes/replace-fankt-models-with-app-owned/proposal.md
+++ b/openspec/changes/replace-fankt-models-with-app-owned/proposal.md
@@ -24,7 +24,7 @@ PixiView は fankt の domain model（`me.matsumo.fankt.fanbox.domain.model.*`�
 ## Impact
 
 - **新規**：`core/model/src/commonMain/.../core/model/fanbox/`（app-owned モデル）、`core/repository/src/commonMain/.../repository/mapper/`（変換層）
-- **変更**：`core/repository`（`FanboxRepository` と実装、`paging/*` 5 本）、`feature/post` 27 / `feature/creator` 21 / `feature/library` 14 / `core/ui` 6 / `core/model` 6 / `feature/setting` 3 / `shared` 1 / `feature/welcome` 1
+- **変更**：`core/repository`（`FanboxRepository` と実装、`paging/*` 5 本、`TranslationRepository`、`DownloadPostsRepository` の interface と android / ios 実装）、`feature/post` 27 / `feature/creator` 21 / `feature/library` 14 / `core/ui` 6 / `core/model` 6 / `feature/setting` 3 / `shared` 1 / `feature/welcome` 1
 - **変更しない**：`core/datastore`（11 ファイル）。cookie / session 系（`FanboxCookieStorage` / `FanboxCookieRecord` / `FanboxSessionId`）は domain model ではなく fankt が要求する基盤契約であり、本 issue の対象外
 - **依存**：fankt 0.1.3。バージョンは変えない
 - **ドキュメント影響**：あり（`README.md` の Architecture 節、`core/model` と `core/repository` の責務記述）

--- a/openspec/changes/replace-fankt-models-with-app-owned/specs/app-owned-fanbox-models/spec.md
+++ b/openspec/changes/replace-fankt-models-with-app-owned/specs/app-owned-fanbox-models/spec.md
@@ -11,6 +11,11 @@ fankt の型を扱ってよいのは `core/repository`（変換層とその呼�
 - **WHEN** `FanboxRepository` の interface 宣言を読む
 - **THEN** 引数、戻り値、プロパティの型はすべてアプリ所有のモデルか標準ライブラリの型である
 
+#### Scenario: UI 層から呼ばれる他のリポジトリも fankt の型を要求しない
+
+- **WHEN** `feature/*` から呼ばれる `TranslationRepository` と `DownloadPostsRepository` の公開宣言を読む
+- **THEN** 引数と戻り値の型はすべてアプリ所有のモデルか標準ライブラリの型である
+
 #### Scenario: UI 層のソースに fankt の import が現れない
 
 - **WHEN** `feature/*`、`core/ui`、`core/model`、`shared` のソースを走査する

--- a/openspec/changes/replace-fankt-models-with-app-owned/specs/app-owned-fanbox-models/spec.md
+++ b/openspec/changes/replace-fankt-models-with-app-owned/specs/app-owned-fanbox-models/spec.md
@@ -2,16 +2,18 @@
 
 ### Requirement: アプリの公開契約は fankt の domain model を露出しない
 
-`FanboxRepository` の public API、`feature/*`、`core/ui`、`core/model`、`shared` は、fankt の domain model（`me.matsumo.fankt.fanbox.domain.*`）を参照してはならない（MUST NOT）。これらの層はアプリが所有するモデル（`me.matsumo.fanbox.core.model.fanbox.*`）だけを扱う。
+`FanboxRepository` の public API、`feature/*`、`core/ui`、`core/model`、`shared` は、fankt の domain model（`me.matsumo.fankt.fanbox.domain.*`）を参照してはならない（MUST NOT）。これらの層が扱う FANBOX のモデルは、アプリが所有するもの（`me.matsumo.fanbox.core.model.fanbox.*`）に限る。
 
-fankt の型を扱ってよいのは `core/repository`（変換層とその呼び出し元）と `core/datastore`（cookie / session の基盤契約と、ブックマークの保存形式）に限る。
+fankt の domain model を扱ってよいのは `core/repository`（変換層とその呼び出し元）と `core/datastore`（ブックマークの保存形式）に限る。
 
-#### Scenario: リポジトリの公開宣言に fankt の型が現れない
+domain model ではない fankt の契約は、この要件の対象ではなく層を問わず参照してよい。例外（`FanboxException`）、cookie と session（`FanboxCookieRecord` / `FanboxCookieStorage` / `FanboxSessionId`）、エントリポイント（`Fanbox` / `FanboxLogLevel`）、スキーマ不一致の診断（`FanboxListItemSchemaMismatch`）が該当する。
+
+#### Scenario: リポジトリの公開宣言に domain model が現れない
 
 - **WHEN** `FanboxRepository` の interface 宣言を読む
-- **THEN** 引数、戻り値、プロパティの型はすべてアプリ所有のモデルか標準ライブラリの型である
+- **THEN** FANBOX のモデルを表す引数・戻り値・プロパティはすべてアプリ所有のモデルであり、fankt の型が残るのは cookie を渡す引数だけである
 
-#### Scenario: UI 層から呼ばれる他のリポジトリも fankt の型を要求しない
+#### Scenario: UI 層から呼ばれる他のリポジトリも domain model を要求しない
 
 - **WHEN** `feature/*` から呼ばれる `TranslationRepository` と `DownloadPostsRepository` の公開宣言を読む
 - **THEN** 引数と戻り値の型はすべてアプリ所有のモデルか標準ライブラリの型である

--- a/openspec/changes/replace-fankt-models-with-app-owned/specs/app-owned-fanbox-models/spec.md
+++ b/openspec/changes/replace-fankt-models-with-app-owned/specs/app-owned-fanbox-models/spec.md
@@ -1,0 +1,108 @@
+## ADDED Requirements
+
+### Requirement: アプリの公開契約は fankt の domain model を露出しない
+
+`FanboxRepository` の public API、`feature/*`、`core/ui`、`core/model`、`shared` は、fankt の domain model（`me.matsumo.fankt.fanbox.domain.*`）を参照してはならない（MUST NOT）。これらの層はアプリが所有するモデル（`me.matsumo.fanbox.core.model.fanbox.*`）だけを扱う。
+
+fankt の型を扱ってよいのは `core/repository`（変換層とその呼び出し元）と `core/datastore`（cookie / session の基盤契約と、ブックマークの保存形式）に限る。
+
+#### Scenario: リポジトリの公開宣言に fankt の型が現れない
+
+- **WHEN** `FanboxRepository` の interface 宣言を読む
+- **THEN** 引数、戻り値、プロパティの型はすべてアプリ所有のモデルか標準ライブラリの型である
+
+#### Scenario: UI 層のソースに fankt の import が現れない
+
+- **WHEN** `feature/*`、`core/ui`、`core/model`、`shared` のソースを走査する
+- **THEN** `me.matsumo.fankt.fanbox.domain` から始まる import は 1 件も存在しない
+
+#### Scenario: 例外と診断の契約は対象外である
+
+- **WHEN** `FanboxException` / `FanboxErrorKind` / `FanboxListItemSchemaMismatch` の扱いを確認する
+- **THEN** これらは domain model ではないため置き換えの対象外であり、`fanbox-error-classification` と `fanbox-schema-diagnostics` の既存要件は変更されない
+
+### Requirement: 変換は fankt のモデルの値を落とさない
+
+変換層は fankt の domain model からアプリ所有のモデルへ、すべてのフィールドを写さなければならない（MUST）。sealed 階層はすべての variant を写し、未知を表す variant が保持する生の JSON も保持しなければならない（MUST）。
+
+#### Scenario: 投稿の全フィールドが写る
+
+- **WHEN** すべてのフィールドに値を持つ fankt の投稿モデルを変換する
+- **THEN** アプリ所有の投稿モデルの各フィールドが、対応する fankt のフィールドと同じ値を持つ
+
+#### Scenario: 投稿詳細の本文の全 variant が写る
+
+- **WHEN** 記事 / 画像 / ファイル / テキスト / 動画 / HTML / 未知 のそれぞれを本文に持つ投稿詳細を変換する
+- **THEN** いずれも対応するアプリ所有の variant へ変換され、変換に失敗するものはない
+
+#### Scenario: 記事ブロックの全 variant が写る
+
+- **WHEN** テキスト / 画像 / ファイル / リンク / 埋め込み / 未知 のブロックを含む記事本文を変換する
+- **THEN** いずれも対応するアプリ所有のブロックへ変換され、テキストブロックが持つ装飾範囲とリンク範囲も写る
+
+#### Scenario: 未知の内容は生の JSON を保ったまま写る
+
+- **WHEN** 未知の本文種別、または未知の記事ブロックを含む投稿詳細を変換する
+- **THEN** アプリ所有のモデルは元の生の JSON 文字列を同じ値で保持する
+
+### Requirement: アプリから fankt へ戻す変換は往復で元の値へ戻る
+
+アプリ所有のモデルのうち、fankt へ渡す必要があるもの（投稿 ID / クリエイター ID / ユーザー ID / コメント ID / 投稿 / ページングのカーソル）は、fankt のモデルへ戻す変換を持たなければならない（MUST）。往復した値は元の値と等しくなければならない（MUST）。
+
+#### Scenario: ID が往復する
+
+- **WHEN** fankt の各 ID をアプリ所有の ID へ変換し、再び fankt の ID へ戻す
+- **THEN** 戻した値は元の値と等しい
+
+#### Scenario: 投稿が往復する
+
+- **WHEN** すべてのフィールドに値を持つ fankt の投稿をアプリ所有の投稿へ変換し、再び fankt の投稿へ戻す
+- **THEN** 戻した値は元の値と等しい
+
+#### Scenario: ページングのカーソルが往復する
+
+- **WHEN** fankt のカーソルをアプリ所有のカーソルへ変換し、再び fankt のカーソルへ戻す
+- **THEN** 戻した値は元の値と等しい
+
+### Requirement: 派生プロパティはアプリ所有のモデルでも同じ値を返す
+
+fankt のモデルが計算していた派生プロパティ（投稿詳細のブラウザ URL、本文が持つ画像とファイルの一覧、埋め込みと動画の URL、ファイルの画像 / 動画への読み替え）は、アプリ所有のモデルでも同じ入力に対して同じ値を返さなければならない（MUST）。
+
+#### Scenario: 投稿詳細のブラウザ URL が変わらない
+
+- **WHEN** 同じ投稿詳細について fankt のモデルとアプリ所有のモデルのブラウザ URL を比べる
+- **THEN** 両者は等しい
+
+#### Scenario: 埋め込みと動画の URL が変わらない
+
+- **WHEN** 対応済みのサービス提供者を持つ埋め込みブロックと動画本文について、両モデルの URL を比べる
+- **THEN** 両者は等しく、未対応の提供者ではどちらも URL を返さない
+
+#### Scenario: ファイルの読み替えが変わらない
+
+- **WHEN** 画像の拡張子を持つファイル、動画の拡張子を持つファイル、どちらでもないファイルについて、両モデルの読み替え結果を比べる
+- **THEN** 変換できる場合は同じ値を返し、変換できない場合はどちらも値を返さない
+
+### Requirement: 永続化済みのデータは置き換え後も読める
+
+ブックマークとブロック設定の保存形式は変更してはならない（MUST NOT）。アプリ所有のモデルへの置き換え前に保存されたデータは、置き換え後も同じ内容として読めなければならない（MUST）。
+
+#### Scenario: 保存済みのブックマークが読める
+
+- **WHEN** 置き換え前の形式で保存されたブックマークの JSON を読み出す
+- **THEN** アプリ所有の投稿モデルとして復元され、各フィールドが保存時の値と一致する
+
+#### Scenario: ブックマークの保存形式が変わらない
+
+- **WHEN** アプリ所有の投稿モデルをブックマークとして保存する
+- **THEN** 保存される JSON は置き換え前と同じ形式であり、置き換え前のアプリでも読める
+
+#### Scenario: ブロック済みクリエイターが読める
+
+- **WHEN** 置き換え前に保存されたブロック済みクリエイターの一覧を読み出す
+- **THEN** アプリ所有のクリエイター ID の集合として復元され、内容が保存時と一致する
+
+#### Scenario: 画面遷移の引数の表現が変わらない
+
+- **WHEN** 投稿 ID とクリエイター ID を画面遷移の引数として符号化する
+- **THEN** 符号化された文字列は置き換え前と同じであり、既存のリンクがそのまま解決できる

--- a/openspec/changes/replace-fankt-models-with-app-owned/tasks.md
+++ b/openspec/changes/replace-fankt-models-with-app-owned/tasks.md
@@ -10,7 +10,7 @@
 - [ ] 1.1 `core/model/src/commonMain/.../core/model/fanbox/` に ID の value class 7 種（`PostId` / `PostItemId` / `CreatorId` / `UserId` / `CommentId` / `PlanId` / `NewsLetterId`）を定義する
 - [ ] 1.2 葉のモデル（`Cover` / `Tag` / `User` / `Creator` / `PaymentMethod`）を定義する
 - [ ] 1.3 集約のモデル（`Post` / `CreatorDetail` / `CreatorPlan` / `CreatorPlanDetail` / `Comment` / `Bell` / `MetaData` / `NewsLetter` / `PaidRecord`）を定義する
-- [ ] 1.4 `PostDetail` と `Body` の sealed 階層、`OtherPost` / `ImageItem` / `VideoItem` / `FileItem` を定義し、派生プロパティ（D7）を移植する
+- [ ] 1.4 `PostDetail` と `Body` の sealed 階層、`OtherPost` / `ImageItem` / `VideoItem` / `FileItem` を定義し、D7 の表で「する」とした派生メンバー 11 個を移植する
 - [ ] 1.5 ページング型（`PageCursorInfo` / `PageNumberInfo` / `PageOffsetInfo` / `Cursor`）を定義する
 - [ ] 1.6 Composable から参照するモデルへ `@Immutable` を付ける（AGENTS.md の Compose 規約）
 - [ ] 1.7 各 `data class` / `enum` / `value class` に日本語 KDoc を付ける
@@ -27,18 +27,19 @@
 - [ ] 3.2 `Body` の 7 variant と記事ブロックの 6 variant がすべて変換されることを固定する
 - [ ] 3.3 未知の variant が生の JSON を保持することを固定する
 - [ ] 3.4 ID / `Post` / `Cursor` の往復が元の値へ戻ることを固定する
-- [ ] 3.5 派生プロパティ（`browserUrl` / `Embed.url` / `Video.url` / `asImageItem` / `asVideoItem`）が fankt と同じ値を返すことを固定する
+- [ ] 3.5 D7 の派生メンバー 11 個が fankt と同じ値を返すことを固定する
 
 ## 4. 公開契約の置き換え（段 3 / `-swap`）
 
 - [ ] 4.1 `FanboxRepository` の interface とその実装をアプリ所有のモデルへ差し替え、`BookmarkDataStore` / `BlockDataStore` との境界で変換する
 - [ ] 4.2 `core/repository/paging/` の 5 本の `PagingSource` を差し替える
-- [ ] 4.3 `core/model` の既存ファイル（`Destination` / `FanboxDownloadItems` / `PostDownloader` / `TransPostDetail` / `TransComments`）を差し替え、`RequestType.Post` を `WholePost` へ改名する（D8）
-- [ ] 4.4 `core/ui` の 6 ファイルを差し替える（`NavTypes` の符号化が変わらないことを含む）
-- [ ] 4.5 `feature/post` 27 ファイルを差し替える
-- [ ] 4.6 `feature/creator` 21 ファイルを差し替える
-- [ ] 4.7 `feature/library` 14 ファイルを差し替える
-- [ ] 4.8 `feature/setting` 3 / `feature/welcome` 1 / `shared` 1 を差し替える
+- [ ] 4.3 `TranslationRepository` の `translate` 2 つと、`DownloadPostsRepository` の interface および android / ios の実装を差し替える（D5）
+- [ ] 4.4 `core/model` の既存ファイル（`Destination` / `FanboxDownloadItems` / `PostDownloader` / `TransPostDetail` / `TransComments`）を差し替え、`RequestType.Post` を `WholePost` へ改名する（D8）
+- [ ] 4.5 `core/ui` の 6 ファイルを差し替える（`NavTypes` の符号化が変わらないことを含む）
+- [ ] 4.6 `feature/post` 27 ファイルを差し替える
+- [ ] 4.7 `feature/creator` 21 ファイルを差し替える
+- [ ] 4.8 `feature/library` 14 ファイルを差し替える
+- [ ] 4.9 `feature/setting` 3 / `feature/welcome` 1 / `shared` 1 を差し替える
 
 ## 5. 永続化の非退行（段 3 / `-swap`）
 

--- a/openspec/changes/replace-fankt-models-with-app-owned/tasks.md
+++ b/openspec/changes/replace-fankt-models-with-app-owned/tasks.md
@@ -18,7 +18,7 @@
 ## 2. 変換層（段 2 / `-defs`）
 
 - [ ] 2.1 `core/repository/src/commonMain/.../repository/mapper/` に fankt → app の変換を全型分置く
-- [ ] 2.2 app → fankt の変換を D5 の 4 種（ID / `Post` / `Cursor`、およびページング型）に限って置く
+- [ ] 2.2 app → fankt の変換を D5 の表が挙げる 3 種（ID 4 つ / `Post` / `Cursor`）に限って置く
 - [ ] 2.3 `PostDetail.Body` と記事ブロックの変換を、`when` を exhaustive に書いて全 variant 分置く
 
 ## 3. 変換のテスト（段 2 / `-defs`）
@@ -39,7 +39,7 @@
 - [ ] 4.6 `feature/post` 27 ファイルを差し替える
 - [ ] 4.7 `feature/creator` 21 ファイルを差し替える
 - [ ] 4.8 `feature/library` 14 ファイルを差し替える
-- [ ] 4.9 `feature/setting` 3 / `feature/welcome` 1 / `shared` 1 を差し替える
+- [ ] 4.9 `feature/setting` と `shared` を差し替える（`feature/welcome` の fankt 参照は cookie の契約のみで対象外）
 
 ## 5. 永続化の非退行（段 3 / `-swap`）
 

--- a/openspec/changes/replace-fankt-models-with-app-owned/tasks.md
+++ b/openspec/changes/replace-fankt-models-with-app-owned/tasks.md
@@ -1,0 +1,57 @@
+担当 PR は design.md D10 の Stack 構成に対応する。
+
+| 段 | branch |
+| --- | --- |
+| 2 | `feature/app-owned-fanbox-models-defs` |
+| 3 | `feature/app-owned-fanbox-models-swap` |
+
+## 1. モデル定義（段 2 / `-defs`）
+
+- [ ] 1.1 `core/model/src/commonMain/.../core/model/fanbox/` に ID の value class 7 種（`PostId` / `PostItemId` / `CreatorId` / `UserId` / `CommentId` / `PlanId` / `NewsLetterId`）を定義する
+- [ ] 1.2 葉のモデル（`Cover` / `Tag` / `User` / `Creator` / `PaymentMethod`）を定義する
+- [ ] 1.3 集約のモデル（`Post` / `CreatorDetail` / `CreatorPlan` / `CreatorPlanDetail` / `Comment` / `Bell` / `MetaData` / `NewsLetter` / `PaidRecord`）を定義する
+- [ ] 1.4 `PostDetail` と `Body` の sealed 階層、`OtherPost` / `ImageItem` / `VideoItem` / `FileItem` を定義し、派生プロパティ（D7）を移植する
+- [ ] 1.5 ページング型（`PageCursorInfo` / `PageNumberInfo` / `PageOffsetInfo` / `Cursor`）を定義する
+- [ ] 1.6 Composable から参照するモデルへ `@Immutable` を付ける（AGENTS.md の Compose 規約）
+- [ ] 1.7 各 `data class` / `enum` / `value class` に日本語 KDoc を付ける
+
+## 2. 変換層（段 2 / `-defs`）
+
+- [ ] 2.1 `core/repository/src/commonMain/.../repository/mapper/` に fankt → app の変換を全型分置く
+- [ ] 2.2 app → fankt の変換を D5 の 4 種（ID / `Post` / `Cursor`、およびページング型）に限って置く
+- [ ] 2.3 `PostDetail.Body` と記事ブロックの変換を、`when` を exhaustive に書いて全 variant 分置く
+
+## 3. 変換のテスト（段 2 / `-defs`）
+
+- [ ] 3.1 全フィールドを埋めた `FanboxPost` / `FanboxPostDetail` / `FanboxCreatorDetail` の変換で、各フィールドが写ることを固定する
+- [ ] 3.2 `Body` の 7 variant と記事ブロックの 6 variant がすべて変換されることを固定する
+- [ ] 3.3 未知の variant が生の JSON を保持することを固定する
+- [ ] 3.4 ID / `Post` / `Cursor` の往復が元の値へ戻ることを固定する
+- [ ] 3.5 派生プロパティ（`browserUrl` / `Embed.url` / `Video.url` / `asImageItem` / `asVideoItem`）が fankt と同じ値を返すことを固定する
+
+## 4. 公開契約の置き換え（段 3 / `-swap`）
+
+- [ ] 4.1 `FanboxRepository` の interface とその実装をアプリ所有のモデルへ差し替え、`BookmarkDataStore` / `BlockDataStore` との境界で変換する
+- [ ] 4.2 `core/repository/paging/` の 5 本の `PagingSource` を差し替える
+- [ ] 4.3 `core/model` の既存ファイル（`Destination` / `FanboxDownloadItems` / `PostDownloader` / `TransPostDetail` / `TransComments`）を差し替え、`RequestType.Post` を `WholePost` へ改名する（D8）
+- [ ] 4.4 `core/ui` の 6 ファイルを差し替える（`NavTypes` の符号化が変わらないことを含む）
+- [ ] 4.5 `feature/post` 27 ファイルを差し替える
+- [ ] 4.6 `feature/creator` 21 ファイルを差し替える
+- [ ] 4.7 `feature/library` 14 ファイルを差し替える
+- [ ] 4.8 `feature/setting` 3 / `feature/welcome` 1 / `shared` 1 を差し替える
+
+## 5. 永続化の非退行（段 3 / `-swap`）
+
+- [ ] 5.1 `core/datastore` が変更されていないことを確認する
+- [ ] 5.2 置き換え前の形式で保存されたブックマーク JSON が読めることを固定する
+- [ ] 5.3 保存される JSON が置き換え前と同じ形式であることを固定する
+- [ ] 5.4 ブロック済みクリエイターが読めることを固定する
+- [ ] 5.5 `PostId` / `CreatorId` の画面遷移引数の符号化が変わらないことを固定する
+
+## 6. 検証とドキュメント（段 3 / `-swap`）
+
+- [ ] 6.1 `feature/*` / `core/ui` / `core/model` / `shared` に `me.matsumo.fankt.fanbox.domain` の import が残っていないことを走査で確認する
+- [ ] 6.2 `./gradlew detekt` と既存テストを通す
+- [ ] 6.3 Android と iOS の両方でコンパイルが通ることを確認する
+- [ ] 6.4 `README.md` の Architecture 節に `core/model` と `core/repository` の責務を反映する
+- [ ] 6.5 変更した機能名・クラス名で `docs/` と `README.md` を走査し、誤りになった記述がないか確認する


### PR DESCRIPTION
Refs #137

fankt の domain model をアプリ所有のモデルへ置き換えるための設計。実装は含まない。

**この PR は 3 本の連鎖の最下段である。** GitHub Stacked PRs を有効化できなかったため、通常 PR の base を連鎖させた構成にしている。`gh stack merge` は使えないので、**下から順に人間が merge する必要がある**。

| 順 | PR | base | 内容 |
| --- | --- | --- | --- |
| 1 | この PR | `main` | proposal / delta spec / design / tasks |
| 2 | 後続 | この PR の branch | `core/model/fanbox/*` のモデル定義、変換層、変換のテスト |
| 3 | 後続 | 2 の branch | `FanboxRepository` の公開契約と全呼び出し元の置換 |

archive は merge 後に別 PR で回収する。

ドキュメント影響: なし（この PR は OpenSpec artifact のみ。README の更新は 3 本目に含む）

## なぜ 3 本に分けるか

`FanboxRepository` の戻り値型を変えた瞬間に、`feature/post`(27) / `feature/creator`(21) / `feature/library`(14) / `core/ui`(6) の呼び出し元が全部同時にコンパイルを失う。変換層の導入と呼び出し元の置換は 1 つのコミット単位から分けられない。

分離できるのはモデル定義だけである。2 本目は 3 本目が無ければ誰にも使われないが、「fankt のモデルと形が一致しているか」「変換が値を落としていないか」を 3 本目の機械的な置換 90 ファイルと切り離してレビューできる。

## 規模の実測

`me.matsumo.fankt` を参照するファイルは 102、import 行は約 260（うち `domain.model.*` が 219）。置き換え対象の fankt domain model は 24 ファイル / 749 行で、`FanboxPostDetail` だけで 272 行（`Body` の sealed 階層）を占める。

## issue の未決事項への回答

| issue #137 の未決事項 | 回答 |
| --- | --- |
| 変換層の置き場所（`core/repository` 内か専用 module か） | `core/repository` 内の `mapper` package（D4）。新しい依存もビルド設定も要らない |
| ID を value class にするか素の `String` か | value class を維持（D2） |
| 一括で移行するか module 単位で段階的に移行するか | 型の依存関係上ほぼ atomic なので、段階化は PR の分割で行う（D10） |

## 検証結果

**該当なし。** この PR は OpenSpec artifact（Markdown）のみで、Kotlin を 1 行も含まない。ビルド・テスト・静的解析の対象になる変更が無いため、検証記録は無い。

設計の検証は `openspec validate replace-fankt-models-with-app-owned --strict` の通過（HEAD `84801b14`）と、下記の独立反証によって行っている。

## 独立反証で閉じた指摘

clean context の falsifier に proposal / delta spec / design / tasks を反証させ、blocking 1 件と non-blocking 1 件が出た。どちらも設計修正で閉じ、同一 falsifier が解消を確認している。

### `TranslationRepository` がアプリ所有モデルの逆変換を要求する（blocking）

D5 は「アプリから fankt へ戻す経路は ID 4 種・`Post`・`Cursor` だけ」と宣言していたが、`TranslationRepository.translate(postDetail: FanboxPostDetail)` と `translate(comments: PageOffsetInfo<FanboxComment>)` を `PostDetailViewModel` が UI 状態そのものを渡して呼んでいる。宣言が事実に反していた。

falsifier は処置として 2 案を挙げたが、案 1（逆変換を足す）は採れない。`toTrans()` / `toFanboxPostDetail()` は `core/model/translation` にあり、受け入れ条件が `core/model` を名指しで含むため、逆変換を足しても fankt 型が残る。

採ったのは境界の移動である。さらに、翻訳 API へ serialize されるのはアプリ所有の `TransPostDetail` / `TransComments` であって fankt の型ではないため、**この経路に逆変換は要らず型の差し替えだけで閉じる**。D5 の逆変換 4 種は変えていない。

同じクラスの見落としを 1 件、こちらで追加発見した。`DownloadPostsRepository` も `requestDownloadPost(post: FanboxPost, …)` を公開して `feature/*` から呼ばれている。受け取った投稿は保存先ディレクトリ名（`post.user?.name`）と一覧表示にしか使わず fankt の API へ渡らないため、こちらも逆変換なしで差し替えられる。

`core/repository` に fankt 型を公開シグネチャで持つのはこの 3 本（`FanboxRepository` / `TranslationRepository` / `DownloadPostsRepository`）で全数であることを、再確認で `RewardRepository` / `SettingRepository` / `FlagRepository` / `LaunchLogRepository` まで含めて確認した。

### 派生メンバーの列挙が非網羅（non-blocking）

design は 6 件と書いていたが実際は 13 件ある。全数を表にし、移植する 11 個と移植しない 2 個を分けた。

`Platform.fromUrl` と `PaymentMethod.fromString` は移植しない。fankt がレスポンスからモデルを組み立てるための companion factory で、アプリからの呼び出しは 1 件もない（repo 全体の grep で確認）。加えて `Platform.fromUrl` は fankt の `internal` な `FanboxUrlParts` に依存するため、移植しようとするとアプリ側に URL パーサを新設することになる。

## 反証の外で見つけた事実誤り

design D2 が「ID の `value` が `String` である点も fankt と同じ」と書いていたが、`FanboxUserId` だけは `value: Long` である。残り 6 種は `String`。修正済み。

## レビューで閉じた指摘

### 要件が「fankt の型」を禁じていたが、実装が満たすのは「domain model」だけだった（P2）

指摘は妥当だった。Requirement 1 は「fankt の型を扱ってよいのは `core/repository` と `core/datastore` に限る」と書いていたが、`core/model/FanboxErrorKind.kt` が `FanboxException` を、`feature/welcome/WebViewCookieConverter.kt` が `FanboxCookieRecord` を参照し続ける。どちらも design の Non-Goals に挙げた非 domain の契約で、この MUST を満たさない。

**同根の 3 件目を、指摘の範囲を超えて自分で見つけた。** Scenario 1 の「引数、戻り値、プロパティの型はすべてアプリ所有のモデルか標準ライブラリの型である」も偽である。`FanboxRepository.setCookies(cookies: List<FanboxCookieRecord>)` が fankt 型を取り続けているためで、これも cookie の契約なので置き換えの対象外である。

問題クラスとして扱い、次を直した。

| # | 箇所 | 修正 |
| --- | --- | --- |
| 1 | Requirement 1 の許可境界 | 対象を domain model に限定し、非 domain の契約（例外 / cookie と session / エントリポイント / 診断）は層を問わず参照してよいと明示 |
| 2 | Scenario 1 | 「domain model が現れない」に改め、fankt の型が残るのは cookie を渡す引数だけであることを条件に含めた |
| 3 | Scenario 3 | 表題を「domain model を要求しない」に統一（`TranslationRepository` / `DownloadPostsRepository` は実際に fankt 型ゼロなので内容は元から真） |
| 4 | proposal の Capabilities | 「fankt 型を外す」→「fankt の domain model を外す」 |

### 反証の外で見つけた 2 件目の誤り

`feature/welcome` の fankt 参照は `FanboxCookieRecord` の 1 件だけで、**この change では一度も変更していない**（`git diff --stat main..HEAD -- feature/welcome` が空）。にもかかわらず proposal の Impact と tasks 4.9 が「置き換えた」と書いていた。両方を「対象外」へ直した。

`core/model` も「6 ファイル変更」と書いていたが、実際に変更したのは 5 件で `FanboxErrorKind.kt` は無変更である。

### tasks 2.2 が design D5 を超えた要求を書いていた

D5 の表が挙げる逆変換は ID 4 種 / `Post` / `Cursor` の 3 行だが、tasks 2.2 は「およびページング型」と書いていた。この記述が独り歩きして未使用の逆変換 3 関数が実装された（#152 で削除）。tasks を D5 の表に合わせた。

## 人間に確認してほしいこと

| # | 帰属 | 内容 |
| --- | --- | --- |
| 1 | ユーザー確認済み | 命名は `Fanbox` prefix を外す（`me.matsumo.fanbox.core.model.fanbox.Post`）。fankt 型と同名にすると import の取り違えがコンパイルを通るため |
| 2 | ユーザー確認済み | ID は value class を維持する |
| 3 | ユーザー確認済み | ブックマークの保存形式を変えない。`core/datastore` は無変更のまま fankt の `FanboxPost.serializer()` を使い続け、変換は repository 層で行う。migration は発生しない |
| 4 | agent 仮決め | 3 の帰結として、アプリ所有の `Post` に fankt へ無いフィールドを足してもその値は保存されない。今回は 1:1 写像に限るため顕在化しないが、将来 `Post` を拡張する際にこの制約へ当たる |
| 5 | agent 仮決め | `FanboxDownloadItems.RequestType.Post` を `WholePost` へ改名する。`val post: Post?` を持つため、app 型を `Post` にすると入れ子クラス自身へ解決されてフィールドの型が書けない。参照は 5 ファイル 12 箇所で、いずれも完全に修飾されている |
| 6 | agent 仮決め | fankt の派生ロジック（D7 の 11 個）をアプリ側へ複製するため、fankt が `Embed.url` の対応サービスを増やしてもアプリは追随しない。これは分離の目的そのものだが、意図した乖離であることを確認してほしい |
| 7 | agent 仮決め | GitHub Stacked PRs を使わず通常 PR の連鎖にした。merge は下から順に手動で行う必要がある |
