### PR TITLE
Add app-owned FANBOX models and the fankt mapper layer

### DIFF
--- a/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/Bell.kt
+++ b/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/Bell.kt
@@ -1,0 +1,45 @@
+package me.matsumo.fanbox.core.model.fanbox
+
+import androidx.compose.runtime.Immutable
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
+
+/** ベル通知。 */
+@Immutable
+sealed interface Bell {
+    /** コメント通知。 */
+    @Immutable
+    @OptIn(ExperimentalTime::class)
+    data class Comment(
+        val id: CommentId,
+        val notifiedDatetime: Instant,
+        val comment: String,
+        val isRootComment: Boolean,
+        val creatorId: CreatorId,
+        val postId: PostId,
+        val postTitle: String,
+        val userName: String,
+        val userProfileIconUrl: String,
+    ) : Bell
+
+    /** いいね通知。 */
+    @Immutable
+    @OptIn(ExperimentalTime::class)
+    data class Like(
+        val id: String,
+        val notifiedDatetime: Instant,
+        val comment: String,
+        val creatorId: CreatorId,
+        val postId: PostId,
+        val count: Int,
+    ) : Bell
+
+    /** 新着投稿通知。 */
+    @Immutable
+    @OptIn(ExperimentalTime::class)
+    data class PostPublished(
+        val id: PostId,
+        val notifiedDatetime: Instant,
+        val post: Post,
+    ) : Bell
+}

--- a/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/Comment.kt
+++ b/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/Comment.kt
@@ -1,0 +1,21 @@
+package me.matsumo.fanbox.core.model.fanbox
+
+import androidx.compose.runtime.Immutable
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
+
+/** 投稿へのコメント。 */
+@Immutable
+@OptIn(ExperimentalTime::class)
+data class Comment(
+    val body: String,
+    val createdDatetime: Instant,
+    val id: CommentId,
+    val isLiked: Boolean,
+    val isOwn: Boolean,
+    val likeCount: Int,
+    val parentCommentId: CommentId,
+    val rootCommentId: CommentId,
+    val replies: List<Comment>,
+    val user: User?,
+)

--- a/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/CommentId.kt
+++ b/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/CommentId.kt
@@ -1,0 +1,7 @@
+package me.matsumo.fanbox.core.model.fanbox
+
+import kotlin.jvm.JvmInline
+
+/** コメントを一意に識別する ID。 */
+@JvmInline
+value class CommentId(val value: String)

--- a/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/CommentId.kt
+++ b/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/CommentId.kt
@@ -1,7 +1,9 @@
 package me.matsumo.fanbox.core.model.fanbox
 
+import kotlinx.serialization.Serializable
 import kotlin.jvm.JvmInline
 
 /** コメントを一意に識別する ID。 */
+@Serializable
 @JvmInline
 value class CommentId(val value: String)

--- a/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/Cover.kt
+++ b/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/Cover.kt
@@ -1,0 +1,10 @@
+package me.matsumo.fanbox.core.model.fanbox
+
+import androidx.compose.runtime.Immutable
+
+/** 投稿のカバー画像。 */
+@Immutable
+data class Cover(
+    val url: String,
+    val type: String,
+)

--- a/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/Creator.kt
+++ b/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/Creator.kt
@@ -1,0 +1,10 @@
+package me.matsumo.fanbox.core.model.fanbox
+
+import androidx.compose.runtime.Immutable
+
+/** クリエイター。ユーザー情報と紐づく。 */
+@Immutable
+data class Creator(
+    val creatorId: CreatorId?,
+    val user: User?,
+)

--- a/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/CreatorDetail.kt
+++ b/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/CreatorDetail.kt
@@ -1,0 +1,93 @@
+package me.matsumo.fanbox.core.model.fanbox
+
+import androidx.compose.runtime.Immutable
+
+/** クリエイターの詳細情報。 */
+@Immutable
+data class CreatorDetail(
+    val creatorId: CreatorId,
+    val coverImageUrl: String?,
+    val description: String,
+    val hasAdultContent: Boolean,
+    val hasBoothShop: Boolean,
+    val isAcceptingRequest: Boolean,
+    val isFollowed: Boolean,
+    val isStopped: Boolean,
+    val isSupported: Boolean,
+    val profileItems: List<ProfileItem>,
+    val profileLinks: List<ProfileLink>,
+    val user: User?,
+) {
+    /** クリエイターサポート画面の URL。 */
+    val supportingBrowserUrl get() = "https://www.fanbox.cc/creators/supporting/@${user?.creatorId?.value}"
+
+    /** `creator.get` のアイテム種別から分類したプロフィールアイテム。 */
+    @Immutable
+    sealed interface ProfileItem {
+
+        /** 画像のプロフィールアイテム。両 URL は FANBOX レスポンスの null 許容値をそのまま保持する。 */
+        @Immutable
+        data class Image(
+            val id: String,
+            val imageUrl: String?,
+            val thumbnailUrl: String?,
+        ) : ProfileItem
+
+        /**
+         * 動画のプロフィールアイテム。
+         *
+         * [url] は既知の YouTube / Vimeo の URL 形式のみを再構築する。[serviceProvider] / [videoId] /
+         * 生成される URL は未検証のネットワークデータのまま残る。呼び出し側はナビゲーションポリシーに
+         * 照らして検証してから URL を開くこと。
+         */
+        @Immutable
+        data class Video(
+            val id: String,
+            val serviceProvider: String,
+            val videoId: String,
+            val thumbnailUrl: String?,
+        ) : ProfileItem {
+            /** 対応済みサービス提供者の動画 URL。未対応の場合は null。 */
+            val url: String?
+                get() = when (serviceProvider) {
+                    "youtube" -> "https://www.youtube.com/watch?v=$videoId"
+                    "vimeo" -> "https://vimeo.com/$videoId"
+                    else -> null
+                }
+        }
+
+        /**
+         * 既知の variant に当てはまらないプロフィールアイテム。
+         *
+         * [rawJson] は転送・診断のために保持する未検証のネットワークデータである。呼び出し側は
+         * パース・表示・内包する URL の利用の前に検証・サニタイズすること。
+         */
+        @Immutable
+        data class Unknown(
+            val id: String?,
+            val type: String,
+            val rawJson: String,
+        ) : ProfileItem
+    }
+
+    /** プロフィールリンク。 */
+    @Immutable
+    data class ProfileLink(
+        val url: String,
+        val link: Platform,
+    )
+
+    /** プロフィールリンクの対応プラットフォーム。 */
+    enum class Platform {
+        BOOTH,
+        FACEBOOK,
+        FANZA,
+        INSTAGRAM,
+        LINE,
+        PIXIV,
+        TUMBLR,
+        TWITTER,
+        YOUTUBE,
+        UNKNOWN,
+    }
+}

--- a/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/CreatorId.kt
+++ b/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/CreatorId.kt
@@ -1,0 +1,7 @@
+package me.matsumo.fanbox.core.model.fanbox
+
+import kotlin.jvm.JvmInline
+
+/** クリエイターを一意に識別する ID。 */
+@JvmInline
+value class CreatorId(val value: String)

--- a/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/CreatorId.kt
+++ b/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/CreatorId.kt
@@ -1,7 +1,9 @@
 package me.matsumo.fanbox.core.model.fanbox
 
+import kotlinx.serialization.Serializable
 import kotlin.jvm.JvmInline
 
 /** クリエイターを一意に識別する ID。 */
+@Serializable
 @JvmInline
 value class CreatorId(val value: String)

--- a/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/CreatorPlan.kt
+++ b/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/CreatorPlan.kt
@@ -1,0 +1,22 @@
+package me.matsumo.fanbox.core.model.fanbox
+
+import androidx.compose.runtime.Immutable
+
+/** 支援プラン。 */
+@Immutable
+data class CreatorPlan(
+    val id: PlanId,
+    val title: String,
+    val description: String,
+    val fee: Int,
+    val coverImageUrl: String?,
+    val hasAdultContent: Boolean,
+    val paymentMethod: PaymentMethod,
+    val user: User?,
+) {
+    /** プラン詳細画面の URL。 */
+    val planBrowserUrl get() = "https://www.fanbox.cc/@${user?.creatorId?.value}/plans/${id.value}"
+
+    /** クリエイターサポート画面の URL。 */
+    val supportingBrowserUrl get() = "https://www.fanbox.cc/creators/supporting/@${user?.creatorId?.value}"
+}

--- a/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/CreatorPlanDetail.kt
+++ b/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/CreatorPlanDetail.kt
@@ -1,0 +1,25 @@
+package me.matsumo.fanbox.core.model.fanbox
+
+import androidx.compose.runtime.Immutable
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
+
+/** 支援プランの詳細と支援履歴。 */
+@Immutable
+data class CreatorPlanDetail(
+    val plan: CreatorPlan,
+    val supportStartDatetime: String,
+    val supportTransactions: List<SupportTransaction>,
+    val supporterCardImageUrl: String,
+) {
+    /** 支援トランザクション。 */
+    @Immutable
+    @OptIn(ExperimentalTime::class)
+    data class SupportTransaction(
+        val id: String,
+        val paidAmount: Int,
+        val transactionDatetime: Instant,
+        val targetMonth: String,
+        val user: User,
+    )
+}

--- a/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/Cursor.kt
+++ b/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/Cursor.kt
@@ -1,0 +1,17 @@
+package me.matsumo.fanbox.core.model.fanbox
+
+import androidx.compose.runtime.Immutable
+
+/**
+ * ページング用のカーソル。
+ *
+ * FANBOX API の `nextUrl` などに含まれるクエリパラメータを保持し、次ページ取得時のリクエストに用いる。
+ */
+@Immutable
+data class Cursor(
+    val firstPublishedDatetime: String?,
+    val maxPublishedDatetime: String?,
+    val firstId: String?,
+    val maxId: String?,
+    val limit: Int?,
+)

--- a/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/MetaData.kt
+++ b/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/MetaData.kt
@@ -1,0 +1,45 @@
+package me.matsumo.fanbox.core.model.fanbox
+
+import androidx.compose.runtime.Immutable
+
+/** FANBOX ページのメタデータ。 */
+@Immutable
+data class MetaData(
+    val apiUrl: String?,
+    val context: Context?,
+    val csrfToken: String,
+) {
+    /** ページ読み込み時点のコンテキスト情報。 */
+    @Immutable
+    data class Context(
+        val privacyPolicy: PrivacyPolicy,
+        val user: User,
+    ) {
+        /** プライバシーポリシーの掲示情報。 */
+        @Immutable
+        data class PrivacyPolicy(
+            val policyUrl: String,
+            val revisionHistoryUrl: String,
+            val shouldShowNotice: Boolean,
+            val updateDate: String,
+        )
+
+        /** ログイン中ユーザーの情報。 */
+        @Immutable
+        data class User(
+            val creatorId: CreatorId?,
+            val fanboxUserStatus: Int,
+            val hasAdultContent: Boolean,
+            val hasUnpaidPayments: Boolean,
+            val iconUrl: String?,
+            val isCreator: Boolean,
+            val isMailAddressOutdated: Boolean,
+            val isSupporter: Boolean,
+            val lang: String,
+            val name: String,
+            val planCount: Int,
+            val showAdultContent: Boolean,
+            val userId: UserId?,
+        )
+    }
+}

--- a/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/NewsLetter.kt
+++ b/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/NewsLetter.kt
@@ -1,0 +1,16 @@
+package me.matsumo.fanbox.core.model.fanbox
+
+import androidx.compose.runtime.Immutable
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
+
+/** ニュースレター。 */
+@Immutable
+@OptIn(ExperimentalTime::class)
+data class NewsLetter(
+    val id: NewsLetterId,
+    val body: String,
+    val createdAt: Instant,
+    val creator: Creator,
+    val isRead: Boolean,
+)

--- a/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/NewsLetterId.kt
+++ b/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/NewsLetterId.kt
@@ -1,7 +1,9 @@
 package me.matsumo.fanbox.core.model.fanbox
 
+import kotlinx.serialization.Serializable
 import kotlin.jvm.JvmInline
 
 /** ニュースレターを一意に識別する ID。 */
+@Serializable
 @JvmInline
 value class NewsLetterId(val value: String)

--- a/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/NewsLetterId.kt
+++ b/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/NewsLetterId.kt
@@ -1,0 +1,7 @@
+package me.matsumo.fanbox.core.model.fanbox
+
+import kotlin.jvm.JvmInline
+
+/** ニュースレターを一意に識別する ID。 */
+@JvmInline
+value class NewsLetterId(val value: String)

--- a/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/PageCursorInfo.kt
+++ b/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/PageCursorInfo.kt
@@ -1,0 +1,24 @@
+package me.matsumo.fanbox.core.model.fanbox
+
+import androidx.compose.runtime.Immutable
+
+/** カーソルでページングされる一覧。 */
+@Immutable
+data class PageCursorInfo<T>(
+    val contents: List<T>,
+    val cursor: Cursor?,
+)
+
+/** ページ番号でページングされる一覧。 */
+@Immutable
+data class PageNumberInfo<T>(
+    val contents: List<T>,
+    val nextPage: Int?,
+)
+
+/** オフセットでページングされる一覧。 */
+@Immutable
+data class PageOffsetInfo<T>(
+    val contents: List<T>,
+    val offset: Int?,
+)

--- a/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/PaidRecord.kt
+++ b/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/PaidRecord.kt
@@ -1,0 +1,16 @@
+package me.matsumo.fanbox.core.model.fanbox
+
+import androidx.compose.runtime.Immutable
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
+
+/** 支援の決済記録。 */
+@Immutable
+@OptIn(ExperimentalTime::class)
+data class PaidRecord(
+    val id: String,
+    val paidAmount: Int,
+    val paymentDateTime: Instant,
+    val paymentMethod: PaymentMethod,
+    val creator: Creator,
+)

--- a/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/PaymentMethod.kt
+++ b/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/PaymentMethod.kt
@@ -1,0 +1,9 @@
+package me.matsumo.fanbox.core.model.fanbox
+
+/** 支援の決済方法。 */
+enum class PaymentMethod {
+    CARD,
+    PAYPAL,
+    CVS,
+    UNKNOWN,
+}

--- a/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/PlanId.kt
+++ b/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/PlanId.kt
@@ -1,7 +1,9 @@
 package me.matsumo.fanbox.core.model.fanbox
 
+import kotlinx.serialization.Serializable
 import kotlin.jvm.JvmInline
 
 /** 支援プランを一意に識別する ID。 */
+@Serializable
 @JvmInline
 value class PlanId(val value: String)

--- a/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/PlanId.kt
+++ b/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/PlanId.kt
@@ -1,0 +1,7 @@
+package me.matsumo.fanbox.core.model.fanbox
+
+import kotlin.jvm.JvmInline
+
+/** 支援プランを一意に識別する ID。 */
+@JvmInline
+value class PlanId(val value: String)

--- a/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/Post.kt
+++ b/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/Post.kt
@@ -1,0 +1,25 @@
+package me.matsumo.fanbox.core.model.fanbox
+
+import androidx.compose.runtime.Immutable
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
+
+/** 投稿一覧に表示される投稿。 */
+@Immutable
+@OptIn(ExperimentalTime::class)
+data class Post(
+    val id: PostId,
+    val title: String,
+    val cover: Cover?,
+    val user: User?,
+    val excerpt: String,
+    val feeRequired: Int,
+    val hasAdultContent: Boolean,
+    val isLiked: Boolean,
+    val isRestricted: Boolean,
+    val likeCount: Int,
+    val commentCount: Int,
+    val tags: List<String>,
+    val publishedDatetime: Instant,
+    val updatedDatetime: Instant,
+)

--- a/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/PostDetail.kt
+++ b/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/PostDetail.kt
@@ -1,0 +1,290 @@
+package me.matsumo.fanbox.core.model.fanbox
+
+import androidx.compose.runtime.Immutable
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
+
+/** 投稿の詳細。 */
+@Immutable
+@OptIn(ExperimentalTime::class)
+data class PostDetail(
+    val id: PostId,
+    val title: String,
+    val body: Body,
+    val coverImageUrl: String?,
+    val commentCount: Int,
+    val excerpt: String,
+    val feeRequired: Int,
+    val hasAdultContent: Boolean,
+    val imageForShare: String,
+    val isLiked: Boolean,
+    val isRestricted: Boolean,
+    val likeCount: Int,
+    val tags: List<String>,
+    val updatedDatetime: Instant,
+    val publishedDatetime: Instant,
+    val nextPost: OtherPost?,
+    val prevPost: OtherPost?,
+    val user: User?,
+) {
+    /** 投稿のブラウザ表示 URL。 */
+    val browserUrl get() = "https://www.fanbox.cc/@${user?.creatorId?.value}/posts/${id.value}"
+
+    /** 投稿本文の種別。 */
+    @Immutable
+    sealed interface Body {
+        /** 本文が含む画像アイテムの一覧。 */
+        val imageItems
+            get() = when (this) {
+                is Article -> blocks.filterIsInstance<Article.Block.Image>().map {
+                    it.item
+                }
+
+                is Image -> images
+                is File -> files.mapNotNull {
+                    it.asImageItem()
+                }
+
+                is Text, is Video, is Html, is Unknown -> emptyList()
+            }
+
+        /** 本文が含むファイルアイテムの一覧。 */
+        val fileItems
+            get() = when (this) {
+                is Article -> blocks.filterIsInstance<Article.Block.File>()
+                    .map {
+                        it.item
+                    }
+
+                is Image -> emptyList()
+                is File -> files
+                is Text, is Video, is Html, is Unknown -> emptyList()
+            }
+
+        /** 記事本文。 */
+        @Immutable
+        data class Article(val blocks: List<Block>) : Body {
+            /** 記事本文を構成するブロック。 */
+            @Immutable
+            sealed interface Block {
+                /**
+                 * 記事本文の段落・見出し。
+                 *
+                 * [isHeader] で段落表示か見出し表示かを選ぶ。スパンのオフセットと長さは FANBOX
+                 * ペイロードの UTF-16 コード単位座標を使う未検証データであり、呼び出し側は適用前に
+                 * [text] の範囲内であることを検証しなければならない。
+                 */
+                @Immutable
+                data class Text(
+                    val text: String,
+                    val styles: List<StyleSpan> = emptyList(),
+                    val links: List<LinkSpan> = emptyList(),
+                    val isHeader: Boolean = false,
+                ) : Block {
+                    /**
+                     * FANBOX の UTF-16 コード単位座標による未検証の装飾範囲。
+                     *
+                     * 呼び出し側は [offset] と [length] を所有する Text の文字列範囲に照らして検証して
+                     * から装飾を適用すること。未知の [type] もそのまま保持する。
+                     */
+                    @Immutable
+                    data class StyleSpan(
+                        val type: String,
+                        val offset: Int,
+                        val length: Int,
+                    )
+
+                    /**
+                     * FANBOX の UTF-16 コード単位座標による未検証のインラインリンク範囲。
+                     *
+                     * 呼び出し側は [offset] と [length] を所有する Text の文字列範囲に照らして検証し、
+                     * ナビゲーション前に [url] をアプリの URL・スキームポリシーに照らして検証すること。
+                     */
+                    @Immutable
+                    data class LinkSpan(
+                        val offset: Int,
+                        val length: Int,
+                        val url: String,
+                    )
+                }
+
+                /** 画像ブロック。 */
+                @Immutable
+                data class Image(val item: ImageItem) : Block
+
+                /** ファイルブロック。 */
+                @Immutable
+                data class File(val item: FileItem) : Block
+
+                /**
+                 * 記事ブロックが参照する URL 埋め込み。
+                 *
+                 * [type] は FANBOX の埋め込み種別。`default` は単純な [url] を、`html` と `html.card` は
+                 * 未検証の [html] を、`fanbox.post` は [post] を表す。未知の種別は種別固有の情報を作らず
+                 * そのまま保持する。呼び出し側は [html] を描画前にサニタイズすること。
+                 */
+                @Immutable
+                data class Link(
+                    val html: String?,
+                    val post: Post?,
+                    val type: String = "unknown",
+                    val url: String? = null,
+                ) : Block
+
+                /**
+                 * サービス提供者に紐づく記事埋め込み。
+                 *
+                 * fanbox の場合 [url] はリダイレクト元 URL。リダイレクトの解決は呼び出し側のネットワーク
+                 * 責務とする。
+                 */
+                @Immutable
+                data class Embed(
+                    val serviceProvider: String,
+                    val contentId: String,
+                ) : Block {
+                    /** 対応済みサービス提供者の埋め込み URL。未対応の場合は null。 */
+                    val url: String?
+                        get() = when (serviceProvider) {
+                            "twitter" -> "https://twitter.com/_/status/$contentId"
+                            "youtube" -> "https://www.youtube.com/watch?v=$contentId"
+                            "vimeo" -> "https://vimeo.com/$contentId"
+                            "soundcloud" -> "https://soundcloud.com/$contentId"
+                            "google_forms" -> {
+                                "https://docs.google.com/forms/d/e/$contentId/viewform?usp=sf_link"
+                            }
+
+                            "fanbox" -> "https://www.pixiv.net/fanbox/$contentId"
+                            else -> null
+                        }
+                }
+
+                /**
+                 * 既知の variant に当てはまらない記事ブロック。
+                 *
+                 * [rawJson] はブロック本体の JSON、またはそのエントリが原因でフォールバックした場合は
+                 * 参照先マップエントリの JSON を保持する。
+                 */
+                @Immutable
+                data class Unknown(val rawJson: String) : Block
+            }
+        }
+
+        /** 画像本文。 */
+        @Immutable
+        data class Image(
+            val text: String,
+            val images: List<ImageItem>,
+        ) : Body
+
+        /** ファイル本文。 */
+        @Immutable
+        data class File(
+            val text: String,
+            val files: List<FileItem>,
+        ) : Body
+
+        /** テキスト本文。 */
+        @Immutable
+        data class Text(val text: String) : Body
+
+        /** 動画本文。 */
+        @Immutable
+        data class Video(
+            val serviceProvider: String,
+            val videoId: String,
+        ) : Body {
+            /** 対応済みサービス提供者の動画 URL。未対応の場合は null。 */
+            val url: String?
+                get() = when (serviceProvider) {
+                    "youtube" -> "https://www.youtube.com/watch?v=$videoId"
+                    "vimeo" -> "https://vimeo.com/$videoId"
+                    else -> null
+                }
+        }
+
+        /**
+         * FANBOX からサニタイズされずに届く HTML 本文。
+         *
+         * [html] は未検証のため、呼び出し側は描画前にサニタイズしなければならない。
+         */
+        @Immutable
+        data class Html(val html: String) : Body
+
+        /** 既知の variant に当てはまらない本文。 */
+        @Immutable
+        data class Unknown(
+            val type: String = "unknown",
+            val rawBodyJson: String? = null,
+        ) : Body
+    }
+
+    /** 前後の投稿。 */
+    @Immutable
+    @OptIn(ExperimentalTime::class)
+    data class OtherPost(
+        val id: PostId,
+        val title: String,
+        val publishedDatetime: Instant,
+    )
+
+    /** 画像アイテム。 */
+    @Immutable
+    data class ImageItem(
+        val id: PostItemId,
+        val postId: PostId,
+        val extension: String,
+        val originalUrl: String,
+        val thumbnailUrl: String,
+        val aspectRatio: Float,
+    )
+
+    /** 動画アイテム。 */
+    @Immutable
+    data class VideoItem(
+        val id: PostItemId,
+        val postId: PostId,
+        val extension: String,
+        val url: String,
+    )
+
+    /** ファイルアイテム。 */
+    @Immutable
+    data class FileItem(
+        val id: PostItemId,
+        val postId: PostId,
+        val name: String,
+        val extension: String,
+        val size: Long,
+        val url: String,
+    ) {
+        /** 画像として扱える拡張子であれば [ImageItem] へ読み替える。 */
+        fun asImageItem(): ImageItem? {
+            return if (!extension.lowercase().contains(Regex("""(jpg|jpeg|png|gif)"""))) {
+                null
+            } else {
+                ImageItem(
+                    id = id,
+                    postId = postId,
+                    extension = extension,
+                    originalUrl = url,
+                    thumbnailUrl = url,
+                    aspectRatio = 1f,
+                )
+            }
+        }
+
+        /** 動画として扱える拡張子であれば [VideoItem] へ読み替える。 */
+        fun asVideoItem(): VideoItem? {
+            return if (!extension.lowercase().contains(Regex("""(mp4|webm)"""))) {
+                null
+            } else {
+                VideoItem(
+                    id = id,
+                    postId = postId,
+                    extension = extension,
+                    url = url,
+                )
+            }
+        }
+    }
+}

--- a/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/PostId.kt
+++ b/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/PostId.kt
@@ -1,0 +1,7 @@
+package me.matsumo.fanbox.core.model.fanbox
+
+import kotlin.jvm.JvmInline
+
+/** 投稿を一意に識別する ID。 */
+@JvmInline
+value class PostId(val value: String)

--- a/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/PostId.kt
+++ b/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/PostId.kt
@@ -1,7 +1,9 @@
 package me.matsumo.fanbox.core.model.fanbox
 
+import kotlinx.serialization.Serializable
 import kotlin.jvm.JvmInline
 
 /** 投稿を一意に識別する ID。 */
+@Serializable
 @JvmInline
 value class PostId(val value: String)

--- a/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/PostItemId.kt
+++ b/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/PostItemId.kt
@@ -1,7 +1,9 @@
 package me.matsumo.fanbox.core.model.fanbox
 
+import kotlinx.serialization.Serializable
 import kotlin.jvm.JvmInline
 
 /** 投稿内のアイテム（画像・動画・ファイル）を一意に識別する ID。 */
+@Serializable
 @JvmInline
 value class PostItemId(val value: String)

--- a/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/PostItemId.kt
+++ b/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/PostItemId.kt
@@ -1,0 +1,7 @@
+package me.matsumo.fanbox.core.model.fanbox
+
+import kotlin.jvm.JvmInline
+
+/** 投稿内のアイテム（画像・動画・ファイル）を一意に識別する ID。 */
+@JvmInline
+value class PostItemId(val value: String)

--- a/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/Tag.kt
+++ b/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/Tag.kt
@@ -1,0 +1,11 @@
+package me.matsumo.fanbox.core.model.fanbox
+
+import androidx.compose.runtime.Immutable
+
+/** 投稿タグ。 */
+@Immutable
+data class Tag(
+    val count: Int,
+    val coverImageUrl: String?,
+    val name: String,
+)

--- a/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/User.kt
+++ b/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/User.kt
@@ -1,0 +1,12 @@
+package me.matsumo.fanbox.core.model.fanbox
+
+import androidx.compose.runtime.Immutable
+
+/** FANBOX のユーザー情報。 */
+@Immutable
+data class User(
+    val userId: UserId?,
+    val creatorId: CreatorId?,
+    val name: String,
+    val iconUrl: String?,
+)

--- a/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/UserId.kt
+++ b/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/UserId.kt
@@ -1,7 +1,9 @@
 package me.matsumo.fanbox.core.model.fanbox
 
+import kotlinx.serialization.Serializable
 import kotlin.jvm.JvmInline
 
 /** ユーザーを一意に識別する ID。 */
+@Serializable
 @JvmInline
 value class UserId(val value: Long)

--- a/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/UserId.kt
+++ b/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/fanbox/UserId.kt
@@ -1,0 +1,7 @@
+package me.matsumo.fanbox.core.model.fanbox
+
+import kotlin.jvm.JvmInline
+
+/** ユーザーを一意に識別する ID。 */
+@JvmInline
+value class UserId(val value: Long)

--- a/core/repository/src/androidHostTest/kotlin/me/matsumo/fanbox/core/repository/BellMapperTest.kt
+++ b/core/repository/src/androidHostTest/kotlin/me/matsumo/fanbox/core/repository/BellMapperTest.kt
@@ -1,0 +1,110 @@
+package me.matsumo.fanbox.core.repository
+
+import me.matsumo.fanbox.core.model.fanbox.Bell
+import me.matsumo.fanbox.core.repository.mapper.toBell
+import me.matsumo.fankt.fanbox.domain.model.FanboxBell
+import me.matsumo.fankt.fanbox.domain.model.FanboxPost
+import me.matsumo.fankt.fanbox.domain.model.id.FanboxCommentId
+import me.matsumo.fankt.fanbox.domain.model.id.FanboxCreatorId
+import me.matsumo.fankt.fanbox.domain.model.id.FanboxPostId
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
+
+/**
+ * [FanboxBell] からアプリ所有の [Bell] への変換を検証するテスト。
+ *
+ * 3 つの subtype を分岐で振り分けており、[FanboxBell.Comment] は同じ型の文字列を 4 つ並べて持つ。
+ * 取り違えても型が合うためコンパイルでは捕まらない。
+ */
+@OptIn(ExperimentalTime::class)
+class BellMapperTest {
+
+    private val notifiedDatetime = Instant.parse("2024-03-01T00:00:00Z")
+
+    /** コメント通知の全フィールドが写ることを確認する。 */
+    @Test
+    fun commentBellConversionPreservesAllFields() {
+        val fanboxBell = FanboxBell.Comment(
+            id = FanboxCommentId("comment-1"),
+            notifiedDatetime = notifiedDatetime,
+            comment = "comment body",
+            isRootComment = true,
+            creatorId = FanboxCreatorId("creator-1"),
+            postId = FanboxPostId("post-1"),
+            postTitle = "post title",
+            userName = "user name",
+            userProfileIconUrl = "https://example.com/icon.png",
+        )
+
+        val bell = assertIs<Bell.Comment>(fanboxBell.toBell())
+
+        assertEquals("comment-1", bell.id.value)
+        assertEquals(notifiedDatetime, bell.notifiedDatetime)
+        assertEquals("comment body", bell.comment)
+        assertEquals(true, bell.isRootComment)
+        assertEquals("creator-1", bell.creatorId.value)
+        assertEquals("post-1", bell.postId.value)
+        assertEquals("post title", bell.postTitle)
+        assertEquals("user name", bell.userName)
+        assertEquals("https://example.com/icon.png", bell.userProfileIconUrl)
+    }
+
+    /** いいね通知の全フィールドが写ることを確認する。 */
+    @Test
+    fun likeBellConversionPreservesAllFields() {
+        val fanboxBell = FanboxBell.Like(
+            id = "like-1",
+            notifiedDatetime = notifiedDatetime,
+            comment = "like comment",
+            creatorId = FanboxCreatorId("creator-1"),
+            postId = FanboxPostId("post-1"),
+            count = 7,
+        )
+
+        val bell = assertIs<Bell.Like>(fanboxBell.toBell())
+
+        assertEquals("like-1", bell.id)
+        assertEquals(notifiedDatetime, bell.notifiedDatetime)
+        assertEquals("like comment", bell.comment)
+        assertEquals("creator-1", bell.creatorId.value)
+        assertEquals("post-1", bell.postId.value)
+        assertEquals(7, bell.count)
+    }
+
+    /** 投稿公開通知が、入れ子の投稿ごと写ることを確認する。 */
+    @Test
+    fun postPublishedBellConversionPreservesTheNestedPost() {
+        val fanboxPost = FanboxPost(
+            id = FanboxPostId("post-1"),
+            title = "title",
+            cover = null,
+            user = null,
+            excerpt = "excerpt",
+            feeRequired = 100,
+            hasAdultContent = false,
+            isLiked = false,
+            isRestricted = true,
+            likeCount = 1,
+            commentCount = 2,
+            tags = listOf("tag"),
+            publishedDatetime = notifiedDatetime,
+            updatedDatetime = notifiedDatetime,
+        )
+        val fanboxBell = FanboxBell.PostPublished(
+            id = FanboxPostId("post-1"),
+            notifiedDatetime = notifiedDatetime,
+            post = fanboxPost,
+        )
+
+        val bell = assertIs<Bell.PostPublished>(fanboxBell.toBell())
+
+        assertEquals("post-1", bell.id.value)
+        assertEquals(notifiedDatetime, bell.notifiedDatetime)
+        assertEquals("title", bell.post.title)
+        assertEquals(100, bell.post.feeRequired)
+        assertEquals(listOf("tag"), bell.post.tags)
+    }
+}

--- a/core/repository/src/androidHostTest/kotlin/me/matsumo/fanbox/core/repository/CommentMapperTest.kt
+++ b/core/repository/src/androidHostTest/kotlin/me/matsumo/fanbox/core/repository/CommentMapperTest.kt
@@ -1,0 +1,88 @@
+package me.matsumo.fanbox.core.repository
+
+import me.matsumo.fanbox.core.repository.mapper.toComment
+import me.matsumo.fankt.fanbox.domain.model.FanboxComment
+import me.matsumo.fankt.fanbox.domain.model.FanboxUser
+import me.matsumo.fankt.fanbox.domain.model.id.FanboxCommentId
+import me.matsumo.fankt.fanbox.domain.model.id.FanboxCreatorId
+import me.matsumo.fankt.fanbox.domain.model.id.FanboxUserId
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
+
+/**
+ * [FanboxComment] からアプリ所有のコメントへの変換を検証するテスト。
+ *
+ * 返信を再帰的にたどるうえ、[FanboxComment.parentCommentId] と [FanboxComment.rootCommentId] が
+ * 同じ型である。取り違えても型が合うためコンパイルでは捕まらない。
+ */
+@OptIn(ExperimentalTime::class)
+class CommentMapperTest {
+
+    private val createdDatetime = Instant.parse("2024-03-01T00:00:00Z")
+
+    private fun comment(
+        id: String,
+        body: String,
+        replies: List<FanboxComment> = emptyList(),
+    ) = FanboxComment(
+        body = body,
+        createdDatetime = createdDatetime,
+        id = FanboxCommentId(id),
+        isLiked = true,
+        isOwn = false,
+        likeCount = 3,
+        parentCommentId = FanboxCommentId("parent-$id"),
+        rootCommentId = FanboxCommentId("root-$id"),
+        replies = replies,
+        user = FanboxUser(
+            userId = FanboxUserId(200),
+            creatorId = FanboxCreatorId("creator-1"),
+            name = "user name",
+            iconUrl = "https://example.com/icon.png",
+        ),
+    )
+
+    /** 全フィールドが写ることを確認する。親とルートの ID を取り違えないことを含む。 */
+    @Test
+    fun commentConversionPreservesAllFields() {
+        val fanboxComment = comment(id = "comment-1", body = "body")
+
+        val converted = fanboxComment.toComment()
+
+        assertEquals("body", converted.body)
+        assertEquals(createdDatetime, converted.createdDatetime)
+        assertEquals("comment-1", converted.id.value)
+        assertEquals(true, converted.isLiked)
+        assertEquals(false, converted.isOwn)
+        assertEquals(3, converted.likeCount)
+        assertEquals("parent-comment-1", converted.parentCommentId.value)
+        assertEquals("root-comment-1", converted.rootCommentId.value)
+        assertEquals(200L, converted.user?.userId?.value)
+        assertEquals("user name", converted.user?.name)
+    }
+
+    /** 入れ子の返信が深さを保ったまま写ることを確認する。 */
+    @Test
+    fun nestedRepliesAreConvertedRecursively() {
+        val fanboxComment = comment(
+            id = "comment-1",
+            body = "root body",
+            replies = listOf(
+                comment(
+                    id = "comment-2",
+                    body = "reply body",
+                    replies = listOf(comment(id = "comment-3", body = "nested reply body")),
+                ),
+            ),
+        )
+
+        val converted = fanboxComment.toComment()
+
+        assertEquals("reply body", converted.replies.single().body)
+        assertEquals("comment-2", converted.replies.single().id.value)
+        assertEquals("nested reply body", converted.replies.single().replies.single().body)
+        assertEquals("comment-3", converted.replies.single().replies.single().id.value)
+    }
+}

--- a/core/repository/src/androidHostTest/kotlin/me/matsumo/fanbox/core/repository/CreatorDetailMapperTest.kt
+++ b/core/repository/src/androidHostTest/kotlin/me/matsumo/fanbox/core/repository/CreatorDetailMapperTest.kt
@@ -1,0 +1,120 @@
+package me.matsumo.fanbox.core.repository
+
+import me.matsumo.fanbox.core.model.fanbox.CreatorDetail
+import me.matsumo.fanbox.core.model.fanbox.CreatorDetail.Platform
+import me.matsumo.fanbox.core.model.fanbox.CreatorDetail.ProfileItem
+import me.matsumo.fanbox.core.repository.mapper.toCreatorDetail
+import me.matsumo.fankt.fanbox.domain.model.FanboxCreatorDetail
+import me.matsumo.fankt.fanbox.domain.model.FanboxUser
+import me.matsumo.fankt.fanbox.domain.model.id.FanboxCreatorId
+import me.matsumo.fankt.fanbox.domain.model.id.FanboxUserId
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import me.matsumo.fankt.fanbox.domain.model.FanboxCreatorDetail.Platform as FanktPlatform
+import me.matsumo.fankt.fanbox.domain.model.FanboxCreatorDetail.ProfileItem as FanktProfileItem
+import me.matsumo.fankt.fanbox.domain.model.FanboxCreatorDetail.ProfileLink as FanktProfileLink
+
+/** [FanboxCreatorDetail] から [CreatorDetail] への変換を検証するテスト。 */
+class CreatorDetailMapperTest {
+
+    private val imageProfileItem = FanktProfileItem.Image(
+        id = "profile-image",
+        imageUrl = "https://example.com/profile.png",
+        thumbnailUrl = "https://example.com/profile-thumb.png",
+    )
+
+    private val videoProfileItem = FanktProfileItem.Video(
+        id = "profile-video",
+        serviceProvider = "youtube",
+        videoId = "video-id",
+        thumbnailUrl = "https://example.com/video-thumb.png",
+    )
+
+    private val unknownProfileItem = FanktProfileItem.Unknown(
+        id = "profile-unknown",
+        type = "mystery",
+        rawJson = """{"itemType":"mystery"}""",
+    )
+
+    private val fanboxCreatorDetail = FanboxCreatorDetail(
+        creatorId = FanboxCreatorId("creator-1"),
+        coverImageUrl = "https://example.com/cover.png",
+        description = "description",
+        hasAdultContent = true,
+        hasBoothShop = true,
+        isAcceptingRequest = true,
+        isFollowed = false,
+        isStopped = false,
+        isSupported = true,
+        profileItems = listOf(imageProfileItem, videoProfileItem, unknownProfileItem),
+        profileLinks = listOf(
+            FanktProfileLink(url = "https://twitter.com/example", link = FanktPlatform.TWITTER),
+            FanktProfileLink(url = "https://example.com", link = FanktPlatform.UNKNOWN),
+        ),
+        user = FanboxUser(
+            userId = FanboxUserId(100),
+            creatorId = FanboxCreatorId("creator-1"),
+            name = "creator name",
+            iconUrl = "https://example.com/icon.png",
+        ),
+    )
+
+    /** クリエイター詳細の全フィールドが値を保ったまま変換されることを確認する。値が欠けていても検出できないため。 */
+    @Test
+    fun creatorDetailConversionPreservesAllFields() {
+        val creatorDetail = fanboxCreatorDetail.toCreatorDetail()
+
+        assertEquals(fanboxCreatorDetail.creatorId.value, creatorDetail.creatorId.value)
+        assertEquals(fanboxCreatorDetail.coverImageUrl, creatorDetail.coverImageUrl)
+        assertEquals(fanboxCreatorDetail.description, creatorDetail.description)
+        assertEquals(fanboxCreatorDetail.hasAdultContent, creatorDetail.hasAdultContent)
+        assertEquals(fanboxCreatorDetail.hasBoothShop, creatorDetail.hasBoothShop)
+        assertEquals(fanboxCreatorDetail.isAcceptingRequest, creatorDetail.isAcceptingRequest)
+        assertEquals(fanboxCreatorDetail.isFollowed, creatorDetail.isFollowed)
+        assertEquals(fanboxCreatorDetail.isStopped, creatorDetail.isStopped)
+        assertEquals(fanboxCreatorDetail.isSupported, creatorDetail.isSupported)
+        assertEquals(fanboxCreatorDetail.user?.userId?.value, creatorDetail.user?.userId?.value)
+        assertEquals(fanboxCreatorDetail.user?.name, creatorDetail.user?.name)
+
+        assertEquals(2, creatorDetail.profileLinks.size)
+        assertEquals(fanboxCreatorDetail.profileLinks[0].url, creatorDetail.profileLinks[0].url)
+        assertEquals(Platform.TWITTER, creatorDetail.profileLinks[0].link)
+        assertEquals(Platform.UNKNOWN, creatorDetail.profileLinks[1].link)
+    }
+
+    /** プロフィールアイテムの3種類すべてが変換でき、未知種別は raw JSON を保持することを確認する。 */
+    @Test
+    fun profileItemVariantsConvertSuccessfullyAndPreserveRawJson() {
+        val profileItems = fanboxCreatorDetail.toCreatorDetail().profileItems
+
+        assertEquals(3, profileItems.size)
+
+        val image = assertIs<ProfileItem.Image>(profileItems[0])
+        assertEquals(imageProfileItem.id, image.id)
+        assertEquals(imageProfileItem.imageUrl, image.imageUrl)
+
+        val video = assertIs<ProfileItem.Video>(profileItems[1])
+        assertEquals(videoProfileItem.id, video.id)
+        assertEquals(videoProfileItem.serviceProvider, video.serviceProvider)
+
+        val unknown = assertIs<ProfileItem.Unknown>(profileItems[2])
+        assertEquals(unknownProfileItem.id, unknown.id)
+        assertEquals(unknownProfileItem.type, unknown.type)
+        assertEquals(unknownProfileItem.rawJson, unknown.rawJson)
+    }
+
+    /**
+     * fankt から移植した派生メンバーが、fankt の元実装と同じ値を返すことを確認する。
+     * 独自ロジックで再実装すると計算式のズレに気付けないため、fankt 側の値と突き合わせる。
+     */
+    @Test
+    fun derivedMembersMatchFanktValues() {
+        val creatorDetail = fanboxCreatorDetail.toCreatorDetail()
+
+        assertEquals(fanboxCreatorDetail.supportingBrowserUrl, creatorDetail.supportingBrowserUrl)
+
+        val video = assertIs<ProfileItem.Video>(creatorDetail.profileItems[1])
+        assertEquals(videoProfileItem.url, video.url)
+    }
+}

--- a/core/repository/src/androidHostTest/kotlin/me/matsumo/fanbox/core/repository/CreatorPlanDetailMapperTest.kt
+++ b/core/repository/src/androidHostTest/kotlin/me/matsumo/fanbox/core/repository/CreatorPlanDetailMapperTest.kt
@@ -1,0 +1,84 @@
+package me.matsumo.fanbox.core.repository
+
+import me.matsumo.fanbox.core.repository.mapper.toCreatorPlanDetail
+import me.matsumo.fankt.fanbox.domain.model.FanboxCreatorPlan
+import me.matsumo.fankt.fanbox.domain.model.FanboxCreatorPlanDetail
+import me.matsumo.fankt.fanbox.domain.model.FanboxPaymentMethod
+import me.matsumo.fankt.fanbox.domain.model.FanboxUser
+import me.matsumo.fankt.fanbox.domain.model.id.FanboxCreatorId
+import me.matsumo.fankt.fanbox.domain.model.id.FanboxPlanId
+import me.matsumo.fankt.fanbox.domain.model.id.FanboxUserId
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
+
+/**
+ * [FanboxCreatorPlanDetail] からアプリ所有のプラン詳細への変換を検証するテスト。
+ *
+ * 支援履歴を一覧で写すうえ、[FanboxCreatorPlanDetail.supportStartDatetime] と
+ * [FanboxCreatorPlanDetail.SupportTransaction.targetMonth] がどちらも文字列である。
+ */
+@OptIn(ExperimentalTime::class)
+class CreatorPlanDetailMapperTest {
+
+    private val transactionDatetime = Instant.parse("2024-02-01T00:00:00Z")
+
+    private val user = FanboxUser(
+        userId = FanboxUserId(400),
+        creatorId = FanboxCreatorId("creator-1"),
+        name = "creator name",
+        iconUrl = "https://example.com/icon.png",
+    )
+
+    private val fanboxPlanDetail = FanboxCreatorPlanDetail(
+        plan = FanboxCreatorPlan(
+            id = FanboxPlanId("plan-1"),
+            title = "plan title",
+            description = "plan description",
+            fee = 1000,
+            coverImageUrl = "https://example.com/plan.png",
+            hasAdultContent = true,
+            paymentMethod = FanboxPaymentMethod.CARD,
+            user = user,
+        ),
+        supportStartDatetime = "2024-01-15",
+        supportTransactions = listOf(
+            FanboxCreatorPlanDetail.SupportTransaction(
+                id = "transaction-1",
+                paidAmount = 1000,
+                transactionDatetime = transactionDatetime,
+                targetMonth = "2024-02",
+                user = user,
+            ),
+        ),
+        supporterCardImageUrl = "https://example.com/card.png",
+    )
+
+    /** 入れ子のプランと支援履歴を含む全フィールドが写ることを確認する。 */
+    @Test
+    fun creatorPlanDetailConversionPreservesAllFields() {
+        val planDetail = fanboxPlanDetail.toCreatorPlanDetail()
+
+        assertEquals("plan-1", planDetail.plan.id.value)
+        assertEquals("plan title", planDetail.plan.title)
+        assertEquals(1000, planDetail.plan.fee)
+        assertEquals("2024-01-15", planDetail.supportStartDatetime)
+        assertEquals("https://example.com/card.png", planDetail.supporterCardImageUrl)
+
+        val transaction = planDetail.supportTransactions.single()
+        assertEquals("transaction-1", transaction.id)
+        assertEquals(1000, transaction.paidAmount)
+        assertEquals(transactionDatetime, transaction.transactionDatetime)
+        assertEquals("2024-02", transaction.targetMonth)
+        assertEquals(400L, transaction.user.userId?.value)
+    }
+
+    /** 支援履歴が無い場合も安全に変換できることを確認する。 */
+    @Test
+    fun creatorPlanDetailConversionHandlesEmptyTransactions() {
+        val planDetail = fanboxPlanDetail.copy(supportTransactions = emptyList()).toCreatorPlanDetail()
+
+        assertEquals(emptyList(), planDetail.supportTransactions)
+    }
+}

--- a/core/repository/src/androidHostTest/kotlin/me/matsumo/fanbox/core/repository/CreatorPlanMapperTest.kt
+++ b/core/repository/src/androidHostTest/kotlin/me/matsumo/fanbox/core/repository/CreatorPlanMapperTest.kt
@@ -1,0 +1,57 @@
+package me.matsumo.fanbox.core.repository
+
+import me.matsumo.fanbox.core.repository.mapper.toCreatorPlan
+import me.matsumo.fankt.fanbox.domain.model.FanboxCreatorPlan
+import me.matsumo.fankt.fanbox.domain.model.FanboxPaymentMethod
+import me.matsumo.fankt.fanbox.domain.model.FanboxUser
+import me.matsumo.fankt.fanbox.domain.model.id.FanboxCreatorId
+import me.matsumo.fankt.fanbox.domain.model.id.FanboxPlanId
+import me.matsumo.fankt.fanbox.domain.model.id.FanboxUserId
+import org.junit.Test
+import kotlin.test.assertEquals
+
+/** [FanboxCreatorPlan] から [me.matsumo.fanbox.core.model.fanbox.CreatorPlan] への変換を検証するテスト。 */
+class CreatorPlanMapperTest {
+
+    private val fanboxCreatorPlan = FanboxCreatorPlan(
+        id = FanboxPlanId("plan-1"),
+        title = "title",
+        description = "description",
+        fee = 1000,
+        coverImageUrl = "https://example.com/cover.png",
+        hasAdultContent = true,
+        paymentMethod = FanboxPaymentMethod.CARD,
+        user = FanboxUser(
+            userId = FanboxUserId(100),
+            creatorId = FanboxCreatorId("creator-1"),
+            name = "creator name",
+            iconUrl = "https://example.com/icon.png",
+        ),
+    )
+
+    /** 支援プランの全フィールドが値を保ったまま変換されることを確認する。 */
+    @Test
+    fun creatorPlanConversionPreservesAllFields() {
+        val creatorPlan = fanboxCreatorPlan.toCreatorPlan()
+
+        assertEquals(fanboxCreatorPlan.id.value, creatorPlan.id.value)
+        assertEquals(fanboxCreatorPlan.title, creatorPlan.title)
+        assertEquals(fanboxCreatorPlan.description, creatorPlan.description)
+        assertEquals(fanboxCreatorPlan.fee, creatorPlan.fee)
+        assertEquals(fanboxCreatorPlan.coverImageUrl, creatorPlan.coverImageUrl)
+        assertEquals(fanboxCreatorPlan.hasAdultContent, creatorPlan.hasAdultContent)
+        assertEquals(fanboxCreatorPlan.user?.userId?.value, creatorPlan.user?.userId?.value)
+    }
+
+    /**
+     * fankt から移植した派生メンバーが、fankt の元実装と同じ値を返すことを確認する。
+     * 独自ロジックで再実装すると計算式のズレに気付けないため、fankt 側の値と突き合わせる。
+     */
+    @Test
+    fun derivedMembersMatchFanktValues() {
+        val creatorPlan = fanboxCreatorPlan.toCreatorPlan()
+
+        assertEquals(fanboxCreatorPlan.planBrowserUrl, creatorPlan.planBrowserUrl)
+        assertEquals(fanboxCreatorPlan.supportingBrowserUrl, creatorPlan.supportingBrowserUrl)
+    }
+}

--- a/core/repository/src/androidHostTest/kotlin/me/matsumo/fanbox/core/repository/IdCursorPagingRoundTripTest.kt
+++ b/core/repository/src/androidHostTest/kotlin/me/matsumo/fanbox/core/repository/IdCursorPagingRoundTripTest.kt
@@ -12,12 +12,7 @@ import me.matsumo.fanbox.core.repository.mapper.toFanboxCreatorId
 import me.matsumo.fanbox.core.repository.mapper.toFanboxCursor
 import me.matsumo.fanbox.core.repository.mapper.toFanboxPostId
 import me.matsumo.fanbox.core.repository.mapper.toFanboxUserId
-import me.matsumo.fanbox.core.repository.mapper.toFanktPageCursorInfo
-import me.matsumo.fanbox.core.repository.mapper.toFanktPageNumberInfo
-import me.matsumo.fanbox.core.repository.mapper.toFanktPageOffsetInfo
 import me.matsumo.fanbox.core.repository.mapper.toPageCursorInfo
-import me.matsumo.fanbox.core.repository.mapper.toPageNumberInfo
-import me.matsumo.fanbox.core.repository.mapper.toPageOffsetInfo
 import me.matsumo.fanbox.core.repository.mapper.toPostId
 import me.matsumo.fanbox.core.repository.mapper.toUserId
 import me.matsumo.fankt.fanbox.domain.FanboxCursor
@@ -28,10 +23,8 @@ import me.matsumo.fankt.fanbox.domain.model.id.FanboxUserId
 import org.junit.Test
 import kotlin.test.assertEquals
 import me.matsumo.fankt.fanbox.domain.PageCursorInfo as FanktPageCursorInfo
-import me.matsumo.fankt.fanbox.domain.PageNumberInfo as FanktPageNumberInfo
-import me.matsumo.fankt.fanbox.domain.PageOffsetInfo as FanktPageOffsetInfo
 
-/** ID・Cursor・ページング型の fankt ↔ app 往復変換が元の値へ戻ることを検証するテスト。 */
+/** ID と Cursor の fankt ↔ app 往復変換が元の値へ戻ることを検証するテスト。 */
 class IdCursorPagingRoundTripTest {
 
     @Test
@@ -87,45 +80,6 @@ class IdCursorPagingRoundTripTest {
         )
 
         assertEquals(original, original.toCursor().toFanboxCursor())
-    }
-
-    @Test
-    fun pageCursorInfoRoundTripReturnsOriginalValue() {
-        val original = FanktPageCursorInfo(
-            contents = listOf("a", "b"),
-            cursor = FanboxCursor(
-                firstPublishedDatetime = null,
-                maxPublishedDatetime = null,
-                firstId = "1",
-                maxId = "2",
-                limit = 10,
-            ),
-        )
-
-        assertEquals(
-            original,
-            original.toPageCursorInfo { it }.toFanktPageCursorInfo { it },
-        )
-    }
-
-    @Test
-    fun pageNumberInfoRoundTripReturnsOriginalValue() {
-        val original = FanktPageNumberInfo(contents = listOf("a", "b"), nextPage = 2)
-
-        assertEquals(
-            original,
-            original.toPageNumberInfo { it }.toFanktPageNumberInfo { it },
-        )
-    }
-
-    @Test
-    fun pageOffsetInfoRoundTripReturnsOriginalValue() {
-        val original = FanktPageOffsetInfo(contents = listOf("a", "b"), offset = 20)
-
-        assertEquals(
-            original,
-            original.toPageOffsetInfo { it }.toFanktPageOffsetInfo { it },
-        )
     }
 
     /** 空リストや null カーソルでもページング型が破綻しないことを確認する。 */

--- a/core/repository/src/androidHostTest/kotlin/me/matsumo/fanbox/core/repository/IdCursorPagingRoundTripTest.kt
+++ b/core/repository/src/androidHostTest/kotlin/me/matsumo/fanbox/core/repository/IdCursorPagingRoundTripTest.kt
@@ -1,0 +1,141 @@
+package me.matsumo.fanbox.core.repository
+
+import me.matsumo.fanbox.core.model.fanbox.CommentId
+import me.matsumo.fanbox.core.model.fanbox.CreatorId
+import me.matsumo.fanbox.core.model.fanbox.PostId
+import me.matsumo.fanbox.core.model.fanbox.UserId
+import me.matsumo.fanbox.core.repository.mapper.toCommentId
+import me.matsumo.fanbox.core.repository.mapper.toCreatorId
+import me.matsumo.fanbox.core.repository.mapper.toCursor
+import me.matsumo.fanbox.core.repository.mapper.toFanboxCommentId
+import me.matsumo.fanbox.core.repository.mapper.toFanboxCreatorId
+import me.matsumo.fanbox.core.repository.mapper.toFanboxCursor
+import me.matsumo.fanbox.core.repository.mapper.toFanboxPostId
+import me.matsumo.fanbox.core.repository.mapper.toFanboxUserId
+import me.matsumo.fanbox.core.repository.mapper.toFanktPageCursorInfo
+import me.matsumo.fanbox.core.repository.mapper.toFanktPageNumberInfo
+import me.matsumo.fanbox.core.repository.mapper.toFanktPageOffsetInfo
+import me.matsumo.fanbox.core.repository.mapper.toPageCursorInfo
+import me.matsumo.fanbox.core.repository.mapper.toPageNumberInfo
+import me.matsumo.fanbox.core.repository.mapper.toPageOffsetInfo
+import me.matsumo.fanbox.core.repository.mapper.toPostId
+import me.matsumo.fanbox.core.repository.mapper.toUserId
+import me.matsumo.fankt.fanbox.domain.FanboxCursor
+import me.matsumo.fankt.fanbox.domain.model.id.FanboxCommentId
+import me.matsumo.fankt.fanbox.domain.model.id.FanboxCreatorId
+import me.matsumo.fankt.fanbox.domain.model.id.FanboxPostId
+import me.matsumo.fankt.fanbox.domain.model.id.FanboxUserId
+import org.junit.Test
+import kotlin.test.assertEquals
+import me.matsumo.fankt.fanbox.domain.PageCursorInfo as FanktPageCursorInfo
+import me.matsumo.fankt.fanbox.domain.PageNumberInfo as FanktPageNumberInfo
+import me.matsumo.fankt.fanbox.domain.PageOffsetInfo as FanktPageOffsetInfo
+
+/** ID・Cursor・ページング型の fankt ↔ app 往復変換が元の値へ戻ることを検証するテスト。 */
+class IdCursorPagingRoundTripTest {
+
+    @Test
+    fun postIdRoundTripReturnsOriginalValue() {
+        val original = FanboxPostId("post-1")
+
+        assertEquals(original, original.toPostId().toFanboxPostId())
+    }
+
+    @Test
+    fun creatorIdRoundTripReturnsOriginalValue() {
+        val original = FanboxCreatorId("creator-1")
+
+        assertEquals(original, original.toCreatorId().toFanboxCreatorId())
+    }
+
+    @Test
+    fun userIdRoundTripReturnsOriginalValue() {
+        val original = FanboxUserId(100)
+
+        assertEquals(original, original.toUserId().toFanboxUserId())
+    }
+
+    @Test
+    fun commentIdRoundTripReturnsOriginalValue() {
+        val original = FanboxCommentId("comment-1")
+
+        assertEquals(original, original.toCommentId().toFanboxCommentId())
+    }
+
+    /** app 側 ID から往復しても値が戻ることを確認する。app 側で生成した ID を fankt へ送る経路のため。 */
+    @Test
+    fun appOwnedIdRoundTripReturnsOriginalValue() {
+        val postId = PostId("post-1")
+        val creatorId = CreatorId("creator-1")
+        val userId = UserId(100)
+        val commentId = CommentId("comment-1")
+
+        assertEquals(postId, postId.toFanboxPostId().toPostId())
+        assertEquals(creatorId, creatorId.toFanboxCreatorId().toCreatorId())
+        assertEquals(userId, userId.toFanboxUserId().toUserId())
+        assertEquals(commentId, commentId.toFanboxCommentId().toCommentId())
+    }
+
+    @Test
+    fun cursorRoundTripReturnsOriginalValue() {
+        val original = FanboxCursor(
+            firstPublishedDatetime = "2024-01-01T00:00:00Z",
+            maxPublishedDatetime = "2024-01-02T00:00:00Z",
+            firstId = "1",
+            maxId = "2",
+            limit = 10,
+        )
+
+        assertEquals(original, original.toCursor().toFanboxCursor())
+    }
+
+    @Test
+    fun pageCursorInfoRoundTripReturnsOriginalValue() {
+        val original = FanktPageCursorInfo(
+            contents = listOf("a", "b"),
+            cursor = FanboxCursor(
+                firstPublishedDatetime = null,
+                maxPublishedDatetime = null,
+                firstId = "1",
+                maxId = "2",
+                limit = 10,
+            ),
+        )
+
+        assertEquals(
+            original,
+            original.toPageCursorInfo { it }.toFanktPageCursorInfo { it },
+        )
+    }
+
+    @Test
+    fun pageNumberInfoRoundTripReturnsOriginalValue() {
+        val original = FanktPageNumberInfo(contents = listOf("a", "b"), nextPage = 2)
+
+        assertEquals(
+            original,
+            original.toPageNumberInfo { it }.toFanktPageNumberInfo { it },
+        )
+    }
+
+    @Test
+    fun pageOffsetInfoRoundTripReturnsOriginalValue() {
+        val original = FanktPageOffsetInfo(contents = listOf("a", "b"), offset = 20)
+
+        assertEquals(
+            original,
+            original.toPageOffsetInfo { it }.toFanktPageOffsetInfo { it },
+        )
+    }
+
+    /** 空リストや null カーソルでもページング型が破綻しないことを確認する。 */
+    @Test
+    fun pageCursorInfoHandlesEmptyContentsAndNullCursor() {
+        val original = FanktPageCursorInfo<String>(contents = emptyList(), cursor = null)
+
+        val converted = original.toPageCursorInfo { it }
+
+        assertEquals(emptyList(), converted.contents)
+        assertEquals(null, converted.cursor)
+    }
+}

--- a/core/repository/src/androidHostTest/kotlin/me/matsumo/fanbox/core/repository/MetaDataMapperTest.kt
+++ b/core/repository/src/androidHostTest/kotlin/me/matsumo/fanbox/core/repository/MetaDataMapperTest.kt
@@ -1,0 +1,87 @@
+package me.matsumo.fanbox.core.repository
+
+import me.matsumo.fanbox.core.repository.mapper.toMetaData
+import me.matsumo.fankt.fanbox.domain.model.FanboxMetaData
+import me.matsumo.fankt.fanbox.domain.model.FanboxMetaData.Context
+import me.matsumo.fankt.fanbox.domain.model.id.FanboxCreatorId
+import me.matsumo.fankt.fanbox.domain.model.id.FanboxUserId
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * [FanboxMetaData] からアプリ所有のメタデータへの変換を検証するテスト。
+ *
+ * 入れ子が 2 段あり、[Context.User] は同じ型の真偽値を 6 つ並べて持つ。取り違えても型が合うため
+ * コンパイルでは捕まらない。ここが崩れると成人向け表示の可否や支援者判定が入れ替わる。
+ */
+class MetaDataMapperTest {
+
+    private val fanboxMetaData = FanboxMetaData(
+        apiUrl = "https://api.fanbox.cc",
+        context = Context(
+            privacyPolicy = Context.PrivacyPolicy(
+                policyUrl = "https://example.com/policy",
+                revisionHistoryUrl = "https://example.com/history",
+                shouldShowNotice = true,
+                updateDate = "2024-01-01",
+            ),
+            user = Context.User(
+                creatorId = FanboxCreatorId("creator-1"),
+                fanboxUserStatus = 2,
+                hasAdultContent = true,
+                hasUnpaidPayments = false,
+                iconUrl = "https://example.com/icon.png",
+                isCreator = true,
+                isMailAddressOutdated = false,
+                isSupporter = true,
+                lang = "ja",
+                name = "user name",
+                planCount = 3,
+                showAdultContent = false,
+                userId = FanboxUserId(300),
+            ),
+        ),
+        csrfToken = "token",
+    )
+
+    /** 入れ子を含む全フィールドが写ることを確認する。真偽値の取り違えを含む。 */
+    @Test
+    fun metaDataConversionPreservesAllFields() {
+        val metaData = fanboxMetaData.toMetaData()
+
+        assertEquals("https://api.fanbox.cc", metaData.apiUrl)
+        assertEquals("token", metaData.csrfToken)
+
+        val privacyPolicy = metaData.context?.privacyPolicy
+        assertEquals("https://example.com/policy", privacyPolicy?.policyUrl)
+        assertEquals("https://example.com/history", privacyPolicy?.revisionHistoryUrl)
+        assertEquals(true, privacyPolicy?.shouldShowNotice)
+        assertEquals("2024-01-01", privacyPolicy?.updateDate)
+
+        val user = metaData.context?.user
+        assertEquals("creator-1", user?.creatorId?.value)
+        assertEquals(2, user?.fanboxUserStatus)
+        assertEquals(true, user?.hasAdultContent)
+        assertEquals(false, user?.hasUnpaidPayments)
+        assertEquals("https://example.com/icon.png", user?.iconUrl)
+        assertEquals(true, user?.isCreator)
+        assertEquals(false, user?.isMailAddressOutdated)
+        assertEquals(true, user?.isSupporter)
+        assertEquals("ja", user?.lang)
+        assertEquals("user name", user?.name)
+        assertEquals(3, user?.planCount)
+        assertEquals(false, user?.showAdultContent)
+        assertEquals(300L, user?.userId?.value)
+    }
+
+    /** context が無い場合も安全に変換できることを確認する。 */
+    @Test
+    fun metaDataConversionHandlesMissingContext() {
+        val metaData = fanboxMetaData.copy(apiUrl = null, context = null).toMetaData()
+
+        assertNull(metaData.apiUrl)
+        assertNull(metaData.context)
+        assertEquals("token", metaData.csrfToken)
+    }
+}

--- a/core/repository/src/androidHostTest/kotlin/me/matsumo/fanbox/core/repository/MetaDataMapperTest.kt
+++ b/core/repository/src/androidHostTest/kotlin/me/matsumo/fanbox/core/repository/MetaDataMapperTest.kt
@@ -1,5 +1,6 @@
 package me.matsumo.fanbox.core.repository
 
+import me.matsumo.fanbox.core.model.fanbox.MetaData
 import me.matsumo.fanbox.core.repository.mapper.toMetaData
 import me.matsumo.fankt.fanbox.domain.model.FanboxMetaData
 import me.matsumo.fankt.fanbox.domain.model.FanboxMetaData.Context
@@ -45,6 +46,24 @@ class MetaDataMapperTest {
         csrfToken = "token",
     )
 
+    private val flagReaders: List<(MetaData.Context.User) -> Boolean> = listOf(
+        { it.hasAdultContent },
+        { it.hasUnpaidPayments },
+        { it.isCreator },
+        { it.isMailAddressOutdated },
+        { it.isSupporter },
+        { it.showAdultContent },
+    )
+
+    private val allFlagsDown: Context.User = requireNotNull(fanboxMetaData.context).user.copy(
+        hasAdultContent = false,
+        hasUnpaidPayments = false,
+        isCreator = false,
+        isMailAddressOutdated = false,
+        isSupporter = false,
+        showAdultContent = false,
+    )
+
     /** 入れ子を含む全フィールドが写ることを確認する。真偽値の取り違えを含む。 */
     @Test
     fun metaDataConversionPreservesAllFields() {
@@ -75,6 +94,22 @@ class MetaDataMapperTest {
         assertEquals(300L, user?.userId?.value)
     }
 
+    /**
+     * 6 つの真偽値がそれぞれ自分のフィールドへ写ることを確認する。
+     *
+     * 同じ値どうしの取り違えは、真偽値を並べた fixture では検出できない。1 つだけを立てた入力を
+     * 6 通り作り、立った先が 1 つだけであることを見る。
+     */
+    @Test
+    fun eachUserFlagIsMappedToItsOwnField() {
+        assertOnlyThisFlagIsRaised({ it.copy(hasAdultContent = true) }, { it.hasAdultContent })
+        assertOnlyThisFlagIsRaised({ it.copy(hasUnpaidPayments = true) }, { it.hasUnpaidPayments })
+        assertOnlyThisFlagIsRaised({ it.copy(isCreator = true) }, { it.isCreator })
+        assertOnlyThisFlagIsRaised({ it.copy(isMailAddressOutdated = true) }, { it.isMailAddressOutdated })
+        assertOnlyThisFlagIsRaised({ it.copy(isSupporter = true) }, { it.isSupporter })
+        assertOnlyThisFlagIsRaised({ it.copy(showAdultContent = true) }, { it.showAdultContent })
+    }
+
     /** context が無い場合も安全に変換できることを確認する。 */
     @Test
     fun metaDataConversionHandlesMissingContext() {
@@ -83,5 +118,16 @@ class MetaDataMapperTest {
         assertNull(metaData.apiUrl)
         assertNull(metaData.context)
         assertEquals("token", metaData.csrfToken)
+    }
+
+    private fun assertOnlyThisFlagIsRaised(
+        raiseOne: (Context.User) -> Context.User,
+        readBack: (MetaData.Context.User) -> Boolean,
+    ) {
+        val context = requireNotNull(fanboxMetaData.context).copy(user = raiseOne(allFlagsDown))
+        val user = requireNotNull(fanboxMetaData.copy(context = context).toMetaData().context).user
+
+        assertEquals(1, flagReaders.count { reader -> reader(user) })
+        assertEquals(true, readBack(user))
     }
 }

--- a/core/repository/src/androidHostTest/kotlin/me/matsumo/fanbox/core/repository/PostDetailMapperTest.kt
+++ b/core/repository/src/androidHostTest/kotlin/me/matsumo/fanbox/core/repository/PostDetailMapperTest.kt
@@ -1,0 +1,284 @@
+package me.matsumo.fanbox.core.repository
+
+import me.matsumo.fanbox.core.model.fanbox.PostDetail
+import me.matsumo.fanbox.core.model.fanbox.PostDetail.Body
+import me.matsumo.fanbox.core.model.fanbox.PostDetail.Body.Article.Block
+import me.matsumo.fanbox.core.model.fanbox.PostDetail.Body.Article.Block.Text
+import me.matsumo.fanbox.core.repository.mapper.toPostDetail
+import me.matsumo.fankt.fanbox.domain.model.FanboxPost
+import me.matsumo.fankt.fanbox.domain.model.FanboxPostDetail
+import me.matsumo.fankt.fanbox.domain.model.FanboxUser
+import me.matsumo.fankt.fanbox.domain.model.id.FanboxCreatorId
+import me.matsumo.fankt.fanbox.domain.model.id.FanboxPostId
+import me.matsumo.fankt.fanbox.domain.model.id.FanboxPostItemId
+import me.matsumo.fankt.fanbox.domain.model.id.FanboxUserId
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
+import me.matsumo.fankt.fanbox.domain.model.FanboxPostDetail.Body as FanktBody
+import me.matsumo.fankt.fanbox.domain.model.FanboxPostDetail.Body.Article.Block as FanktBlock
+import me.matsumo.fankt.fanbox.domain.model.FanboxPostDetail.Body.Article.Block.Text as FanktBlockText
+
+/**
+ * [FanboxPostDetail] から [PostDetail] への変換を検証するテスト。
+ *
+ * D5 の方針により、このモデルの変換は fankt → app の一方向のみを持つ。
+ */
+@OptIn(ExperimentalTime::class)
+class PostDetailMapperTest {
+
+    private val imageItem = FanboxPostDetail.ImageItem(
+        id = FanboxPostItemId("item-1"),
+        postId = FanboxPostId("post-1"),
+        extension = "jpg",
+        originalUrl = "https://example.com/original.jpg",
+        thumbnailUrl = "https://example.com/thumbnail.jpg",
+        aspectRatio = 1.5f,
+    )
+
+    private val fileItem = FanboxPostDetail.FileItem(
+        id = FanboxPostItemId("item-2"),
+        postId = FanboxPostId("post-1"),
+        name = "document",
+        extension = "pdf",
+        size = 1024L,
+        url = "https://example.com/document.pdf",
+    )
+
+    private val textBlock = FanktBlock.Text(
+        text = "hello world",
+        styles = listOf(FanktBlockText.StyleSpan(type = "bold", offset = 0, length = 5)),
+        links = listOf(FanktBlockText.LinkSpan(offset = 6, length = 5, url = "https://example.com")),
+        isHeader = true,
+    )
+
+    private val imageBlock = FanktBlock.Image(item = imageItem)
+    private val fileBlock = FanktBlock.File(item = fileItem)
+
+    private val linkBlock = FanktBlock.Link(
+        html = "<p>html</p>",
+        post = FanboxPost(
+            id = FanboxPostId("linked-post"),
+            title = "linked title",
+            cover = null,
+            user = null,
+            excerpt = "excerpt",
+            feeRequired = 0,
+            hasAdultContent = false,
+            isLiked = false,
+            isRestricted = false,
+            likeCount = 0,
+            commentCount = 0,
+            tags = emptyList(),
+            publishedDatetime = Instant.parse("2024-01-01T00:00:00Z"),
+            updatedDatetime = Instant.parse("2024-01-01T00:00:00Z"),
+        ),
+        type = "fanbox.post",
+        url = "https://example.com/linked",
+    )
+
+    private val embedBlock = FanktBlock.Embed(
+        serviceProvider = "youtube",
+        contentId = "video-id",
+    )
+
+    private val unknownBlock = FanktBlock.Unknown(rawJson = """{"type":"mystery"}""")
+
+    private val articleBody = FanktBody.Article(
+        blocks = listOf(textBlock, imageBlock, fileBlock, linkBlock, embedBlock, unknownBlock),
+    )
+
+    private val fanboxPostDetail = FanboxPostDetail(
+        id = FanboxPostId("post-1"),
+        title = "title",
+        body = articleBody,
+        coverImageUrl = "https://example.com/cover.png",
+        commentCount = 3,
+        excerpt = "excerpt",
+        feeRequired = 500,
+        hasAdultContent = true,
+        imageForShare = "https://example.com/share.png",
+        isLiked = true,
+        isRestricted = false,
+        likeCount = 10,
+        tags = listOf("tag1", "tag2"),
+        updatedDatetime = Instant.parse("2024-01-02T00:00:00Z"),
+        publishedDatetime = Instant.parse("2024-01-01T00:00:00Z"),
+        nextPost = FanboxPostDetail.OtherPost(
+            id = FanboxPostId("next-post"),
+            title = "next title",
+            publishedDatetime = Instant.parse("2024-01-03T00:00:00Z"),
+        ),
+        prevPost = FanboxPostDetail.OtherPost(
+            id = FanboxPostId("prev-post"),
+            title = "prev title",
+            publishedDatetime = Instant.parse("2023-12-31T00:00:00Z"),
+        ),
+        user = FanboxUser(
+            userId = FanboxUserId(100),
+            creatorId = FanboxCreatorId("creator-1"),
+            name = "creator name",
+            iconUrl = "https://example.com/icon.png",
+        ),
+    )
+
+    /** 記事本文の全フィールドが値を保ったまま変換されることを確認する。値が欠けていても検出できないため。 */
+    @Test
+    fun postDetailConversionPreservesAllFields() {
+        val postDetail = fanboxPostDetail.toPostDetail()
+
+        assertEquals(fanboxPostDetail.id.value, postDetail.id.value)
+        assertEquals(fanboxPostDetail.title, postDetail.title)
+        assertEquals(fanboxPostDetail.coverImageUrl, postDetail.coverImageUrl)
+        assertEquals(fanboxPostDetail.commentCount, postDetail.commentCount)
+        assertEquals(fanboxPostDetail.excerpt, postDetail.excerpt)
+        assertEquals(fanboxPostDetail.feeRequired, postDetail.feeRequired)
+        assertEquals(fanboxPostDetail.hasAdultContent, postDetail.hasAdultContent)
+        assertEquals(fanboxPostDetail.imageForShare, postDetail.imageForShare)
+        assertEquals(fanboxPostDetail.isLiked, postDetail.isLiked)
+        assertEquals(fanboxPostDetail.isRestricted, postDetail.isRestricted)
+        assertEquals(fanboxPostDetail.likeCount, postDetail.likeCount)
+        assertEquals(fanboxPostDetail.tags, postDetail.tags)
+        assertEquals(fanboxPostDetail.updatedDatetime, postDetail.updatedDatetime)
+        assertEquals(fanboxPostDetail.publishedDatetime, postDetail.publishedDatetime)
+        assertEquals(fanboxPostDetail.nextPost?.id?.value, postDetail.nextPost?.id?.value)
+        assertEquals(fanboxPostDetail.nextPost?.title, postDetail.nextPost?.title)
+        assertEquals(fanboxPostDetail.nextPost?.publishedDatetime, postDetail.nextPost?.publishedDatetime)
+        assertEquals(fanboxPostDetail.prevPost?.id?.value, postDetail.prevPost?.id?.value)
+        assertEquals(fanboxPostDetail.user?.userId?.value, postDetail.user?.userId?.value)
+        assertEquals(fanboxPostDetail.user?.creatorId?.value, postDetail.user?.creatorId?.value)
+    }
+
+    /** 記事ブロックを構成する6種類すべてが変換できることを確認する。1種類でも欠けると記事が描画できないため。 */
+    @Test
+    fun allArticleBlockVariantsConvertSuccessfully() {
+        val body = fanboxPostDetail.toPostDetail().body
+
+        assertIs<Body.Article>(body)
+        assertEquals(6, body.blocks.size)
+
+        val text = assertIs<Block.Text>(body.blocks[0])
+        assertEquals(textBlock.text, text.text)
+        assertEquals(textBlock.isHeader, text.isHeader)
+        assertEquals(textBlock.styles[0].type, text.styles[0].type)
+        assertEquals(textBlock.links[0].url, text.links[0].url)
+
+        val image = assertIs<Block.Image>(body.blocks[1])
+        assertEquals(imageItem.id.value, image.item.id.value)
+        assertEquals(imageItem.originalUrl, image.item.originalUrl)
+
+        val file = assertIs<Block.File>(body.blocks[2])
+        assertEquals(fileItem.id.value, file.item.id.value)
+        assertEquals(fileItem.name, file.item.name)
+
+        val link = assertIs<Block.Link>(body.blocks[3])
+        assertEquals(linkBlock.html, link.html)
+        assertEquals(linkBlock.post?.id?.value, link.post?.id?.value)
+        assertEquals(linkBlock.type, link.type)
+        assertEquals(linkBlock.url, link.url)
+
+        val embed = assertIs<Block.Embed>(body.blocks[4])
+        assertEquals(embedBlock.serviceProvider, embed.serviceProvider)
+        assertEquals(embedBlock.contentId, embed.contentId)
+
+        val unknown = assertIs<Block.Unknown>(body.blocks[5])
+        assertEquals(unknownBlock.rawJson, unknown.rawJson)
+    }
+
+    /** 未知種別の記事ブロックが元の raw JSON を失わないことを確認する。フォールバック表示に必要なため。 */
+    @Test
+    fun unknownBlockVariantPreservesRawJson() {
+        val body = fanboxPostDetail.toPostDetail().body
+
+        assertIs<Body.Article>(body)
+
+        val unknown = assertIs<Block.Unknown>(body.blocks.last())
+        assertEquals("""{"type":"mystery"}""", unknown.rawJson)
+    }
+
+    /** 記事以外の6種類の本文がそれぞれ変換できることを確認する。 */
+    @Test
+    fun allBodyVariantsConvertSuccessfully() {
+        val imageBody = fanboxPostDetail.copy(
+            body = FanktBody.Image(text = "image text", images = listOf(imageItem)),
+        ).toPostDetail().body
+        val image = assertIs<Body.Image>(imageBody)
+        assertEquals("image text", image.text)
+        assertEquals(1, image.images.size)
+
+        val fileBody = fanboxPostDetail.copy(
+            body = FanktBody.File(text = "file text", files = listOf(fileItem)),
+        ).toPostDetail().body
+        val file = assertIs<Body.File>(fileBody)
+        assertEquals("file text", file.text)
+        assertEquals(1, file.files.size)
+
+        val textBody = fanboxPostDetail.copy(
+            body = FanktBody.Text(text = "plain text"),
+        ).toPostDetail().body
+        val text = assertIs<Body.Text>(textBody)
+        assertEquals("plain text", text.text)
+
+        val videoBody = fanboxPostDetail.copy(
+            body = FanktBody.Video(serviceProvider = "youtube", videoId = "video-id"),
+        ).toPostDetail().body
+        val video = assertIs<Body.Video>(videoBody)
+        assertEquals("youtube", video.serviceProvider)
+        assertEquals("video-id", video.videoId)
+
+        val htmlBody = fanboxPostDetail.copy(
+            body = FanktBody.Html(html = "<p>html</p>"),
+        ).toPostDetail().body
+        val html = assertIs<Body.Html>(htmlBody)
+        assertEquals("<p>html</p>", html.html)
+
+        val unknownBody = fanboxPostDetail.copy(
+            body = FanktBody.Unknown(type = "mystery", rawBodyJson = """{"foo":"bar"}"""),
+        ).toPostDetail().body
+        val unknown = assertIs<Body.Unknown>(unknownBody)
+        assertEquals("mystery", unknown.type)
+        assertEquals("""{"foo":"bar"}""", unknown.rawBodyJson)
+    }
+
+    /** 未知種別の本文が元の raw JSON を失わないことを確認する。フォールバック表示に必要なため。 */
+    @Test
+    fun unknownBodyVariantPreservesRawJson() {
+        val postDetail = fanboxPostDetail.copy(
+            body = FanktBody.Unknown(type = "mystery", rawBodyJson = """{"foo":"bar"}"""),
+        ).toPostDetail()
+
+        val unknown = assertIs<Body.Unknown>(postDetail.body)
+        assertEquals("""{"foo":"bar"}""", unknown.rawBodyJson)
+    }
+
+    /**
+     * fankt から移植した派生メンバーが、fankt の元実装と同じ値を返すことを確認する。
+     * 独自ロジックで再実装すると計算式のズレに気付けないため、fankt 側の値と突き合わせる。
+     */
+    @Test
+    fun derivedMembersMatchFanktValues() {
+        val postDetail = fanboxPostDetail.toPostDetail()
+
+        assertEquals(fanboxPostDetail.browserUrl, postDetail.browserUrl)
+        assertEquals(
+            fanboxPostDetail.body.imageItems.map { it.id.value },
+            postDetail.body.imageItems.map { it.id.value },
+        )
+        assertEquals(
+            fanboxPostDetail.body.fileItems.map { it.id.value },
+            postDetail.body.fileItems.map { it.id.value },
+        )
+
+        val fanktArticleBody = assertIs<FanktBody.Article>(fanboxPostDetail.body)
+        val articleBodyResult = assertIs<Body.Article>(postDetail.body)
+        val fanktEmbed = assertIs<FanktBlock.Embed>(fanktArticleBody.blocks[4])
+        val embed = assertIs<Block.Embed>(articleBodyResult.blocks[4])
+        assertEquals(fanktEmbed.url, embed.url)
+
+        val fanktVideoBody = FanktBody.Video(serviceProvider = "youtube", videoId = "video-id")
+        val videoBody = assertIs<Body.Video>(fanboxPostDetail.copy(body = fanktVideoBody).toPostDetail().body)
+        assertEquals(fanktVideoBody.url, videoBody.url)
+    }
+}

--- a/core/repository/src/androidHostTest/kotlin/me/matsumo/fanbox/core/repository/PostDetailMapperTest.kt
+++ b/core/repository/src/androidHostTest/kotlin/me/matsumo/fanbox/core/repository/PostDetailMapperTest.kt
@@ -281,4 +281,38 @@ class PostDetailMapperTest {
         val videoBody = assertIs<Body.Video>(fanboxPostDetail.copy(body = fanktVideoBody).toPostDetail().body)
         assertEquals(fanktVideoBody.url, videoBody.url)
     }
+
+    /**
+     * [FanboxPostDetail.FileItem.asImageItem] と [asVideoItem] が fankt の元実装と同じ結果を返すことを確認する。
+     * 拡張子ごとの判定ロジックを独自に再実装しているため、fankt 側の値と突き合わせる。
+     */
+    @Test
+    fun fileItemDerivedConversionMethodsMatchFanktValues() {
+        val fanktImageExtensionFile = fileItem.copy(extension = "jpg")
+        val fanktVideoExtensionFile = fileItem.copy(extension = "mp4")
+        val fanktUnmatchedExtensionFile = fileItem.copy(extension = "pdf")
+
+        val imageExtensionFile = fanboxPostDetail.copy(
+            body = FanktBody.File(text = "file text", files = listOf(fanktImageExtensionFile)),
+        ).toPostDetail().let { assertIs<Body.File>(it.body).files.single() }
+        val videoExtensionFile = fanboxPostDetail.copy(
+            body = FanktBody.File(text = "file text", files = listOf(fanktVideoExtensionFile)),
+        ).toPostDetail().let { assertIs<Body.File>(it.body).files.single() }
+        val unmatchedExtensionFile = fanboxPostDetail.copy(
+            body = FanktBody.File(text = "file text", files = listOf(fanktUnmatchedExtensionFile)),
+        ).toPostDetail().let { assertIs<Body.File>(it.body).files.single() }
+
+        assertEquals(fanktImageExtensionFile.asImageItem()?.originalUrl, imageExtensionFile.asImageItem()?.originalUrl)
+        assertEquals(fanktImageExtensionFile.asVideoItem(), null)
+        assertEquals(imageExtensionFile.asVideoItem(), null)
+
+        assertEquals(fanktVideoExtensionFile.asVideoItem()?.url, videoExtensionFile.asVideoItem()?.url)
+        assertEquals(fanktVideoExtensionFile.asImageItem(), null)
+        assertEquals(videoExtensionFile.asImageItem(), null)
+
+        assertEquals(fanktUnmatchedExtensionFile.asImageItem(), null)
+        assertEquals(fanktUnmatchedExtensionFile.asVideoItem(), null)
+        assertEquals(unmatchedExtensionFile.asImageItem(), null)
+        assertEquals(unmatchedExtensionFile.asVideoItem(), null)
+    }
 }

--- a/core/repository/src/androidHostTest/kotlin/me/matsumo/fanbox/core/repository/PostMapperTest.kt
+++ b/core/repository/src/androidHostTest/kotlin/me/matsumo/fanbox/core/repository/PostMapperTest.kt
@@ -1,0 +1,84 @@
+package me.matsumo.fanbox.core.repository
+
+import me.matsumo.fanbox.core.repository.mapper.toFanboxPost
+import me.matsumo.fanbox.core.repository.mapper.toPost
+import me.matsumo.fankt.fanbox.domain.model.FanboxCover
+import me.matsumo.fankt.fanbox.domain.model.FanboxPost
+import me.matsumo.fankt.fanbox.domain.model.FanboxUser
+import me.matsumo.fankt.fanbox.domain.model.id.FanboxCreatorId
+import me.matsumo.fankt.fanbox.domain.model.id.FanboxPostId
+import me.matsumo.fankt.fanbox.domain.model.id.FanboxUserId
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
+
+/** [FanboxPost] と [me.matsumo.fanbox.core.model.fanbox.Post] の相互変換を検証するテスト。 */
+@OptIn(ExperimentalTime::class)
+class PostMapperTest {
+
+    private val fanboxPost = FanboxPost(
+        id = FanboxPostId("post-1"),
+        title = "title",
+        cover = FanboxCover(url = "https://example.com/cover.png", type = "cover"),
+        user = FanboxUser(
+            userId = FanboxUserId(100),
+            creatorId = FanboxCreatorId("creator-1"),
+            name = "creator name",
+            iconUrl = "https://example.com/icon.png",
+        ),
+        excerpt = "excerpt",
+        feeRequired = 500,
+        hasAdultContent = true,
+        isLiked = true,
+        isRestricted = false,
+        likeCount = 10,
+        commentCount = 3,
+        tags = listOf("tag1", "tag2"),
+        publishedDatetime = Instant.parse("2024-01-01T00:00:00Z"),
+        updatedDatetime = Instant.parse("2024-01-02T00:00:00Z"),
+    )
+
+    /** 全フィールドが値を保ったまま変換されることを確認する。値が欠けていても検出できないため。 */
+    @Test
+    fun postConversionPreservesAllFields() {
+        val post = fanboxPost.toPost()
+
+        assertEquals(fanboxPost.id.value, post.id.value)
+        assertEquals(fanboxPost.title, post.title)
+        assertEquals(fanboxPost.cover?.url, post.cover?.url)
+        assertEquals(fanboxPost.cover?.type, post.cover?.type)
+        assertEquals(fanboxPost.user?.userId?.value, post.user?.userId?.value)
+        assertEquals(fanboxPost.user?.creatorId?.value, post.user?.creatorId?.value)
+        assertEquals(fanboxPost.user?.name, post.user?.name)
+        assertEquals(fanboxPost.user?.iconUrl, post.user?.iconUrl)
+        assertEquals(fanboxPost.excerpt, post.excerpt)
+        assertEquals(fanboxPost.feeRequired, post.feeRequired)
+        assertEquals(fanboxPost.hasAdultContent, post.hasAdultContent)
+        assertEquals(fanboxPost.isLiked, post.isLiked)
+        assertEquals(fanboxPost.isRestricted, post.isRestricted)
+        assertEquals(fanboxPost.likeCount, post.likeCount)
+        assertEquals(fanboxPost.commentCount, post.commentCount)
+        assertEquals(fanboxPost.tags, post.tags)
+        assertEquals(fanboxPost.publishedDatetime, post.publishedDatetime)
+        assertEquals(fanboxPost.updatedDatetime, post.updatedDatetime)
+    }
+
+    /** fankt → app → fankt の往復で元の値へ戻ることを確認する。永続化・再送信の前提となるため。 */
+    @Test
+    fun postRoundTripReturnsOriginalValue() {
+        assertEquals(fanboxPost, fanboxPost.toPost().toFanboxPost())
+    }
+
+    /** null 許容フィールドが null のままでも安全に変換できることを確認する。 */
+    @Test
+    fun postConversionHandlesNullableFields() {
+        val nullableFanboxPost = fanboxPost.copy(cover = null, user = null)
+
+        val post = nullableFanboxPost.toPost()
+
+        assertEquals(null, post.cover)
+        assertEquals(null, post.user)
+        assertEquals(nullableFanboxPost, post.toFanboxPost())
+    }
+}

--- a/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/mapper/BellMapper.kt
+++ b/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/mapper/BellMapper.kt
@@ -1,0 +1,37 @@
+package me.matsumo.fanbox.core.repository.mapper
+
+import me.matsumo.fanbox.core.model.fanbox.Bell
+import me.matsumo.fankt.fanbox.domain.model.FanboxBell
+import kotlin.time.ExperimentalTime
+
+@OptIn(ExperimentalTime::class)
+fun FanboxBell.toBell(): Bell {
+    return when (this) {
+        is FanboxBell.Comment -> Bell.Comment(
+            id = id.toCommentId(),
+            notifiedDatetime = notifiedDatetime,
+            comment = comment,
+            isRootComment = isRootComment,
+            creatorId = creatorId.toCreatorId(),
+            postId = postId.toPostId(),
+            postTitle = postTitle,
+            userName = userName,
+            userProfileIconUrl = userProfileIconUrl,
+        )
+
+        is FanboxBell.Like -> Bell.Like(
+            id = id,
+            notifiedDatetime = notifiedDatetime,
+            comment = comment,
+            creatorId = creatorId.toCreatorId(),
+            postId = postId.toPostId(),
+            count = count,
+        )
+
+        is FanboxBell.PostPublished -> Bell.PostPublished(
+            id = id.toPostId(),
+            notifiedDatetime = notifiedDatetime,
+            post = post.toPost(),
+        )
+    }
+}

--- a/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/mapper/CommentMapper.kt
+++ b/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/mapper/CommentMapper.kt
@@ -1,0 +1,21 @@
+package me.matsumo.fanbox.core.repository.mapper
+
+import me.matsumo.fanbox.core.model.fanbox.Comment
+import me.matsumo.fankt.fanbox.domain.model.FanboxComment
+import kotlin.time.ExperimentalTime
+
+@OptIn(ExperimentalTime::class)
+fun FanboxComment.toComment(): Comment {
+    return Comment(
+        body = body,
+        createdDatetime = createdDatetime,
+        id = id.toCommentId(),
+        isLiked = isLiked,
+        isOwn = isOwn,
+        likeCount = likeCount,
+        parentCommentId = parentCommentId.toCommentId(),
+        rootCommentId = rootCommentId.toCommentId(),
+        replies = replies.map { it.toComment() },
+        user = user?.toUser(),
+    )
+}

--- a/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/mapper/CoverMapper.kt
+++ b/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/mapper/CoverMapper.kt
@@ -1,0 +1,11 @@
+package me.matsumo.fanbox.core.repository.mapper
+
+import me.matsumo.fanbox.core.model.fanbox.Cover
+import me.matsumo.fankt.fanbox.domain.model.FanboxCover
+
+fun FanboxCover.toCover(): Cover {
+    return Cover(
+        url = url,
+        type = type,
+    )
+}

--- a/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/mapper/CreatorDetailMapper.kt
+++ b/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/mapper/CreatorDetailMapper.kt
@@ -1,0 +1,71 @@
+package me.matsumo.fanbox.core.repository.mapper
+
+import me.matsumo.fanbox.core.model.fanbox.CreatorDetail
+import me.matsumo.fanbox.core.model.fanbox.CreatorDetail.Platform
+import me.matsumo.fanbox.core.model.fanbox.CreatorDetail.ProfileItem
+import me.matsumo.fankt.fanbox.domain.model.FanboxCreatorDetail
+import me.matsumo.fankt.fanbox.domain.model.FanboxCreatorDetail.Platform as FanktPlatform
+import me.matsumo.fankt.fanbox.domain.model.FanboxCreatorDetail.ProfileItem as FanktProfileItem
+import me.matsumo.fankt.fanbox.domain.model.FanboxCreatorDetail.ProfileLink as FanktProfileLink
+
+fun FanboxCreatorDetail.toCreatorDetail(): CreatorDetail {
+    return CreatorDetail(
+        creatorId = creatorId.toCreatorId(),
+        coverImageUrl = coverImageUrl,
+        description = description,
+        hasAdultContent = hasAdultContent,
+        hasBoothShop = hasBoothShop,
+        isAcceptingRequest = isAcceptingRequest,
+        isFollowed = isFollowed,
+        isStopped = isStopped,
+        isSupported = isSupported,
+        profileItems = profileItems.map { it.toProfileItem() },
+        profileLinks = profileLinks.map { it.toProfileLink() },
+        user = user?.toUser(),
+    )
+}
+
+private fun FanktProfileItem.toProfileItem(): ProfileItem {
+    return when (this) {
+        is FanktProfileItem.Image -> ProfileItem.Image(
+            id = id,
+            imageUrl = imageUrl,
+            thumbnailUrl = thumbnailUrl,
+        )
+
+        is FanktProfileItem.Video -> ProfileItem.Video(
+            id = id,
+            serviceProvider = serviceProvider,
+            videoId = videoId,
+            thumbnailUrl = thumbnailUrl,
+        )
+
+        is FanktProfileItem.Unknown -> ProfileItem.Unknown(
+            id = id,
+            type = type,
+            rawJson = rawJson,
+        )
+    }
+}
+
+private fun FanktProfileLink.toProfileLink(): CreatorDetail.ProfileLink {
+    return CreatorDetail.ProfileLink(
+        url = url,
+        link = link.toPlatform(),
+    )
+}
+
+private fun FanktPlatform.toPlatform(): Platform {
+    return when (this) {
+        FanktPlatform.BOOTH -> Platform.BOOTH
+        FanktPlatform.FACEBOOK -> Platform.FACEBOOK
+        FanktPlatform.FANZA -> Platform.FANZA
+        FanktPlatform.INSTAGRAM -> Platform.INSTAGRAM
+        FanktPlatform.LINE -> Platform.LINE
+        FanktPlatform.PIXIV -> Platform.PIXIV
+        FanktPlatform.TUMBLR -> Platform.TUMBLR
+        FanktPlatform.TWITTER -> Platform.TWITTER
+        FanktPlatform.YOUTUBE -> Platform.YOUTUBE
+        FanktPlatform.UNKNOWN -> Platform.UNKNOWN
+    }
+}

--- a/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/mapper/CreatorMapper.kt
+++ b/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/mapper/CreatorMapper.kt
@@ -1,0 +1,11 @@
+package me.matsumo.fanbox.core.repository.mapper
+
+import me.matsumo.fanbox.core.model.fanbox.Creator
+import me.matsumo.fankt.fanbox.domain.model.FanboxCreator
+
+fun FanboxCreator.toCreator(): Creator {
+    return Creator(
+        creatorId = creatorId?.toCreatorId(),
+        user = user?.toUser(),
+    )
+}

--- a/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/mapper/CreatorPlanDetailMapper.kt
+++ b/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/mapper/CreatorPlanDetailMapper.kt
@@ -1,0 +1,26 @@
+package me.matsumo.fanbox.core.repository.mapper
+
+import me.matsumo.fanbox.core.model.fanbox.CreatorPlanDetail
+import me.matsumo.fankt.fanbox.domain.model.FanboxCreatorPlanDetail
+import kotlin.time.ExperimentalTime
+
+@OptIn(ExperimentalTime::class)
+fun FanboxCreatorPlanDetail.toCreatorPlanDetail(): CreatorPlanDetail {
+    return CreatorPlanDetail(
+        plan = plan.toCreatorPlan(),
+        supportStartDatetime = supportStartDatetime,
+        supportTransactions = supportTransactions.map { it.toSupportTransaction() },
+        supporterCardImageUrl = supporterCardImageUrl,
+    )
+}
+
+@OptIn(ExperimentalTime::class)
+private fun FanboxCreatorPlanDetail.SupportTransaction.toSupportTransaction(): CreatorPlanDetail.SupportTransaction {
+    return CreatorPlanDetail.SupportTransaction(
+        id = id,
+        paidAmount = paidAmount,
+        transactionDatetime = transactionDatetime,
+        targetMonth = targetMonth,
+        user = user.toUser(),
+    )
+}

--- a/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/mapper/CreatorPlanMapper.kt
+++ b/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/mapper/CreatorPlanMapper.kt
@@ -1,0 +1,17 @@
+package me.matsumo.fanbox.core.repository.mapper
+
+import me.matsumo.fanbox.core.model.fanbox.CreatorPlan
+import me.matsumo.fankt.fanbox.domain.model.FanboxCreatorPlan
+
+fun FanboxCreatorPlan.toCreatorPlan(): CreatorPlan {
+    return CreatorPlan(
+        id = id.toPlanId(),
+        title = title,
+        description = description,
+        fee = fee,
+        coverImageUrl = coverImageUrl,
+        hasAdultContent = hasAdultContent,
+        paymentMethod = paymentMethod.toPaymentMethod(),
+        user = user?.toUser(),
+    )
+}

--- a/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/mapper/CursorMapper.kt
+++ b/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/mapper/CursorMapper.kt
@@ -1,0 +1,24 @@
+package me.matsumo.fanbox.core.repository.mapper
+
+import me.matsumo.fanbox.core.model.fanbox.Cursor
+import me.matsumo.fankt.fanbox.domain.FanboxCursor
+
+fun FanboxCursor.toCursor(): Cursor {
+    return Cursor(
+        firstPublishedDatetime = firstPublishedDatetime,
+        maxPublishedDatetime = maxPublishedDatetime,
+        firstId = firstId,
+        maxId = maxId,
+        limit = limit,
+    )
+}
+
+fun Cursor.toFanboxCursor(): FanboxCursor {
+    return FanboxCursor(
+        firstPublishedDatetime = firstPublishedDatetime,
+        maxPublishedDatetime = maxPublishedDatetime,
+        firstId = firstId,
+        maxId = maxId,
+        limit = limit,
+    )
+}

--- a/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/mapper/IdMapper.kt
+++ b/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/mapper/IdMapper.kt
@@ -1,0 +1,34 @@
+package me.matsumo.fanbox.core.repository.mapper
+
+import me.matsumo.fanbox.core.model.fanbox.CommentId
+import me.matsumo.fanbox.core.model.fanbox.CreatorId
+import me.matsumo.fanbox.core.model.fanbox.NewsLetterId
+import me.matsumo.fanbox.core.model.fanbox.PlanId
+import me.matsumo.fanbox.core.model.fanbox.PostId
+import me.matsumo.fanbox.core.model.fanbox.PostItemId
+import me.matsumo.fanbox.core.model.fanbox.UserId
+import me.matsumo.fankt.fanbox.domain.model.id.FanboxCommentId
+import me.matsumo.fankt.fanbox.domain.model.id.FanboxCreatorId
+import me.matsumo.fankt.fanbox.domain.model.id.FanboxNewsLetterId
+import me.matsumo.fankt.fanbox.domain.model.id.FanboxPlanId
+import me.matsumo.fankt.fanbox.domain.model.id.FanboxPostId
+import me.matsumo.fankt.fanbox.domain.model.id.FanboxPostItemId
+import me.matsumo.fankt.fanbox.domain.model.id.FanboxUserId
+
+fun FanboxPostId.toPostId() = PostId(value)
+fun PostId.toFanboxPostId() = FanboxPostId(value)
+
+fun FanboxPostItemId.toPostItemId() = PostItemId(value)
+
+fun FanboxCreatorId.toCreatorId() = CreatorId(value)
+fun CreatorId.toFanboxCreatorId() = FanboxCreatorId(value)
+
+fun FanboxUserId.toUserId() = UserId(value)
+fun UserId.toFanboxUserId() = FanboxUserId(value)
+
+fun FanboxCommentId.toCommentId() = CommentId(value)
+fun CommentId.toFanboxCommentId() = FanboxCommentId(value)
+
+fun FanboxPlanId.toPlanId() = PlanId(value)
+
+fun FanboxNewsLetterId.toNewsLetterId() = NewsLetterId(value)

--- a/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/mapper/MetaDataMapper.kt
+++ b/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/mapper/MetaDataMapper.kt
@@ -1,0 +1,48 @@
+package me.matsumo.fanbox.core.repository.mapper
+
+import me.matsumo.fanbox.core.model.fanbox.MetaData
+import me.matsumo.fanbox.core.model.fanbox.MetaData.Context
+import me.matsumo.fankt.fanbox.domain.model.FanboxMetaData
+import me.matsumo.fankt.fanbox.domain.model.FanboxMetaData.Context as FanktContext
+
+fun FanboxMetaData.toMetaData(): MetaData {
+    return MetaData(
+        apiUrl = apiUrl,
+        context = context?.toContext(),
+        csrfToken = csrfToken,
+    )
+}
+
+private fun FanktContext.toContext(): Context {
+    return Context(
+        privacyPolicy = privacyPolicy.toPrivacyPolicy(),
+        user = user.toContextUser(),
+    )
+}
+
+private fun FanktContext.PrivacyPolicy.toPrivacyPolicy(): Context.PrivacyPolicy {
+    return Context.PrivacyPolicy(
+        policyUrl = policyUrl,
+        revisionHistoryUrl = revisionHistoryUrl,
+        shouldShowNotice = shouldShowNotice,
+        updateDate = updateDate,
+    )
+}
+
+private fun FanktContext.User.toContextUser(): Context.User {
+    return Context.User(
+        creatorId = creatorId?.toCreatorId(),
+        fanboxUserStatus = fanboxUserStatus,
+        hasAdultContent = hasAdultContent,
+        hasUnpaidPayments = hasUnpaidPayments,
+        iconUrl = iconUrl,
+        isCreator = isCreator,
+        isMailAddressOutdated = isMailAddressOutdated,
+        isSupporter = isSupporter,
+        lang = lang,
+        name = name,
+        planCount = planCount,
+        showAdultContent = showAdultContent,
+        userId = userId?.toUserId(),
+    )
+}

--- a/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/mapper/NewsLetterMapper.kt
+++ b/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/mapper/NewsLetterMapper.kt
@@ -1,0 +1,16 @@
+package me.matsumo.fanbox.core.repository.mapper
+
+import me.matsumo.fanbox.core.model.fanbox.NewsLetter
+import me.matsumo.fankt.fanbox.domain.model.FanboxNewsLetter
+import kotlin.time.ExperimentalTime
+
+@OptIn(ExperimentalTime::class)
+fun FanboxNewsLetter.toNewsLetter(): NewsLetter {
+    return NewsLetter(
+        id = id.toNewsLetterId(),
+        body = body,
+        createdAt = createdAt,
+        creator = creator.toCreator(),
+        isRead = isRead,
+    )
+}

--- a/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/mapper/PagingMapper.kt
+++ b/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/mapper/PagingMapper.kt
@@ -1,0 +1,50 @@
+package me.matsumo.fanbox.core.repository.mapper
+
+import me.matsumo.fanbox.core.model.fanbox.PageCursorInfo
+import me.matsumo.fanbox.core.model.fanbox.PageNumberInfo
+import me.matsumo.fanbox.core.model.fanbox.PageOffsetInfo
+import me.matsumo.fankt.fanbox.domain.PageCursorInfo as FanktPageCursorInfo
+import me.matsumo.fankt.fanbox.domain.PageNumberInfo as FanktPageNumberInfo
+import me.matsumo.fankt.fanbox.domain.PageOffsetInfo as FanktPageOffsetInfo
+
+fun <T, R> FanktPageCursorInfo<T>.toPageCursorInfo(contentMapper: (T) -> R): PageCursorInfo<R> {
+    return PageCursorInfo(
+        contents = contents.map(contentMapper),
+        cursor = cursor?.toCursor(),
+    )
+}
+
+fun <T, R> PageCursorInfo<T>.toFanktPageCursorInfo(contentMapper: (T) -> R): FanktPageCursorInfo<R> {
+    return FanktPageCursorInfo(
+        contents = contents.map(contentMapper),
+        cursor = cursor?.toFanboxCursor(),
+    )
+}
+
+fun <T, R> FanktPageNumberInfo<T>.toPageNumberInfo(contentMapper: (T) -> R): PageNumberInfo<R> {
+    return PageNumberInfo(
+        contents = contents.map(contentMapper),
+        nextPage = nextPage,
+    )
+}
+
+fun <T, R> PageNumberInfo<T>.toFanktPageNumberInfo(contentMapper: (T) -> R): FanktPageNumberInfo<R> {
+    return FanktPageNumberInfo(
+        contents = contents.map(contentMapper),
+        nextPage = nextPage,
+    )
+}
+
+fun <T, R> FanktPageOffsetInfo<T>.toPageOffsetInfo(contentMapper: (T) -> R): PageOffsetInfo<R> {
+    return PageOffsetInfo(
+        contents = contents.map(contentMapper),
+        offset = offset,
+    )
+}
+
+fun <T, R> PageOffsetInfo<T>.toFanktPageOffsetInfo(contentMapper: (T) -> R): FanktPageOffsetInfo<R> {
+    return FanktPageOffsetInfo(
+        contents = contents.map(contentMapper),
+        offset = offset,
+    )
+}

--- a/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/mapper/PagingMapper.kt
+++ b/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/mapper/PagingMapper.kt
@@ -14,13 +14,6 @@ fun <T, R> FanktPageCursorInfo<T>.toPageCursorInfo(contentMapper: (T) -> R): Pag
     )
 }
 
-fun <T, R> PageCursorInfo<T>.toFanktPageCursorInfo(contentMapper: (T) -> R): FanktPageCursorInfo<R> {
-    return FanktPageCursorInfo(
-        contents = contents.map(contentMapper),
-        cursor = cursor?.toFanboxCursor(),
-    )
-}
-
 fun <T, R> FanktPageNumberInfo<T>.toPageNumberInfo(contentMapper: (T) -> R): PageNumberInfo<R> {
     return PageNumberInfo(
         contents = contents.map(contentMapper),
@@ -28,22 +21,8 @@ fun <T, R> FanktPageNumberInfo<T>.toPageNumberInfo(contentMapper: (T) -> R): Pag
     )
 }
 
-fun <T, R> PageNumberInfo<T>.toFanktPageNumberInfo(contentMapper: (T) -> R): FanktPageNumberInfo<R> {
-    return FanktPageNumberInfo(
-        contents = contents.map(contentMapper),
-        nextPage = nextPage,
-    )
-}
-
 fun <T, R> FanktPageOffsetInfo<T>.toPageOffsetInfo(contentMapper: (T) -> R): PageOffsetInfo<R> {
     return PageOffsetInfo(
-        contents = contents.map(contentMapper),
-        offset = offset,
-    )
-}
-
-fun <T, R> PageOffsetInfo<T>.toFanktPageOffsetInfo(contentMapper: (T) -> R): FanktPageOffsetInfo<R> {
-    return FanktPageOffsetInfo(
         contents = contents.map(contentMapper),
         offset = offset,
     )

--- a/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/mapper/PaidRecordMapper.kt
+++ b/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/mapper/PaidRecordMapper.kt
@@ -1,0 +1,16 @@
+package me.matsumo.fanbox.core.repository.mapper
+
+import me.matsumo.fanbox.core.model.fanbox.PaidRecord
+import me.matsumo.fankt.fanbox.domain.model.FanboxPaidRecord
+import kotlin.time.ExperimentalTime
+
+@OptIn(ExperimentalTime::class)
+fun FanboxPaidRecord.toPaidRecord(): PaidRecord {
+    return PaidRecord(
+        id = id,
+        paidAmount = paidAmount,
+        paymentDateTime = paymentDateTime,
+        paymentMethod = paymentMethod.toPaymentMethod(),
+        creator = creator.toCreator(),
+    )
+}

--- a/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/mapper/PaymentMethodMapper.kt
+++ b/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/mapper/PaymentMethodMapper.kt
@@ -1,0 +1,13 @@
+package me.matsumo.fanbox.core.repository.mapper
+
+import me.matsumo.fanbox.core.model.fanbox.PaymentMethod
+import me.matsumo.fankt.fanbox.domain.model.FanboxPaymentMethod
+
+fun FanboxPaymentMethod.toPaymentMethod(): PaymentMethod {
+    return when (this) {
+        FanboxPaymentMethod.CARD -> PaymentMethod.CARD
+        FanboxPaymentMethod.PAYPAL -> PaymentMethod.PAYPAL
+        FanboxPaymentMethod.CVS -> PaymentMethod.CVS
+        FanboxPaymentMethod.UNKNOWN -> PaymentMethod.UNKNOWN
+    }
+}

--- a/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/mapper/PostDetailMapper.kt
+++ b/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/mapper/PostDetailMapper.kt
@@ -1,0 +1,146 @@
+package me.matsumo.fanbox.core.repository.mapper
+
+import me.matsumo.fanbox.core.model.fanbox.PostDetail
+import me.matsumo.fanbox.core.model.fanbox.PostDetail.Body
+import me.matsumo.fanbox.core.model.fanbox.PostDetail.Body.Article.Block
+import me.matsumo.fanbox.core.model.fanbox.PostDetail.Body.Article.Block.Text
+import me.matsumo.fankt.fanbox.domain.model.FanboxPostDetail
+import kotlin.time.ExperimentalTime
+import me.matsumo.fankt.fanbox.domain.model.FanboxPostDetail.Body as FanktBody
+import me.matsumo.fankt.fanbox.domain.model.FanboxPostDetail.Body.Article.Block as FanktBlock
+import me.matsumo.fankt.fanbox.domain.model.FanboxPostDetail.Body.Article.Block.Text as FanktBlockText
+import me.matsumo.fankt.fanbox.domain.model.FanboxPostDetail.FileItem as FanktFileItem
+import me.matsumo.fankt.fanbox.domain.model.FanboxPostDetail.ImageItem as FanktImageItem
+import me.matsumo.fankt.fanbox.domain.model.FanboxPostDetail.OtherPost as FanktOtherPost
+
+@OptIn(ExperimentalTime::class)
+fun FanboxPostDetail.toPostDetail(): PostDetail {
+    return PostDetail(
+        id = id.toPostId(),
+        title = title,
+        body = body.toBody(),
+        coverImageUrl = coverImageUrl,
+        commentCount = commentCount,
+        excerpt = excerpt,
+        feeRequired = feeRequired,
+        hasAdultContent = hasAdultContent,
+        imageForShare = imageForShare,
+        isLiked = isLiked,
+        isRestricted = isRestricted,
+        likeCount = likeCount,
+        tags = tags,
+        updatedDatetime = updatedDatetime,
+        publishedDatetime = publishedDatetime,
+        nextPost = nextPost?.toOtherPost(),
+        prevPost = prevPost?.toOtherPost(),
+        user = user?.toUser(),
+    )
+}
+
+@OptIn(ExperimentalTime::class)
+private fun FanktOtherPost.toOtherPost(): PostDetail.OtherPost {
+    return PostDetail.OtherPost(
+        id = id.toPostId(),
+        title = title,
+        publishedDatetime = publishedDatetime,
+    )
+}
+
+private fun FanktBody.toBody(): Body {
+    return when (this) {
+        is FanktBody.Article -> Body.Article(
+            blocks = blocks.map { it.toBlock() },
+        )
+
+        is FanktBody.Image -> Body.Image(
+            text = text,
+            images = images.map { it.toImageItem() },
+        )
+
+        is FanktBody.File -> Body.File(
+            text = text,
+            files = files.map { it.toFileItem() },
+        )
+
+        is FanktBody.Text -> Body.Text(text = text)
+
+        is FanktBody.Video -> Body.Video(
+            serviceProvider = serviceProvider,
+            videoId = videoId,
+        )
+
+        is FanktBody.Html -> Body.Html(html = html)
+
+        is FanktBody.Unknown -> Body.Unknown(
+            type = type,
+            rawBodyJson = rawBodyJson,
+        )
+    }
+}
+
+private fun FanktBlock.toBlock(): Block {
+    return when (this) {
+        is FanktBlock.Text -> Block.Text(
+            text = text,
+            styles = styles.map { it.toStyleSpan() },
+            links = links.map { it.toLinkSpan() },
+            isHeader = isHeader,
+        )
+
+        is FanktBlock.Image -> Block.Image(item = item.toImageItem())
+
+        is FanktBlock.File -> Block.File(item = item.toFileItem())
+
+        is FanktBlock.Link -> Block.Link(
+            html = html,
+            post = post?.toPost(),
+            type = type,
+            url = url,
+        )
+
+        is FanktBlock.Embed -> Block.Embed(
+            serviceProvider = serviceProvider,
+            contentId = contentId,
+        )
+
+        is FanktBlock.Unknown -> Block.Unknown(rawJson = rawJson)
+    }
+}
+
+private fun FanktBlockText.StyleSpan.toStyleSpan(): Text.StyleSpan {
+    return Text.StyleSpan(
+        type = type,
+        offset = offset,
+        length = length,
+    )
+}
+
+private fun FanktBlockText.LinkSpan.toLinkSpan(): Text.LinkSpan {
+    return Text.LinkSpan(
+        offset = offset,
+        length = length,
+        url = url,
+    )
+}
+
+private fun FanktImageItem.toImageItem(): PostDetail.ImageItem {
+    return PostDetail.ImageItem(
+        id = id.toPostItemId(),
+        postId = postId.toPostId(),
+        extension = extension,
+        originalUrl = originalUrl,
+        thumbnailUrl = thumbnailUrl,
+        aspectRatio = aspectRatio,
+    )
+}
+
+private fun FanktFileItem.toFileItem(): PostDetail.FileItem {
+    return PostDetail.FileItem(
+        id = id.toPostItemId(),
+        postId = postId.toPostId(),
+        name = name,
+        extension = extension,
+        size = size,
+        url = url,
+    )
+}

--- a/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/mapper/PostMapper.kt
+++ b/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/mapper/PostMapper.kt
@@ -1,0 +1,65 @@
+package me.matsumo.fanbox.core.repository.mapper
+
+import me.matsumo.fanbox.core.model.fanbox.Cover
+import me.matsumo.fanbox.core.model.fanbox.Post
+import me.matsumo.fanbox.core.model.fanbox.User
+import me.matsumo.fankt.fanbox.domain.model.FanboxCover
+import me.matsumo.fankt.fanbox.domain.model.FanboxPost
+import me.matsumo.fankt.fanbox.domain.model.FanboxUser
+import kotlin.time.ExperimentalTime
+
+@OptIn(ExperimentalTime::class)
+fun FanboxPost.toPost(): Post {
+    return Post(
+        id = id.toPostId(),
+        title = title,
+        cover = cover?.toCover(),
+        user = user?.toUser(),
+        excerpt = excerpt,
+        feeRequired = feeRequired,
+        hasAdultContent = hasAdultContent,
+        isLiked = isLiked,
+        isRestricted = isRestricted,
+        likeCount = likeCount,
+        commentCount = commentCount,
+        tags = tags,
+        publishedDatetime = publishedDatetime,
+        updatedDatetime = updatedDatetime,
+    )
+}
+
+@OptIn(ExperimentalTime::class)
+fun Post.toFanboxPost(): FanboxPost {
+    return FanboxPost(
+        id = id.toFanboxPostId(),
+        title = title,
+        cover = cover?.toFanboxCover(),
+        user = user?.toFanboxUser(),
+        excerpt = excerpt,
+        feeRequired = feeRequired,
+        hasAdultContent = hasAdultContent,
+        isLiked = isLiked,
+        isRestricted = isRestricted,
+        likeCount = likeCount,
+        commentCount = commentCount,
+        tags = tags,
+        publishedDatetime = publishedDatetime,
+        updatedDatetime = updatedDatetime,
+    )
+}
+
+private fun Cover.toFanboxCover(): FanboxCover {
+    return FanboxCover(
+        url = url,
+        type = type,
+    )
+}
+
+private fun User.toFanboxUser(): FanboxUser {
+    return FanboxUser(
+        userId = userId?.toFanboxUserId(),
+        creatorId = creatorId?.toFanboxCreatorId(),
+        name = name,
+        iconUrl = iconUrl,
+    )
+}

--- a/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/mapper/TagMapper.kt
+++ b/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/mapper/TagMapper.kt
@@ -1,0 +1,12 @@
+package me.matsumo.fanbox.core.repository.mapper
+
+import me.matsumo.fanbox.core.model.fanbox.Tag
+import me.matsumo.fankt.fanbox.domain.model.FanboxTag
+
+fun FanboxTag.toTag(): Tag {
+    return Tag(
+        count = count,
+        coverImageUrl = coverImageUrl,
+        name = name,
+    )
+}

--- a/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/mapper/UserMapper.kt
+++ b/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/mapper/UserMapper.kt
@@ -1,0 +1,13 @@
+package me.matsumo.fanbox.core.repository.mapper
+
+import me.matsumo.fanbox.core.model.fanbox.User
+import me.matsumo.fankt.fanbox.domain.model.FanboxUser
+
+fun FanboxUser.toUser(): User {
+    return User(
+        userId = userId?.toUserId(),
+        creatorId = creatorId?.toCreatorId(),
+        name = name,
+        iconUrl = iconUrl,
+    )
+}

--- a/openspec/changes/replace-fankt-models-with-app-owned/tasks.md
+++ b/openspec/changes/replace-fankt-models-with-app-owned/tasks.md
@@ -7,27 +7,27 @@
 
 ## 1. モデル定義（段 2 / `-defs`）
 
-- [ ] 1.1 `core/model/src/commonMain/.../core/model/fanbox/` に ID の value class 7 種（`PostId` / `PostItemId` / `CreatorId` / `UserId` / `CommentId` / `PlanId` / `NewsLetterId`）を定義する
-- [ ] 1.2 葉のモデル（`Cover` / `Tag` / `User` / `Creator` / `PaymentMethod`）を定義する
-- [ ] 1.3 集約のモデル（`Post` / `CreatorDetail` / `CreatorPlan` / `CreatorPlanDetail` / `Comment` / `Bell` / `MetaData` / `NewsLetter` / `PaidRecord`）を定義する
-- [ ] 1.4 `PostDetail` と `Body` の sealed 階層、`OtherPost` / `ImageItem` / `VideoItem` / `FileItem` を定義し、D7 の表で「する」とした派生メンバー 11 個を移植する
-- [ ] 1.5 ページング型（`PageCursorInfo` / `PageNumberInfo` / `PageOffsetInfo` / `Cursor`）を定義する
-- [ ] 1.6 Composable から参照するモデルへ `@Immutable` を付ける（AGENTS.md の Compose 規約）
-- [ ] 1.7 各 `data class` / `enum` / `value class` に日本語 KDoc を付ける
+- [x] 1.1 `core/model/src/commonMain/.../core/model/fanbox/` に ID の value class 7 種（`PostId` / `PostItemId` / `CreatorId` / `UserId` / `CommentId` / `PlanId` / `NewsLetterId`）を定義する
+- [x] 1.2 葉のモデル（`Cover` / `Tag` / `User` / `Creator` / `PaymentMethod`）を定義する
+- [x] 1.3 集約のモデル（`Post` / `CreatorDetail` / `CreatorPlan` / `CreatorPlanDetail` / `Comment` / `Bell` / `MetaData` / `NewsLetter` / `PaidRecord`）を定義する
+- [x] 1.4 `PostDetail` と `Body` の sealed 階層、`OtherPost` / `ImageItem` / `VideoItem` / `FileItem` を定義し、D7 の表で「する」とした派生メンバー 11 個を移植する
+- [x] 1.5 ページング型（`PageCursorInfo` / `PageNumberInfo` / `PageOffsetInfo` / `Cursor`）を定義する
+- [x] 1.6 Composable から参照するモデルへ `@Immutable` を付ける（AGENTS.md の Compose 規約）
+- [x] 1.7 各 `data class` / `enum` / `value class` に日本語 KDoc を付ける
 
 ## 2. 変換層（段 2 / `-defs`）
 
-- [ ] 2.1 `core/repository/src/commonMain/.../repository/mapper/` に fankt → app の変換を全型分置く
-- [ ] 2.2 app → fankt の変換を D5 の表が挙げる 3 種（ID 4 つ / `Post` / `Cursor`）に限って置く
-- [ ] 2.3 `PostDetail.Body` と記事ブロックの変換を、`when` を exhaustive に書いて全 variant 分置く
+- [x] 2.1 `core/repository/src/commonMain/.../repository/mapper/` に fankt → app の変換を全型分置く
+- [x] 2.2 app → fankt の変換を D5 の表が挙げる 3 種（ID 4 つ / `Post` / `Cursor`）に限って置く
+- [x] 2.3 `PostDetail.Body` と記事ブロックの変換を、`when` を exhaustive に書いて全 variant 分置く
 
 ## 3. 変換のテスト（段 2 / `-defs`）
 
-- [ ] 3.1 全フィールドを埋めた `FanboxPost` / `FanboxPostDetail` / `FanboxCreatorDetail` の変換で、各フィールドが写ることを固定する
-- [ ] 3.2 `Body` の 7 variant と記事ブロックの 6 variant がすべて変換されることを固定する
-- [ ] 3.3 未知の variant が生の JSON を保持することを固定する
-- [ ] 3.4 ID / `Post` / `Cursor` の往復が元の値へ戻ることを固定する
-- [ ] 3.5 D7 の派生メンバー 11 個が fankt と同じ値を返すことを固定する
+- [x] 3.1 全フィールドを埋めた `FanboxPost` / `FanboxPostDetail` / `FanboxCreatorDetail` の変換で、各フィールドが写ることを固定する
+- [x] 3.2 `Body` の 7 variant と記事ブロックの 6 variant がすべて変換されることを固定する
+- [x] 3.3 未知の variant が生の JSON を保持することを固定する
+- [x] 3.4 ID / `Post` / `Cursor` の往復が元の値へ戻ることを固定する
+- [x] 3.5 D7 の派生メンバー 11 個が fankt と同じ値を返すことを固定する
 
 ## 4. 公開契約の置き換え（段 3 / `-swap`）
 


### PR DESCRIPTION
Refs #137
base: #151（**先に #151 を merge する必要がある**）

アプリ所有の FANBOX モデルと、fankt モデルからの変換層を追加する。設計と delta spec は #151 の `openspec/changes/replace-fankt-models-with-app-owned/` にある。

**この PR は既存コードを 1 行も変更しない純粋な追加である。** 追加したモデルと変換層は、この時点ではまだ誰からも呼ばれていない。公開契約の置き換えは後続の 3 本目で行う。

担当は tasks.md のセクション 1（モデル定義）/ 2（変換層）/ 3（変換のテスト）。

ドキュメント影響: なし（README の更新は 3 本目に含む）

## なぜ定義だけを切り離すか

`FanboxRepository` の戻り値型を変えた瞬間に全呼び出し元がコンパイルを失うため、変換層の導入と呼び出し元の置換は分けられない。分離できるのはモデル定義だけである。

この PR を独立させると、「fankt のモデルと形が一致しているか」「変換が値を落としていないか」を、3 本目の機械的な置換 90 ファイルと切り離してレビューできる。

## 内容

| 対象 | ファイル数 | 行数 |
| --- | --- | --- |
| `core/model/.../core/model/fanbox/` | 24 | 740 |
| `core/repository/.../repository/mapper/` | 18 | 631 |
| `core/repository/.../androidHostTest/` | 5 | 720 |

fankt の domain model 24 ファイルに 1:1 で対応する。`Fanbox` prefix を外し、フィールド名は fankt と同じにしている。

### 逆変換を書いた範囲

app → fankt の変換は次に限っている。それ以外は表示専用で、アプリから fankt へ戻す経路が無い。

| 型 | 逆変換が要る理由 |
| --- | --- |
| `PostId` / `CreatorId` / `UserId` / `CommentId` | `FanboxRepository` の引数を fankt の API へ渡す |
| `Post` | `BookmarkDataStore` が fankt の serializer で保存する（保存形式を変えないため） |
| `Cursor` | paging で fankt へ次ページ位置を渡す |

### 移植しなかったもの

`FanboxCreatorDetail.Platform.fromUrl` と `FanboxPaymentMethod.fromString` は移植していない。fankt がレスポンスからモデルを組み立てるための companion factory で、アプリからの呼び出しはゼロである（repo 全体の grep で確認）。加えて `fromUrl` は fankt の `internal` な `FanboxUrlParts` に依存するため、移植するとアプリ側に URL パーサを新設することになる。

## 検証結果

すべて HEAD `8c173c90` で実施。

```
./gradlew detekt :core:repository:testAndroidHostTest :core:model:testAndroidHostTest \
          :core:model:compileKotlinIosSimulatorArm64 \
          :core:repository:compileKotlinIosSimulatorArm64
→ BUILD SUCCESSFUL
```

CI は detekt しか回さないため、iOS 側は `compileKotlinIosSimulatorArm64` をローカルで通している。

### テスト（56 件 / failures 0 / errors 0）

このうち本 PR が追加したのは変換のテスト 32 件である。

```
BellMapperTest               tests=3  time=0.289s   ← 本 PR
CommentMapperTest            tests=2  time=0.002s   ← 本 PR
CreatorDetailMapperTest      tests=3  time=0.008s   ← 本 PR
CreatorPlanDetailMapperTest  tests=2  time=0.002s   ← 本 PR
CreatorPlanMapperTest        tests=2  time=0.002s   ← 本 PR
IdCursorPagingRoundTripTest  tests=7  time=0.004s   ← 本 PR
MetaDataMapperTest           tests=3  time=0.003s   ← 本 PR
PostDetailMapperTest         tests=7  time=0.016s   ← 本 PR
PostMapperTest               tests=3  time=0.0s     ← 本 PR
FanboxErrorKindTest          tests=4  time=0.036s
SettingBillingRetentionPromptTest tests=8 time=0.007s
SettingPlusStatusUpdateTest  tests=4  time=0.001s
GuestChannelSelectionTest    tests=5  time=0.537s
GuestDeliveryKeyTest         tests=1  time=0.003s
RewardRepositoryTest         tests=2  time=0.059s
```

### 後から入れた修正（`c5eda413`）

初版（`056e95ad`）では ID の value class に `@Serializable` が無かった。後続の置き換え作業で `core/model` のコンパイルが止まって判明した。`Destination`（navigation の route）は `@Serializable` で `PostId` / `CreatorId` を保持するため、value class 側に serializer が要る。fankt の ID はすべて `@Serializable` を持っており、写しから漏れていた。

7 種すべてに追加し、上記の検証はその状態で実施している。

### レビューで閉じた指摘（`1e659564`）

独立レビューで should が 1 件出た。**分岐やループを持つ変換にテストが無い**という指摘で、18 ある mapper のうちテストがあるのは 4 本だけだった。

分岐・ループを持つ 4 本にテストを足した。取り違えても型が合うためコンパイルでは捕まらない箇所である。

| mapper | 非自明な点 | 同型フィールドの並び |
| --- | --- | --- |
| `BellMapper` | 3 つの subtype を分岐で振り分ける | `Bell.Comment` に `String` が 4 つ |
| `CommentMapper` | 返信を再帰的にたどる | `parentCommentId` と `rootCommentId` が同型 |
| `MetaDataMapper` | 入れ子が 2 段 | `Context.User` に `Boolean` が 6 つ |
| `CreatorPlanDetailMapper` | 支援履歴を一覧で写す | `supportStartDatetime` と `targetMonth` がどちらも `String` |

残る 10 本（`Cover` / `Creator` / `NewsLetter` / `PaidRecord` / `PaymentMethod` / `Tag` / `User` / `Id` / `Cursor` / `Paging`）は分岐もループも無い平坦な 1:1 写しである。うち `Id` / `Cursor` / `Paging` は `IdCursorPagingRoundTripTest` が、`Cover` と `User` は `PostMapperTest` がフィールド単位で確認している。テストにも YAGNI を適用し、これらには足していない。

#### 真偽値の取り違えは、値を並べた fixture では検出できない

`MetaData` の `Context.User` は真偽値を 6 つ並べて持つ。初版のテストは true 3 個 / false 3 個の fixture で全フィールドを assert していたが、**同じ値どうしの入れ替えは検出できない**（15 通りの組み合わせのうち 6 通りを見逃す）。

`isCreator` と `isSupporter` を入れ替えて確認した。

```
MetaDataMapperTest > eachUserFlagIsMappedToItsOwnField FAILED
（metaDataConversionPreservesAllFields は通過してしまう）
```

真偽値を 1 つだけ立てた入力を 6 通り作り、立った先が 1 つだけであることを見る形へ変えた（`60209a9e`）。上の出力はその確認のために一時的に mapper を壊して得たもので、確認後に戻している。

変換でフィールドを取り違えても、型が同じならコンパイルでは捕まらない。症状は「値が入れ替わって表示される」形で出るためテストで固定している。

| tasks | 証明するテスト |
| --- | --- |
| 3.1 全フィールドが写る | `postConversionPreservesAllFields` / `postDetailConversionPreservesAllFields` / `creatorDetailConversionPreservesAllFields` / `creatorPlanConversionPreservesAllFields` |
| 3.2 `Body` 7 variant と記事ブロック 6 variant | `allBodyVariantsConvertSuccessfully` / `allArticleBlockVariantsConvertSuccessfully` / `profileItemVariantsConvertSuccessfullyAndPreserveRawJson` |
| 3.3 未知 variant の生 JSON 保持 | `unknownBodyVariantPreservesRawJson` / `unknownBlockVariantPreservesRawJson` |
| 3.4 往復 | `postRoundTripReturnsOriginalValue` / `{postId,creatorId,userId,commentId}RoundTripReturnsOriginalValue` / `appOwnedIdRoundTripReturnsOriginalValue` / `cursorRoundTripReturnsOriginalValue` / `{pageCursorInfo,pageNumberInfo,pageOffsetInfo}RoundTripReturnsOriginalValue` |
| 3.5 派生メンバー 11 個 | `derivedMembersMatchFanktValues`（3 クラス）/ `fileItemDerivedConversionMethodsMatchFanktValues` |

3.5 は fankt 側の値とアプリ側の値を直接比較している（同じ入力に対して同じ URL・同じ読み替え結果を返すこと）。

## レビューで閉じた指摘

### 未使用の逆変換 API を削った（P3 / ponytail）

指摘は妥当だった。`toFanktPageCursorInfo` / `toFanktPageNumberInfo` / `toFanktPageOffsetInfo` は production から一度も呼ばれず、参照元は `IdCursorPagingRoundTripTest` だけだった。**テストがあるから必要に見えていたが、テストはこの関数が存在するから書かれたもので、根拠が循環していた。**

design D5 の表が挙げる逆変換は ID 4 種 / `Post` / `Cursor` の 3 行で、main spec の Requirement も「ページングのカーソル」までしか要求していない。ページング型を足したのは tasks 2.2 の記述だけで、これは #151 で D5 の表に合わせた。

3 関数と、それに対応する往復テスト 3 本を削除した。ページング型の前方変換（`toPageCursorInfo` など）は repository が実際に使っているので残している。空リストと null カーソルの確認も残した。

テストは 59 → 56 件。

## 人間に確認してほしいこと

| # | 帰属 | 内容 |
| --- | --- | --- |
| 1 | agent 仮決め | `UserId` の内側の型だけが `Long` で、残り 6 種の ID は `String`。fankt に合わせている |
| 2 | agent 仮決め | `Platform` enum は値だけを移植し、`fromUrl` は書いていない（上記「移植しなかったもの」） |
| 3 | agent 仮決め | fankt の派生ロジック 11 個をアプリ側へ複製したため、fankt が `Embed.url` の対応サービスを増やしてもアプリは追随しない。これは分離の目的そのものだが、意図した乖離であることを確認してほしい |
| 4 | agent 仮決め | この PR の追加物はまだどこからも呼ばれていない。本番経路への接続は 3 本目で行う |
