### PR TITLE
Replace fankt domain models with app-owned models across the app

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,14 @@ graph LR
   model --> common
 ```
 
+The FANBOX models the screens work with are owned by this app and live in `core/model`. The
+`fankt` library has its own models, and `core/repository` converts between the two. A change to a
+`fankt` model therefore stops at that conversion layer instead of reaching the screens.
+
+`core/datastore` is the one other place that holds `fankt` types. It keeps the cookie storage
+contract that `fankt` requires, and it writes bookmarks with `fankt`'s own serializer so that
+bookmarks saved by an earlier version stay readable.
+
 ## Remote parsing updates
 When FANBOX changes the shape of its responses, the app stops being able to read them, and a fix
 would otherwise reach you only through a store update. To close that gap, the Android app fetches a

--- a/README.md
+++ b/README.md
@@ -131,9 +131,12 @@ The FANBOX models the screens work with are owned by this app and live in `core/
 `fankt` library has its own models, and `core/repository` converts between the two. A change to a
 `fankt` model therefore stops at that conversion layer instead of reaching the screens.
 
-`core/datastore` is the one other place that holds `fankt` types. It keeps the cookie storage
-contract that `fankt` requires, and it writes bookmarks with `fankt`'s own serializer so that
-bookmarks saved by an earlier version stay readable.
+`core/datastore` writes bookmarks with `fankt`'s own serializer, so bookmarks saved by an earlier
+version stay readable. That is a persistence boundary, not a screen one.
+
+Contracts that are not models still come straight from `fankt`, wherever they are needed: the
+exception type the network layer throws, the cookie and session storage `fankt` requires, and the
+client entry point itself. Those are not part of the conversion described above.
 
 ## Remote parsing updates
 When FANBOX changes the shape of its responses, the app stops being able to read them, and a fix

--- a/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/Destination.kt
+++ b/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/Destination.kt
@@ -1,8 +1,8 @@
 package me.matsumo.fanbox.core.model
 
 import kotlinx.serialization.Serializable
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxCreatorId
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxPostId
+import me.matsumo.fanbox.core.model.fanbox.CreatorId
+import me.matsumo.fanbox.core.model.fanbox.PostId
 
 @Serializable
 sealed interface Destination {
@@ -12,7 +12,7 @@ sealed interface Destination {
 
     @Serializable
     data class PostDetail(
-        val postId: FanboxPostId,
+        val postId: PostId,
         val pagingType: PagingType = PagingType.Unknown,
     ) : Destination {
         @Serializable
@@ -27,20 +27,20 @@ sealed interface Destination {
 
     @Serializable
     data class PostImage(
-        val postId: FanboxPostId,
+        val postId: PostId,
         val index: Int,
     ) : Destination
 
     @Serializable
     data class PostSearch(
-        val creatorId: FanboxCreatorId,
+        val creatorId: CreatorId,
         val creatorQuery: String?,
         val tag: String?,
     ) : Destination
 
     @Serializable
     data class PostByCreatorSearch(
-        val creatorId: FanboxCreatorId,
+        val creatorId: CreatorId,
     ) : Destination
 
     @Serializable
@@ -48,13 +48,13 @@ sealed interface Destination {
 
     @Serializable
     data class CreatorTop(
-        val creatorId: FanboxCreatorId,
+        val creatorId: CreatorId,
         val isPosts: Boolean = true,
     ) : Destination
 
     @Serializable
     data class CreatorPostsDownload(
-        val creatorId: FanboxCreatorId,
+        val creatorId: CreatorId,
     ) : Destination
 
     @Serializable
@@ -68,7 +68,7 @@ sealed interface Destination {
 
     @Serializable
     data class FanCard(
-        val creatorId: FanboxCreatorId,
+        val creatorId: CreatorId,
     ) : Destination
 
     @Serializable

--- a/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/FanboxDownloadItems.kt
+++ b/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/FanboxDownloadItems.kt
@@ -1,19 +1,19 @@
 package me.matsumo.fanbox.core.model
 
-import me.matsumo.fankt.fanbox.domain.model.FanboxPost
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxPostId
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxPostItemId
+import me.matsumo.fanbox.core.model.fanbox.Post
+import me.matsumo.fanbox.core.model.fanbox.PostId
+import me.matsumo.fanbox.core.model.fanbox.PostItemId
 
 data class FanboxDownloadItems(
-    val postId: FanboxPostId,
+    val postId: PostId,
     val title: String,
     val items: List<Item>,
     val requestType: RequestType,
     val key: String,
 ) {
     data class Item(
-        val postId: FanboxPostId,
-        val itemId: FanboxPostItemId,
+        val postId: PostId,
+        val itemId: PostItemId,
         val name: String,
         val extension: String,
         val originalUrl: String,
@@ -30,8 +30,8 @@ data class FanboxDownloadItems(
     sealed interface RequestType {
         data object Image : RequestType
         data object File : RequestType
-        data class Post(
-            val post: FanboxPost?,
+        data class WholePost(
+            val post: Post?,
             val isIgnoreFiles: Boolean,
         ) : RequestType
     }

--- a/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/contract/PostDownloader.kt
+++ b/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/contract/PostDownloader.kt
@@ -1,10 +1,10 @@
 package me.matsumo.fanbox.core.model.contract
 
-import me.matsumo.fankt.fanbox.domain.model.FanboxPost
-import me.matsumo.fankt.fanbox.domain.model.FanboxPostDetail
+import me.matsumo.fanbox.core.model.fanbox.Post
+import me.matsumo.fanbox.core.model.fanbox.PostDetail
 
 interface PostDownloader {
-    fun onDownloadImages(imageItems: List<FanboxPostDetail.ImageItem>)
-    fun onDownloadFile(fileItem: FanboxPostDetail.FileItem)
-    fun onDownloadPosts(posts: List<FanboxPost>, isIgnoreFree: Boolean, isIgnoreFile: Boolean)
+    fun onDownloadImages(imageItems: List<PostDetail.ImageItem>)
+    fun onDownloadFile(fileItem: PostDetail.FileItem)
+    fun onDownloadPosts(posts: List<Post>, isIgnoreFree: Boolean, isIgnoreFile: Boolean)
 }

--- a/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/translation/TransComments.kt
+++ b/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/translation/TransComments.kt
@@ -21,7 +21,7 @@ fun PageOffsetInfo<Comment>.toTrans(): TransComments {
     )
 }
 
-fun TransComments.toFanboxComments(original: PageOffsetInfo<Comment>): PageOffsetInfo<Comment> {
+fun TransComments.toTranslatedComments(original: PageOffsetInfo<Comment>): PageOffsetInfo<Comment> {
     var index = 0
 
     fun replaceCommentBody(comment: Comment): Comment {

--- a/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/translation/TransComments.kt
+++ b/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/translation/TransComments.kt
@@ -1,30 +1,30 @@
 package me.matsumo.fanbox.core.model.translation
 
 import kotlinx.serialization.Serializable
-import me.matsumo.fankt.fanbox.domain.PageOffsetInfo
-import me.matsumo.fankt.fanbox.domain.model.FanboxComment
+import me.matsumo.fanbox.core.model.fanbox.Comment
+import me.matsumo.fanbox.core.model.fanbox.PageOffsetInfo
 
 @Serializable
 data class TransComments(
     val comments: List<String>,
 )
 
-private fun flatCooments(comments: List<FanboxComment>): List<FanboxComment> {
+private fun flatCooments(comments: List<Comment>): List<Comment> {
     return comments.flatMap {
         listOf(it) + flatCooments(it.replies)
     }
 }
 
-fun PageOffsetInfo<FanboxComment>.toTrans(): TransComments {
+fun PageOffsetInfo<Comment>.toTrans(): TransComments {
     return TransComments(
         comments = flatCooments(contents).map { it.body },
     )
 }
 
-fun TransComments.toFanboxComments(original: PageOffsetInfo<FanboxComment>): PageOffsetInfo<FanboxComment> {
+fun TransComments.toFanboxComments(original: PageOffsetInfo<Comment>): PageOffsetInfo<Comment> {
     var index = 0
 
-    fun replaceCommentBody(comment: FanboxComment): FanboxComment {
+    fun replaceCommentBody(comment: Comment): Comment {
         val newBody = comments[index++]
 
         return comment.copy(

--- a/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/translation/TransPostDetail.kt
+++ b/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/translation/TransPostDetail.kt
@@ -26,7 +26,7 @@ fun PostDetail.toTrans(): TransPostDetail {
     )
 }
 
-fun TransPostDetail.toFanboxPostDetail(original: PostDetail): PostDetail {
+fun TransPostDetail.toTranslatedPostDetail(original: PostDetail): PostDetail {
     var index = 0
     val newBody = when (val originalBody = original.body) {
         is PostDetail.Body.Article -> {

--- a/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/translation/TransPostDetail.kt
+++ b/core/model/src/commonMain/kotlin/me/matsumo/fanbox/core/model/translation/TransPostDetail.kt
@@ -1,7 +1,7 @@
 package me.matsumo.fanbox.core.model.translation
 
 import kotlinx.serialization.Serializable
-import me.matsumo.fankt.fanbox.domain.model.FanboxPostDetail
+import me.matsumo.fanbox.core.model.fanbox.PostDetail
 
 @Serializable
 data class TransPostDetail(
@@ -12,27 +12,27 @@ data class TransPostDetail(
     val excerpt: String,
 )
 
-fun FanboxPostDetail.toTrans(): TransPostDetail {
-    val textBody = (body as? FanboxPostDetail.Body.Article)?.blocks?.mapNotNull {
-        (it as? FanboxPostDetail.Body.Article.Block.Text)?.text
+fun PostDetail.toTrans(): TransPostDetail {
+    val textBody = (body as? PostDetail.Body.Article)?.blocks?.mapNotNull {
+        (it as? PostDetail.Body.Article.Block.Text)?.text
     }
 
     return TransPostDetail(
         title = title,
         textBody = textBody.orEmpty(),
-        imageBody = (body as? FanboxPostDetail.Body.Image)?.text.orEmpty(),
-        fileBody = (body as? FanboxPostDetail.Body.File)?.text.orEmpty(),
+        imageBody = (body as? PostDetail.Body.Image)?.text.orEmpty(),
+        fileBody = (body as? PostDetail.Body.File)?.text.orEmpty(),
         excerpt = excerpt,
     )
 }
 
-fun TransPostDetail.toFanboxPostDetail(original: FanboxPostDetail): FanboxPostDetail {
+fun TransPostDetail.toFanboxPostDetail(original: PostDetail): PostDetail {
     var index = 0
     val newBody = when (val originalBody = original.body) {
-        is FanboxPostDetail.Body.Article -> {
+        is PostDetail.Body.Article -> {
             originalBody.copy(
                 blocks = originalBody.blocks.map { block ->
-                    if (block is FanboxPostDetail.Body.Article.Block.Text) {
+                    if (block is PostDetail.Body.Article.Block.Text) {
                         block.copy(text = textBody[index]).also { index++ }
                     } else {
                         block
@@ -41,8 +41,8 @@ fun TransPostDetail.toFanboxPostDetail(original: FanboxPostDetail): FanboxPostDe
             )
         }
 
-        is FanboxPostDetail.Body.Image -> originalBody.copy(text = imageBody)
-        is FanboxPostDetail.Body.File -> originalBody.copy(text = fileBody)
+        is PostDetail.Body.Image -> originalBody.copy(text = imageBody)
+        is PostDetail.Body.File -> originalBody.copy(text = fileBody)
         else -> originalBody
     }
 

--- a/core/repository/src/androidHostTest/kotlin/me/matsumo/fanbox/core/repository/BookmarkPersistenceCompatibilityTest.kt
+++ b/core/repository/src/androidHostTest/kotlin/me/matsumo/fanbox/core/repository/BookmarkPersistenceCompatibilityTest.kt
@@ -1,0 +1,62 @@
+package me.matsumo.fanbox.core.repository
+
+import kotlinx.serialization.json.Json
+import me.matsumo.fanbox.core.repository.mapper.toCreatorId
+import me.matsumo.fanbox.core.repository.mapper.toFanboxPost
+import me.matsumo.fanbox.core.repository.mapper.toPost
+import me.matsumo.fankt.fanbox.domain.model.FanboxPost
+import me.matsumo.fankt.fanbox.domain.model.id.FanboxCreatorId
+import org.junit.Test
+import kotlin.test.assertEquals
+
+/**
+ * 置き換え前に保存された内容が、アプリ所有のモデルへ移った後も同じように読めることを検証するテスト。
+ *
+ * ブックマークは `BookmarkDataStore` が fankt の `FanboxPost` の serializer で JSON を書いており、
+ * 保存形式は本変更でも変えていない。アプリ所有の [me.matsumo.fanbox.core.model.fanbox.Post] は
+ * 読み出しと書き込みの境界で相互変換される。この往復で値が落ちると、既存ユーザーのブックマークが
+ * 静かに壊れる。
+ */
+class BookmarkPersistenceCompatibilityTest {
+
+    private val storedBookmarkJson = """
+        {"id":"post-1","title":"title","cover":{"url":"https://example.com/cover.png","type":"cover"},"user":{"userId":100,"creatorId":"creator-1","name":"creator name","iconUrl":"https://example.com/icon.png"},"excerpt":"excerpt","feeRequired":500,"hasAdultContent":true,"isLiked":true,"isRestricted":false,"likeCount":10,"commentCount":3,"tags":["tag1","tag2"],"publishedDatetime":"2024-01-01T00:00:00Z","updatedDatetime":"2024-01-02T00:00:00Z"}
+    """.trimIndent()
+
+    /** 保存済みの JSON がアプリ所有のモデルとして復元できることを確認する。 */
+    @Test
+    fun storedBookmarkJsonIsReadableAsAppOwnedPost() {
+        val storedPost = Json.decodeFromString(FanboxPost.serializer(), storedBookmarkJson)
+
+        val post = storedPost.toPost()
+
+        assertEquals("post-1", post.id.value)
+        assertEquals("title", post.title)
+        assertEquals("https://example.com/cover.png", post.cover?.url)
+        assertEquals(100L, post.user?.userId?.value)
+        assertEquals("creator-1", post.user?.creatorId?.value)
+        assertEquals(500, post.feeRequired)
+        assertEquals(listOf("tag1", "tag2"), post.tags)
+        assertEquals(storedPost.publishedDatetime, post.publishedDatetime)
+    }
+
+    /** アプリ所有のモデルから書き戻した JSON が、保存済みの JSON と一致することを確認する。 */
+    @Test
+    fun writingBackAnAppOwnedPostKeepsTheStoredJsonFormat() {
+        val storedPost = Json.decodeFromString(FanboxPost.serializer(), storedBookmarkJson)
+
+        val writtenBackJson = Json.encodeToString(FanboxPost.serializer(), storedPost.toPost().toFanboxPost())
+
+        assertEquals(storedBookmarkJson, writtenBackJson)
+    }
+
+    /** 保存済みのブロック済みクリエイターが、アプリ所有の ID として復元できることを確認する。 */
+    @Test
+    fun storedBlockedCreatorsAreReadableAsAppOwnedIds() {
+        val storedCreatorIds = setOf("creator-1", "creator-2")
+
+        val creatorIds = storedCreatorIds.map { FanboxCreatorId(it).toCreatorId() }
+
+        assertEquals(storedCreatorIds, creatorIds.map { it.value }.toSet())
+    }
+}

--- a/core/repository/src/androidMain/kotlin/me/matsumo/fanbox/core/repository/DownloadPostsRepository.android.kt
+++ b/core/repository/src/androidMain/kotlin/me/matsumo/fanbox/core/repository/DownloadPostsRepository.android.kt
@@ -32,9 +32,9 @@ import me.matsumo.fanbox.core.logs.logger.send
 import me.matsumo.fanbox.core.model.DownloadFileType
 import me.matsumo.fanbox.core.model.DownloadState
 import me.matsumo.fanbox.core.model.FanboxDownloadItems
-import me.matsumo.fankt.fanbox.domain.model.FanboxPost
-import me.matsumo.fankt.fanbox.domain.model.FanboxPostDetail
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxPostId
+import me.matsumo.fanbox.core.model.fanbox.Post
+import me.matsumo.fanbox.core.model.fanbox.PostDetail
+import me.matsumo.fanbox.core.model.fanbox.PostId
 import java.io.File
 import kotlin.coroutines.resume
 import kotlin.uuid.ExperimentalUuidApi
@@ -69,7 +69,7 @@ class DownloadPostsRepositoryImpl(
                     val items = when (val type = downloadItems.requestType) {
                         FanboxDownloadItems.RequestType.File -> downloadItems.items
                         FanboxDownloadItems.RequestType.Image -> downloadItems.items
-                        is FanboxDownloadItems.RequestType.Post -> {
+                        is FanboxDownloadItems.RequestType.WholePost -> {
                             val postDetail = fanboxRepository.getPostDetail(downloadItems.postId)
                             val images = postDetail.body.imageItems.mapIndexed { index, image -> image.toDownloadItem(index) }
                             val files = postDetail.body.fileItems.map { it.toDownloadItem() }
@@ -104,13 +104,13 @@ class DownloadPostsRepositoryImpl(
         }
     }
 
-    override fun requestDownloadPost(post: FanboxPost, isIgnoreFiles: Boolean) {
+    override fun requestDownloadPost(post: Post, isIgnoreFiles: Boolean) {
         scope.launch {
             val items = FanboxDownloadItems(
                 postId = post.id,
                 title = post.title,
                 items = emptyList(),
-                requestType = FanboxDownloadItems.RequestType.Post(post, isIgnoreFiles),
+                requestType = FanboxDownloadItems.RequestType.WholePost(post, isIgnoreFiles),
                 key = Uuid.random().toHexString(),
             )
 
@@ -118,7 +118,7 @@ class DownloadPostsRepositoryImpl(
         }
     }
 
-    override fun requestDownloadImages(postId: FanboxPostId, title: String, images: List<FanboxPostDetail.ImageItem>) {
+    override fun requestDownloadImages(postId: PostId, title: String, images: List<PostDetail.ImageItem>) {
         val items = FanboxDownloadItems(
             postId = postId,
             title = title,
@@ -130,7 +130,7 @@ class DownloadPostsRepositoryImpl(
         _reservingPosts.update { it + items }
     }
 
-    override fun requestDownloadFiles(postId: FanboxPostId, title: String, files: List<FanboxPostDetail.FileItem>) {
+    override fun requestDownloadFiles(postId: PostId, title: String, files: List<PostDetail.FileItem>) {
         val items = FanboxDownloadItems(
             postId = postId,
             title = title,
@@ -146,7 +146,7 @@ class DownloadPostsRepositoryImpl(
         return (getParentFile(requestType) ?: getOldParentFile(requestType, true))?.filePath ?: "Unknown"
     }
 
-    private fun FanboxPostDetail.ImageItem.toDownloadItem(index: Int = -1): FanboxDownloadItems.Item {
+    private fun PostDetail.ImageItem.toDownloadItem(index: Int = -1): FanboxDownloadItems.Item {
         val namePrefix = if (index >= 0) "image-%03d".format(index) else "image"
         return FanboxDownloadItems.Item(
             postId = postId,
@@ -159,7 +159,7 @@ class DownloadPostsRepositoryImpl(
         )
     }
 
-    private fun FanboxPostDetail.FileItem.toDownloadItem(): FanboxDownloadItems.Item {
+    private fun PostDetail.FileItem.toDownloadItem(): FanboxDownloadItems.Item {
         return FanboxDownloadItems.Item(
             postId = postId,
             itemId = id,
@@ -215,13 +215,13 @@ class DownloadPostsRepositoryImpl(
         val environmentDir = when (requestType) {
             is FanboxDownloadItems.RequestType.Image -> Environment.DIRECTORY_PICTURES
             is FanboxDownloadItems.RequestType.File -> Environment.DIRECTORY_DOWNLOADS
-            is FanboxDownloadItems.RequestType.Post -> Environment.DIRECTORY_DOWNLOADS
+            is FanboxDownloadItems.RequestType.WholePost -> Environment.DIRECTORY_DOWNLOADS
         }
 
         val child = when (requestType) {
             is FanboxDownloadItems.RequestType.Image -> "FANBOX"
             is FanboxDownloadItems.RequestType.File -> "FANBOX"
-            is FanboxDownloadItems.RequestType.Post -> requestType.post?.user?.name ?: "UnknownCreator"
+            is FanboxDownloadItems.RequestType.WholePost -> requestType.post?.user?.name ?: "UnknownCreator"
         }
 
         val dir = File("${Environment.getExternalStorageDirectory().path}/$environmentDir", "FANBOX")
@@ -258,7 +258,7 @@ class DownloadPostsRepositoryImpl(
                 UniFile.fromUri(context, userData.fileSaveDirectory.toUri())
             }
 
-            is FanboxDownloadItems.RequestType.Post -> {
+            is FanboxDownloadItems.RequestType.WholePost -> {
                 if (userData.postSaveDirectory.isBlank()) return null
                 val parentFile = UniFile.fromUri(context, userData.postSaveDirectory.toUri())
                 parentFile.createDirectory(requestType.post?.user?.name ?: "UnknownCreator")

--- a/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/DownloadPostsRepository.kt
+++ b/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/DownloadPostsRepository.kt
@@ -3,9 +3,9 @@ package me.matsumo.fanbox.core.repository
 import kotlinx.coroutines.flow.StateFlow
 import me.matsumo.fanbox.core.model.DownloadState
 import me.matsumo.fanbox.core.model.FanboxDownloadItems
-import me.matsumo.fankt.fanbox.domain.model.FanboxPost
-import me.matsumo.fankt.fanbox.domain.model.FanboxPostDetail
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxPostId
+import me.matsumo.fanbox.core.model.fanbox.Post
+import me.matsumo.fanbox.core.model.fanbox.PostDetail
+import me.matsumo.fanbox.core.model.fanbox.PostId
 
 interface DownloadPostsRepository {
     val reservingPosts: StateFlow<List<FanboxDownloadItems>>
@@ -13,9 +13,9 @@ interface DownloadPostsRepository {
 
     fun cancelDownload(key: String)
 
-    fun requestDownloadPost(post: FanboxPost, isIgnoreFiles: Boolean)
-    fun requestDownloadImages(postId: FanboxPostId, title: String, images: List<FanboxPostDetail.ImageItem>)
-    fun requestDownloadFiles(postId: FanboxPostId, title: String, files: List<FanboxPostDetail.FileItem>)
+    fun requestDownloadPost(post: Post, isIgnoreFiles: Boolean)
+    fun requestDownloadImages(postId: PostId, title: String, images: List<PostDetail.ImageItem>)
+    fun requestDownloadFiles(postId: PostId, title: String, files: List<PostDetail.FileItem>)
 
     suspend fun getSaveDirectory(requestType: FanboxDownloadItems.RequestType): String
 }

--- a/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/FanboxRepository.kt
+++ b/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/FanboxRepository.kt
@@ -47,7 +47,6 @@ import me.matsumo.fanbox.core.model.fanbox.Tag
 import me.matsumo.fanbox.core.model.fanbox.UserId
 import me.matsumo.fanbox.core.repository.mapper.toBell
 import me.matsumo.fanbox.core.repository.mapper.toComment
-import me.matsumo.fanbox.core.repository.mapper.toCommentId
 import me.matsumo.fanbox.core.repository.mapper.toCreatorDetail
 import me.matsumo.fanbox.core.repository.mapper.toCreatorId
 import me.matsumo.fanbox.core.repository.mapper.toCreatorPlan
@@ -69,7 +68,6 @@ import me.matsumo.fanbox.core.repository.mapper.toPost
 import me.matsumo.fanbox.core.repository.mapper.toPostDetail
 import me.matsumo.fanbox.core.repository.mapper.toPostId
 import me.matsumo.fanbox.core.repository.mapper.toTag
-import me.matsumo.fanbox.core.repository.mapper.toUserId
 import me.matsumo.fanbox.core.repository.paging.CreatorPostsPagingSource
 import me.matsumo.fanbox.core.repository.paging.HomePostsPagingSource
 import me.matsumo.fanbox.core.repository.paging.SearchCreatorsPagingSource

--- a/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/FanboxRepository.kt
+++ b/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/FanboxRepository.kt
@@ -14,8 +14,10 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.withContext
 import me.matsumo.fanbox.core.common.PixiViewConfig
 import me.matsumo.fanbox.core.common.util.recordException
@@ -24,6 +26,50 @@ import me.matsumo.fanbox.core.datastore.BookmarkDataStore
 import me.matsumo.fanbox.core.datastore.OldCookieDataStore
 import me.matsumo.fanbox.core.datastore.SettingDataStore
 import me.matsumo.fanbox.core.datastore.cookie.MigratingFanboxCookieStorage
+import me.matsumo.fanbox.core.model.fanbox.Bell
+import me.matsumo.fanbox.core.model.fanbox.Comment
+import me.matsumo.fanbox.core.model.fanbox.CommentId
+import me.matsumo.fanbox.core.model.fanbox.CreatorDetail
+import me.matsumo.fanbox.core.model.fanbox.CreatorId
+import me.matsumo.fanbox.core.model.fanbox.CreatorPlan
+import me.matsumo.fanbox.core.model.fanbox.CreatorPlanDetail
+import me.matsumo.fanbox.core.model.fanbox.Cursor
+import me.matsumo.fanbox.core.model.fanbox.MetaData
+import me.matsumo.fanbox.core.model.fanbox.NewsLetter
+import me.matsumo.fanbox.core.model.fanbox.PageCursorInfo
+import me.matsumo.fanbox.core.model.fanbox.PageNumberInfo
+import me.matsumo.fanbox.core.model.fanbox.PageOffsetInfo
+import me.matsumo.fanbox.core.model.fanbox.PaidRecord
+import me.matsumo.fanbox.core.model.fanbox.Post
+import me.matsumo.fanbox.core.model.fanbox.PostDetail
+import me.matsumo.fanbox.core.model.fanbox.PostId
+import me.matsumo.fanbox.core.model.fanbox.Tag
+import me.matsumo.fanbox.core.model.fanbox.UserId
+import me.matsumo.fanbox.core.repository.mapper.toBell
+import me.matsumo.fanbox.core.repository.mapper.toComment
+import me.matsumo.fanbox.core.repository.mapper.toCommentId
+import me.matsumo.fanbox.core.repository.mapper.toCreatorDetail
+import me.matsumo.fanbox.core.repository.mapper.toCreatorId
+import me.matsumo.fanbox.core.repository.mapper.toCreatorPlan
+import me.matsumo.fanbox.core.repository.mapper.toCreatorPlanDetail
+import me.matsumo.fanbox.core.repository.mapper.toCursor
+import me.matsumo.fanbox.core.repository.mapper.toFanboxCommentId
+import me.matsumo.fanbox.core.repository.mapper.toFanboxCreatorId
+import me.matsumo.fanbox.core.repository.mapper.toFanboxCursor
+import me.matsumo.fanbox.core.repository.mapper.toFanboxPost
+import me.matsumo.fanbox.core.repository.mapper.toFanboxPostId
+import me.matsumo.fanbox.core.repository.mapper.toFanboxUserId
+import me.matsumo.fanbox.core.repository.mapper.toMetaData
+import me.matsumo.fanbox.core.repository.mapper.toNewsLetter
+import me.matsumo.fanbox.core.repository.mapper.toPageCursorInfo
+import me.matsumo.fanbox.core.repository.mapper.toPageNumberInfo
+import me.matsumo.fanbox.core.repository.mapper.toPageOffsetInfo
+import me.matsumo.fanbox.core.repository.mapper.toPaidRecord
+import me.matsumo.fanbox.core.repository.mapper.toPost
+import me.matsumo.fanbox.core.repository.mapper.toPostDetail
+import me.matsumo.fanbox.core.repository.mapper.toPostId
+import me.matsumo.fanbox.core.repository.mapper.toTag
+import me.matsumo.fanbox.core.repository.mapper.toUserId
 import me.matsumo.fanbox.core.repository.paging.CreatorPostsPagingSource
 import me.matsumo.fanbox.core.repository.paging.HomePostsPagingSource
 import me.matsumo.fanbox.core.repository.paging.SearchCreatorsPagingSource
@@ -35,31 +81,12 @@ import me.matsumo.fankt.fanbox.FanboxCookieStorage
 import me.matsumo.fankt.fanbox.FanboxException
 import me.matsumo.fankt.fanbox.FanboxListItemSchemaMismatch
 import me.matsumo.fankt.fanbox.FanboxLogLevel
-import me.matsumo.fankt.fanbox.domain.FanboxCursor
-import me.matsumo.fankt.fanbox.domain.PageCursorInfo
-import me.matsumo.fankt.fanbox.domain.PageNumberInfo
-import me.matsumo.fankt.fanbox.domain.PageOffsetInfo
-import me.matsumo.fankt.fanbox.domain.model.FanboxBell
-import me.matsumo.fankt.fanbox.domain.model.FanboxComment
-import me.matsumo.fankt.fanbox.domain.model.FanboxCreatorDetail
-import me.matsumo.fankt.fanbox.domain.model.FanboxCreatorPlan
-import me.matsumo.fankt.fanbox.domain.model.FanboxCreatorPlanDetail
-import me.matsumo.fankt.fanbox.domain.model.FanboxMetaData
-import me.matsumo.fankt.fanbox.domain.model.FanboxNewsLetter
-import me.matsumo.fankt.fanbox.domain.model.FanboxPaidRecord
-import me.matsumo.fankt.fanbox.domain.model.FanboxPost
-import me.matsumo.fankt.fanbox.domain.model.FanboxPostDetail
-import me.matsumo.fankt.fanbox.domain.model.FanboxTag
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxCommentId
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxCreatorId
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxPostId
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxUserId
 import org.koin.core.component.KoinComponent
 import kotlin.random.Random
 
 interface FanboxRepository {
-    val bookmarkedPostsIds: SharedFlow<List<FanboxPostId>>
-    val blockedCreators: SharedFlow<Set<FanboxCreatorId>>
+    val bookmarkedPostsIds: SharedFlow<List<PostId>>
+    val blockedCreators: SharedFlow<Set<CreatorId>>
     val sessionId: Flow<String?>
     val csrfToken: Flow<String?>
     val logoutTrigger: Flow<Long>
@@ -78,122 +105,122 @@ interface FanboxRepository {
 
     suspend fun setCookies(cookies: List<FanboxCookieRecord>)
     suspend fun updateCsrfToken()
-    suspend fun getMetadata(): FanboxMetaData
+    suspend fun getMetadata(): MetaData
 
     suspend fun getHomePosts(
-        cursor: FanboxCursor?,
+        cursor: Cursor?,
         loadSize: Int = cursor?.limit ?: 10,
-    ): PageCursorInfo<FanboxPost>
+    ): PageCursorInfo<Post>
 
     suspend fun getSupportedPosts(
-        cursor: FanboxCursor?,
+        cursor: Cursor?,
         loadSize: Int = cursor?.limit ?: 10,
-    ): PageCursorInfo<FanboxPost>
+    ): PageCursorInfo<Post>
 
     suspend fun getCreatorPosts(
-        creatorId: FanboxCreatorId,
-        currentCursor: FanboxCursor,
-        nextCursor: FanboxCursor?,
+        creatorId: CreatorId,
+        currentCursor: Cursor,
+        nextCursor: Cursor?,
         loadSize: Int = currentCursor.limit ?: 10,
-    ): PageCursorInfo<FanboxPost>
+    ): PageCursorInfo<Post>
 
-    suspend fun getCreatorPostsPagination(creatorId: FanboxCreatorId): List<FanboxCursor>
-    suspend fun getPostDetail(postId: FanboxPostId): FanboxPostDetail
-    suspend fun getPostDetailCached(postId: FanboxPostId): FanboxPostDetail
+    suspend fun getCreatorPostsPagination(creatorId: CreatorId): List<Cursor>
+    suspend fun getPostDetail(postId: PostId): PostDetail
+    suspend fun getPostDetailCached(postId: PostId): PostDetail
     suspend fun getPostComment(
-        postId: FanboxPostId,
+        postId: PostId,
         offset: Int = 0,
-    ): PageOffsetInfo<FanboxComment>
+    ): PageOffsetInfo<Comment>
 
     suspend fun getPostFromQuery(
         query: String,
-        creatorId: FanboxCreatorId? = null,
+        creatorId: CreatorId? = null,
         page: Int = 0,
-    ): PageNumberInfo<FanboxPost>
+    ): PageNumberInfo<Post>
 
     suspend fun getCreatorFromQuery(
         query: String,
         page: Int = 0,
-    ): PageNumberInfo<FanboxCreatorDetail>
+    ): PageNumberInfo<CreatorDetail>
 
-    suspend fun getTagFromQuery(query: String): List<FanboxTag>
+    suspend fun getTagFromQuery(query: String): List<Tag>
 
     suspend fun getHomePostsPager(
         loadSize: Int,
         isHideRestricted: Boolean,
-    ): Flow<PagingData<FanboxPost>>
+    ): Flow<PagingData<Post>>
 
     suspend fun getHomePostsPagerCache(
         loadSize: Int,
         isHideRestricted: Boolean,
-    ): Flow<PagingData<FanboxPost>>
+    ): Flow<PagingData<Post>>
 
     suspend fun getSupportedPostsPager(
         loadSize: Int,
         isHideRestricted: Boolean,
-    ): Flow<PagingData<FanboxPost>>
+    ): Flow<PagingData<Post>>
 
     suspend fun getSupportedPostsPagerCache(
         loadSize: Int,
         isHideRestricted: Boolean,
-    ): Flow<PagingData<FanboxPost>>
+    ): Flow<PagingData<Post>>
 
     suspend fun getCreatorPostsPager(
-        creatorId: FanboxCreatorId,
+        creatorId: CreatorId,
         loadSize: Int,
-    ): Flow<PagingData<FanboxPost>>
+    ): Flow<PagingData<Post>>
 
-    suspend fun getCreatorPostsPagerCache(): Flow<PagingData<FanboxPost>>?
+    suspend fun getCreatorPostsPagerCache(): Flow<PagingData<Post>>?
     suspend fun getPostsFromQueryPager(
         query: String,
-        creatorId: FanboxCreatorId? = null,
-    ): Flow<PagingData<FanboxPost>>
+        creatorId: CreatorId? = null,
+    ): Flow<PagingData<Post>>
 
-    suspend fun getPostsFromQueryPagerCache(): Flow<PagingData<FanboxPost>>?
-    suspend fun getCreatorsFromQueryPager(query: String): Flow<PagingData<FanboxCreatorDetail>>
+    suspend fun getPostsFromQueryPagerCache(): Flow<PagingData<Post>>?
+    suspend fun getCreatorsFromQueryPager(query: String): Flow<PagingData<CreatorDetail>>
 
-    suspend fun getFollowingCreators(): List<FanboxCreatorDetail>
-    suspend fun getFollowingPixivCreators(): List<FanboxCreatorDetail>
-    suspend fun getRecommendedCreators(): List<FanboxCreatorDetail>
+    suspend fun getFollowingCreators(): List<CreatorDetail>
+    suspend fun getFollowingPixivCreators(): List<CreatorDetail>
+    suspend fun getRecommendedCreators(): List<CreatorDetail>
 
-    suspend fun getCreatorDetail(creatorId: FanboxCreatorId): FanboxCreatorDetail
-    suspend fun getCreatorDetailCached(creatorId: FanboxCreatorId): FanboxCreatorDetail
-    suspend fun getCreatorTags(creatorId: FanboxCreatorId): List<FanboxTag>
+    suspend fun getCreatorDetail(creatorId: CreatorId): CreatorDetail
+    suspend fun getCreatorDetailCached(creatorId: CreatorId): CreatorDetail
+    suspend fun getCreatorTags(creatorId: CreatorId): List<Tag>
 
-    suspend fun getSupportedPlans(): List<FanboxCreatorPlan>
-    suspend fun getCreatorPlans(creatorId: FanboxCreatorId): List<FanboxCreatorPlan>
-    suspend fun getCreatorPlan(creatorId: FanboxCreatorId): FanboxCreatorPlanDetail
+    suspend fun getSupportedPlans(): List<CreatorPlan>
+    suspend fun getCreatorPlans(creatorId: CreatorId): List<CreatorPlan>
+    suspend fun getCreatorPlan(creatorId: CreatorId): CreatorPlanDetail
 
-    suspend fun getPaidRecords(): List<FanboxPaidRecord>
-    suspend fun getUnpaidRecords(): List<FanboxPaidRecord>
+    suspend fun getPaidRecords(): List<PaidRecord>
+    suspend fun getUnpaidRecords(): List<PaidRecord>
 
-    suspend fun getNewsLetters(): List<FanboxNewsLetter>
-    suspend fun getBells(page: Int = 0): PageNumberInfo<FanboxBell>
+    suspend fun getNewsLetters(): List<NewsLetter>
+    suspend fun getBells(page: Int = 0): PageNumberInfo<Bell>
 
-    suspend fun likePost(postId: FanboxPostId)
-    suspend fun likeComment(commentId: FanboxCommentId)
+    suspend fun likePost(postId: PostId)
+    suspend fun likeComment(commentId: CommentId)
 
     suspend fun addComment(
-        postId: FanboxPostId,
+        postId: PostId,
         comment: String,
-        rootCommentId: FanboxCommentId? = null,
-        parentCommentId: FanboxCommentId? = null,
+        rootCommentId: CommentId? = null,
+        parentCommentId: CommentId? = null,
     )
 
-    suspend fun deleteComment(commentId: FanboxCommentId)
+    suspend fun deleteComment(commentId: CommentId)
 
-    suspend fun followCreator(creatorUserId: FanboxUserId)
-    suspend fun unfollowCreator(creatorUserId: FanboxUserId)
+    suspend fun followCreator(creatorUserId: UserId)
+    suspend fun unfollowCreator(creatorUserId: UserId)
 
-    suspend fun blockCreator(creatorId: FanboxCreatorId)
-    suspend fun unblockCreator(creatorId: FanboxCreatorId)
+    suspend fun blockCreator(creatorId: CreatorId)
+    suspend fun unblockCreator(creatorId: CreatorId)
 
-    suspend fun getBookmarkedPosts(): List<FanboxPost>
-    suspend fun bookmarkPost(post: FanboxPost)
-    suspend fun unbookmarkPost(post: FanboxPost)
+    suspend fun getBookmarkedPosts(): List<Post>
+    suspend fun bookmarkPost(post: Post)
+    suspend fun unbookmarkPost(post: Post)
 
-    suspend fun setCreatorAllPostsCache(creatorId: FanboxCreatorId, posts: List<FanboxPost>)
-    suspend fun getCreatorAllPostsCache(creatorId: FanboxCreatorId): List<FanboxPost>?
+    suspend fun setCreatorAllPostsCache(creatorId: CreatorId, posts: List<Post>)
+    suspend fun getCreatorAllPostsCache(creatorId: CreatorId): List<Post>?
 
     /**
      * ダウンロードした内容を [onChunk] へ順に渡す。
@@ -244,13 +271,13 @@ class FanboxRepositoryImpl(
         cookieStorage = cookieStorage,
     )
 
-    private val creatorCache = mutableMapOf<FanboxCreatorId, FanboxCreatorDetail>()
-    private val postCache = mutableMapOf<FanboxPostId, FanboxPostDetail>()
-    private val creatorAllPostsCache = mutableMapOf<FanboxCreatorId, List<FanboxPost>>()
-    private var homePostsPager: Flow<PagingData<FanboxPost>>? = null
-    private var supportedPostsPager: Flow<PagingData<FanboxPost>>? = null
-    private var creatorPostsPager: Flow<PagingData<FanboxPost>>? = null
-    private var searchPostsPager: Flow<PagingData<FanboxPost>>? = null
+    private val creatorCache = mutableMapOf<CreatorId, CreatorDetail>()
+    private val postCache = mutableMapOf<PostId, PostDetail>()
+    private val creatorAllPostsCache = mutableMapOf<CreatorId, List<Post>>()
+    private var homePostsPager: Flow<PagingData<Post>>? = null
+    private var supportedPostsPager: Flow<PagingData<Post>>? = null
+    private var creatorPostsPager: Flow<PagingData<Post>>? = null
+    private var searchPostsPager: Flow<PagingData<Post>>? = null
 
     // ログアウトの完了を待つ呼び出し元を止めないため、受け手がいなくても送信が進む容量を持たせる。
     private val _logoutTrigger = Channel<Long>(Channel.CONFLATED)
@@ -262,8 +289,13 @@ class FanboxRepositoryImpl(
     override val logoutTrigger: Flow<Long> = _logoutTrigger.receiveAsFlow()
     override val sessionInvalidatedTrigger: Flow<Long> = _sessionInvalidatedTrigger.receiveAsFlow()
 
-    override val bookmarkedPostsIds: SharedFlow<List<FanboxPostId>> = bookmarkDataStore.data
-    override val blockedCreators: SharedFlow<Set<FanboxCreatorId>> = blockDataStore.data
+    override val bookmarkedPostsIds: SharedFlow<List<PostId>> = bookmarkDataStore.data
+        .map { ids -> ids.map { it.toPostId() } }
+        .shareIn(scope, SharingStarted.Eagerly, replay = 1)
+
+    override val blockedCreators: SharedFlow<Set<CreatorId>> = blockDataStore.data
+        .map { ids -> ids.map { it.toCreatorId() }.toSet() }
+        .shareIn(scope, SharingStarted.Eagerly, replay = 1)
 
     /**
      * ログアウトする。
@@ -356,85 +388,85 @@ class FanboxRepositoryImpl(
         }
     }
 
-    override suspend fun getMetadata(): FanboxMetaData = withSessionCheck {
-        fanbox.getMetadata()
+    override suspend fun getMetadata(): MetaData = withSessionCheck {
+        fanbox.getMetadata().toMetaData()
     }
 
     override suspend fun getHomePosts(
-        cursor: FanboxCursor?,
+        cursor: Cursor?,
         loadSize: Int,
-    ): PageCursorInfo<FanboxPost> = withSessionCheck {
-        fanbox.getHomePosts(cursor, ::recordSchemaMismatch)
+    ): PageCursorInfo<Post> = withSessionCheck {
+        fanbox.getHomePosts(cursor?.toFanboxCursor(), ::recordSchemaMismatch).toPageCursorInfo { it.toPost() }
     }
 
     override suspend fun getSupportedPosts(
-        cursor: FanboxCursor?,
+        cursor: Cursor?,
         loadSize: Int,
-    ): PageCursorInfo<FanboxPost> = withSessionCheck {
-        fanbox.getSupportedPosts(cursor, ::recordSchemaMismatch)
+    ): PageCursorInfo<Post> = withSessionCheck {
+        fanbox.getSupportedPosts(cursor?.toFanboxCursor(), ::recordSchemaMismatch).toPageCursorInfo { it.toPost() }
     }
 
     override suspend fun getCreatorPosts(
-        creatorId: FanboxCreatorId,
-        currentCursor: FanboxCursor,
-        nextCursor: FanboxCursor?,
+        creatorId: CreatorId,
+        currentCursor: Cursor,
+        nextCursor: Cursor?,
         loadSize: Int,
-    ): PageCursorInfo<FanboxPost> = withSessionCheck {
+    ): PageCursorInfo<Post> = withSessionCheck {
         fanbox.getCreatorPosts(
-            creatorId = creatorId,
-            cursor = currentCursor,
-            nextCursor = nextCursor,
+            creatorId = creatorId.toFanboxCreatorId(),
+            cursor = currentCursor.toFanboxCursor(),
+            nextCursor = nextCursor?.toFanboxCursor(),
             onItemSchemaMismatch = ::recordSchemaMismatch,
-        )
+        ).toPageCursorInfo { it.toPost() }
     }
 
     override suspend fun getPostFromQuery(
         query: String,
-        creatorId: FanboxCreatorId?,
+        creatorId: CreatorId?,
         page: Int,
-    ): PageNumberInfo<FanboxPost> = withSessionCheck {
-        fanbox.getPostFromQuery(query, creatorId, page)
+    ): PageNumberInfo<Post> = withSessionCheck {
+        fanbox.getPostFromQuery(query, creatorId?.toFanboxCreatorId(), page).toPageNumberInfo { it.toPost() }
     }
 
-    override suspend fun getCreatorPostsPagination(creatorId: FanboxCreatorId): List<FanboxCursor> = withSessionCheck {
-        fanbox.getCreatorPostsPagination(creatorId)
+    override suspend fun getCreatorPostsPagination(creatorId: CreatorId): List<Cursor> = withSessionCheck {
+        fanbox.getCreatorPostsPagination(creatorId.toFanboxCreatorId()).map { it.toCursor() }
     }
 
     override suspend fun getCreatorFromQuery(
         query: String,
         page: Int,
-    ): PageNumberInfo<FanboxCreatorDetail> = withSessionCheck {
-        fanbox.searchCreators(query, page)
+    ): PageNumberInfo<CreatorDetail> = withSessionCheck {
+        fanbox.searchCreators(query, page).toPageNumberInfo { it.toCreatorDetail() }
     }
 
-    override suspend fun getTagFromQuery(query: String): List<FanboxTag> = withSessionCheck {
-        fanbox.searchTags(query)
+    override suspend fun getTagFromQuery(query: String): List<Tag> = withSessionCheck {
+        fanbox.searchTags(query).map { it.toTag() }
     }
 
-    override suspend fun getPostDetail(postId: FanboxPostId): FanboxPostDetail = withSessionCheck {
-        fanbox.getPostDetail(postId)
+    override suspend fun getPostDetail(postId: PostId): PostDetail = withSessionCheck {
+        fanbox.getPostDetail(postId.toFanboxPostId()).toPostDetail()
     }
 
-    override suspend fun getPostDetailCached(postId: FanboxPostId): FanboxPostDetail =
+    override suspend fun getPostDetailCached(postId: PostId): PostDetail =
         withContext(ioDispatcher) {
             postCache.getOrPut(postId) { getPostDetail(postId) }
         }
 
     override suspend fun getPostComment(
-        postId: FanboxPostId,
+        postId: PostId,
         offset: Int,
-    ): PageOffsetInfo<FanboxComment> = withSessionCheck {
+    ): PageOffsetInfo<Comment> = withSessionCheck {
         fanbox.getPostComment(
-            postId = postId,
+            postId = postId.toFanboxPostId(),
             offset = offset,
             onItemSchemaMismatch = ::recordSchemaMismatch,
-        )
+        ).toPageOffsetInfo { it.toComment() }
     }
 
     override suspend fun getHomePostsPager(
         loadSize: Int,
         isHideRestricted: Boolean,
-    ): Flow<PagingData<FanboxPost>> {
+    ): Flow<PagingData<Post>> {
         return Pager(
             config = PagingConfig(pageSize = loadSize),
             initialKey = null,
@@ -450,14 +482,14 @@ class FanboxRepositoryImpl(
     override suspend fun getHomePostsPagerCache(
         loadSize: Int,
         isHideRestricted: Boolean,
-    ): Flow<PagingData<FanboxPost>> {
+    ): Flow<PagingData<Post>> {
         return homePostsPager ?: getHomePostsPager(loadSize, isHideRestricted)
     }
 
     override suspend fun getSupportedPostsPager(
         loadSize: Int,
         isHideRestricted: Boolean,
-    ): Flow<PagingData<FanboxPost>> {
+    ): Flow<PagingData<Post>> {
         return Pager(
             config = PagingConfig(pageSize = loadSize),
             initialKey = null,
@@ -473,14 +505,14 @@ class FanboxRepositoryImpl(
     override suspend fun getSupportedPostsPagerCache(
         loadSize: Int,
         isHideRestricted: Boolean,
-    ): Flow<PagingData<FanboxPost>> {
+    ): Flow<PagingData<Post>> {
         return supportedPostsPager ?: getSupportedPostsPager(loadSize, isHideRestricted)
     }
 
     override suspend fun getCreatorPostsPager(
-        creatorId: FanboxCreatorId,
+        creatorId: CreatorId,
         loadSize: Int,
-    ): Flow<PagingData<FanboxPost>> {
+    ): Flow<PagingData<Post>> {
         val cursors = getCreatorPostsPagination(creatorId)
 
         return Pager(
@@ -499,14 +531,14 @@ class FanboxRepositoryImpl(
             .also { creatorPostsPager = it }
     }
 
-    override suspend fun getCreatorPostsPagerCache(): Flow<PagingData<FanboxPost>>? {
+    override suspend fun getCreatorPostsPagerCache(): Flow<PagingData<Post>>? {
         return creatorPostsPager
     }
 
     override suspend fun getPostsFromQueryPager(
         query: String,
-        creatorId: FanboxCreatorId?,
-    ): Flow<PagingData<FanboxPost>> {
+        creatorId: CreatorId?,
+    ): Flow<PagingData<Post>> {
         return Pager(
             config = PagingConfig(pageSize = 10),
             initialKey = null,
@@ -519,11 +551,11 @@ class FanboxRepositoryImpl(
             .also { searchPostsPager = it }
     }
 
-    override suspend fun getPostsFromQueryPagerCache(): Flow<PagingData<FanboxPost>>? {
+    override suspend fun getPostsFromQueryPagerCache(): Flow<PagingData<Post>>? {
         return searchPostsPager
     }
 
-    override suspend fun getCreatorsFromQueryPager(query: String): Flow<PagingData<FanboxCreatorDetail>> {
+    override suspend fun getCreatorsFromQueryPager(query: String): Flow<PagingData<CreatorDetail>> {
         return Pager(
             config = PagingConfig(pageSize = 10),
             initialKey = null,
@@ -533,124 +565,124 @@ class FanboxRepositoryImpl(
         ).flow
     }
 
-    override suspend fun getFollowingCreators(): List<FanboxCreatorDetail> = withSessionCheck {
-        fanbox.getFollowingCreators(::recordSchemaMismatch)
+    override suspend fun getFollowingCreators(): List<CreatorDetail> = withSessionCheck {
+        fanbox.getFollowingCreators(::recordSchemaMismatch).map { it.toCreatorDetail() }
     }
 
-    override suspend fun getFollowingPixivCreators(): List<FanboxCreatorDetail> = withSessionCheck {
-        fanbox.getFollowingPixivCreators(::recordSchemaMismatch)
+    override suspend fun getFollowingPixivCreators(): List<CreatorDetail> = withSessionCheck {
+        fanbox.getFollowingPixivCreators(::recordSchemaMismatch).map { it.toCreatorDetail() }
     }
 
-    override suspend fun getRecommendedCreators(): List<FanboxCreatorDetail> = withSessionCheck {
-        fanbox.getRecommendedCreators(::recordSchemaMismatch)
+    override suspend fun getRecommendedCreators(): List<CreatorDetail> = withSessionCheck {
+        fanbox.getRecommendedCreators(::recordSchemaMismatch).map { it.toCreatorDetail() }
     }
 
-    override suspend fun getCreatorDetail(creatorId: FanboxCreatorId): FanboxCreatorDetail = withSessionCheck {
-        fanbox.getCreatorDetail(creatorId)
+    override suspend fun getCreatorDetail(creatorId: CreatorId): CreatorDetail = withSessionCheck {
+        fanbox.getCreatorDetail(creatorId.toFanboxCreatorId()).toCreatorDetail()
     }
 
-    override suspend fun getCreatorDetailCached(creatorId: FanboxCreatorId): FanboxCreatorDetail =
+    override suspend fun getCreatorDetailCached(creatorId: CreatorId): CreatorDetail =
         withContext(ioDispatcher) {
             creatorCache.getOrPut(creatorId) { getCreatorDetail(creatorId) }
         }
 
-    override suspend fun getCreatorTags(creatorId: FanboxCreatorId): List<FanboxTag> = withSessionCheck {
-        fanbox.getCreatorTags(creatorId)
+    override suspend fun getCreatorTags(creatorId: CreatorId): List<Tag> = withSessionCheck {
+        fanbox.getCreatorTags(creatorId.toFanboxCreatorId()).map { it.toTag() }
     }
 
-    override suspend fun getSupportedPlans(): List<FanboxCreatorPlan> = withSessionCheck {
-        fanbox.getSupportedPlans(::recordSchemaMismatch)
+    override suspend fun getSupportedPlans(): List<CreatorPlan> = withSessionCheck {
+        fanbox.getSupportedPlans(::recordSchemaMismatch).map { it.toCreatorPlan() }
     }
 
-    override suspend fun getCreatorPlans(creatorId: FanboxCreatorId): List<FanboxCreatorPlan> = withSessionCheck {
-        fanbox.getCreatorPlans(creatorId, ::recordSchemaMismatch)
+    override suspend fun getCreatorPlans(creatorId: CreatorId): List<CreatorPlan> = withSessionCheck {
+        fanbox.getCreatorPlans(creatorId.toFanboxCreatorId(), ::recordSchemaMismatch).map { it.toCreatorPlan() }
     }
 
-    override suspend fun getCreatorPlan(creatorId: FanboxCreatorId): FanboxCreatorPlanDetail = withSessionCheck {
-        fanbox.getCreatorPlanDetail(creatorId)
+    override suspend fun getCreatorPlan(creatorId: CreatorId): CreatorPlanDetail = withSessionCheck {
+        fanbox.getCreatorPlanDetail(creatorId.toFanboxCreatorId()).toCreatorPlanDetail()
     }
 
-    override suspend fun getPaidRecords(): List<FanboxPaidRecord> = withSessionCheck {
-        fanbox.getPaidRecords()
+    override suspend fun getPaidRecords(): List<PaidRecord> = withSessionCheck {
+        fanbox.getPaidRecords().map { it.toPaidRecord() }
     }
 
-    override suspend fun getUnpaidRecords(): List<FanboxPaidRecord> = withSessionCheck {
-        fanbox.getUnpaidRecords()
+    override suspend fun getUnpaidRecords(): List<PaidRecord> = withSessionCheck {
+        fanbox.getUnpaidRecords().map { it.toPaidRecord() }
     }
 
-    override suspend fun getNewsLetters(): List<FanboxNewsLetter> = withSessionCheck {
-        fanbox.getNewsLetters()
+    override suspend fun getNewsLetters(): List<NewsLetter> = withSessionCheck {
+        fanbox.getNewsLetters().map { it.toNewsLetter() }
     }
 
-    override suspend fun getBells(page: Int): PageNumberInfo<FanboxBell> = withSessionCheck {
+    override suspend fun getBells(page: Int): PageNumberInfo<Bell> = withSessionCheck {
         // 一覧を取得した時点で FANBOX 側の通知を既読にする。fankt 0.1.0 の既定は未読のまま残す
         // 挙動だが、PixiView は従来どおり既読化する。
         fanbox.getBells(
             page = page,
             onItemSchemaMismatch = ::recordSchemaMismatch,
             markNotificationsRead = true,
-        )
+        ).toPageNumberInfo { it.toBell() }
     }
 
-    override suspend fun likePost(postId: FanboxPostId) = withSessionCheck {
-        fanbox.likePost(postId)
+    override suspend fun likePost(postId: PostId) = withSessionCheck {
+        fanbox.likePost(postId.toFanboxPostId())
     }
 
-    override suspend fun likeComment(commentId: FanboxCommentId) = withSessionCheck {
-        fanbox.likeComment(commentId)
+    override suspend fun likeComment(commentId: CommentId) = withSessionCheck {
+        fanbox.likeComment(commentId.toFanboxCommentId())
     }
 
     override suspend fun addComment(
-        postId: FanboxPostId,
+        postId: PostId,
         comment: String,
-        rootCommentId: FanboxCommentId?,
-        parentCommentId: FanboxCommentId?,
+        rootCommentId: CommentId?,
+        parentCommentId: CommentId?,
     ) = withSessionCheck {
         fanbox.addComment(
-            postId = postId,
-            rootCommentId = rootCommentId,
-            parentCommentId = parentCommentId,
+            postId = postId.toFanboxPostId(),
+            rootCommentId = rootCommentId?.toFanboxCommentId(),
+            parentCommentId = parentCommentId?.toFanboxCommentId(),
             body = comment,
         )
     }
 
-    override suspend fun deleteComment(commentId: FanboxCommentId) = withSessionCheck {
-        fanbox.deleteComment(commentId)
+    override suspend fun deleteComment(commentId: CommentId) = withSessionCheck {
+        fanbox.deleteComment(commentId.toFanboxCommentId())
     }
 
-    override suspend fun followCreator(creatorUserId: FanboxUserId) = withSessionCheck {
-        fanbox.followCreator(creatorUserId)
+    override suspend fun followCreator(creatorUserId: UserId) = withSessionCheck {
+        fanbox.followCreator(creatorUserId.toFanboxUserId())
     }
 
-    override suspend fun unfollowCreator(creatorUserId: FanboxUserId) = withSessionCheck {
-        fanbox.unfollowCreator(creatorUserId)
+    override suspend fun unfollowCreator(creatorUserId: UserId) = withSessionCheck {
+        fanbox.unfollowCreator(creatorUserId.toFanboxUserId())
     }
 
-    override suspend fun blockCreator(creatorId: FanboxCreatorId) {
-        blockDataStore.blockCreator(creatorId)
+    override suspend fun blockCreator(creatorId: CreatorId) {
+        blockDataStore.blockCreator(creatorId.toFanboxCreatorId())
     }
 
-    override suspend fun unblockCreator(creatorId: FanboxCreatorId) {
-        blockDataStore.unblockCreator(creatorId)
+    override suspend fun unblockCreator(creatorId: CreatorId) {
+        blockDataStore.unblockCreator(creatorId.toFanboxCreatorId())
     }
 
-    override suspend fun getBookmarkedPosts(): List<FanboxPost> = withContext(ioDispatcher) {
-        bookmarkDataStore.get()
+    override suspend fun getBookmarkedPosts(): List<Post> = withContext(ioDispatcher) {
+        bookmarkDataStore.get().map { it.toPost() }
     }
 
-    override suspend fun bookmarkPost(post: FanboxPost) = withContext(ioDispatcher) {
-        bookmarkDataStore.save(post)
+    override suspend fun bookmarkPost(post: Post) = withContext(ioDispatcher) {
+        bookmarkDataStore.save(post.toFanboxPost())
     }
 
-    override suspend fun unbookmarkPost(post: FanboxPost) {
-        bookmarkDataStore.remove(post)
+    override suspend fun unbookmarkPost(post: Post) {
+        bookmarkDataStore.remove(post.toFanboxPost())
     }
 
-    override suspend fun setCreatorAllPostsCache(creatorId: FanboxCreatorId, posts: List<FanboxPost>) {
+    override suspend fun setCreatorAllPostsCache(creatorId: CreatorId, posts: List<Post>) {
         creatorAllPostsCache[creatorId] = posts
     }
 
-    override suspend fun getCreatorAllPostsCache(creatorId: FanboxCreatorId): List<FanboxPost>? {
+    override suspend fun getCreatorAllPostsCache(creatorId: CreatorId): List<Post>? {
         return creatorAllPostsCache[creatorId]
     }
 

--- a/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/TranslationRepository.kt
+++ b/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/TranslationRepository.kt
@@ -13,13 +13,13 @@ import kotlinx.coroutines.IO
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import me.matsumo.fanbox.core.common.PixiViewConfig
+import me.matsumo.fanbox.core.model.fanbox.Comment
+import me.matsumo.fanbox.core.model.fanbox.PageOffsetInfo
+import me.matsumo.fanbox.core.model.fanbox.PostDetail
 import me.matsumo.fanbox.core.model.translation.TransString
 import me.matsumo.fanbox.core.model.translation.toFanboxComments
 import me.matsumo.fanbox.core.model.translation.toFanboxPostDetail
 import me.matsumo.fanbox.core.model.translation.toTrans
-import me.matsumo.fankt.fanbox.domain.PageOffsetInfo
-import me.matsumo.fankt.fanbox.domain.model.FanboxComment
-import me.matsumo.fankt.fanbox.domain.model.FanboxPostDetail
 import kotlin.time.Duration.Companion.seconds
 
 class TranslationRepository(
@@ -49,14 +49,14 @@ class TranslationRepository(
         result.body
     }
 
-    suspend fun translate(postDetail: FanboxPostDetail, locale: Locale): FanboxPostDetail = withContext(ioDispatcher) {
+    suspend fun translate(postDetail: PostDetail, locale: Locale): PostDetail = withContext(ioDispatcher) {
         val transPostDetail = postDetail.toTrans()
         val result = translate(transPostDetail, locale)
 
         result.toFanboxPostDetail(postDetail)
     }
 
-    suspend fun translate(comments: PageOffsetInfo<FanboxComment>, locale: Locale): PageOffsetInfo<FanboxComment> = withContext(ioDispatcher) {
+    suspend fun translate(comments: PageOffsetInfo<Comment>, locale: Locale): PageOffsetInfo<Comment> = withContext(ioDispatcher) {
         val transComments = comments.toTrans()
         val result = translate(transComments, locale)
 

--- a/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/TranslationRepository.kt
+++ b/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/TranslationRepository.kt
@@ -17,9 +17,9 @@ import me.matsumo.fanbox.core.model.fanbox.Comment
 import me.matsumo.fanbox.core.model.fanbox.PageOffsetInfo
 import me.matsumo.fanbox.core.model.fanbox.PostDetail
 import me.matsumo.fanbox.core.model.translation.TransString
-import me.matsumo.fanbox.core.model.translation.toFanboxComments
-import me.matsumo.fanbox.core.model.translation.toFanboxPostDetail
 import me.matsumo.fanbox.core.model.translation.toTrans
+import me.matsumo.fanbox.core.model.translation.toTranslatedComments
+import me.matsumo.fanbox.core.model.translation.toTranslatedPostDetail
 import kotlin.time.Duration.Companion.seconds
 
 class TranslationRepository(
@@ -53,14 +53,14 @@ class TranslationRepository(
         val transPostDetail = postDetail.toTrans()
         val result = translate(transPostDetail, locale)
 
-        result.toFanboxPostDetail(postDetail)
+        result.toTranslatedPostDetail(postDetail)
     }
 
     suspend fun translate(comments: PageOffsetInfo<Comment>, locale: Locale): PageOffsetInfo<Comment> = withContext(ioDispatcher) {
         val transComments = comments.toTrans()
         val result = translate(transComments, locale)
 
-        result.toFanboxComments(comments)
+        result.toTranslatedComments(comments)
     }
 
     private fun buildChatCompletionRequest(json: String, locale: Locale): ChatCompletionRequest {

--- a/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/paging/CreatorPostsPagingSource.kt
+++ b/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/paging/CreatorPostsPagingSource.kt
@@ -4,20 +4,20 @@ import androidx.paging.PagingSource
 import androidx.paging.PagingState
 import kotlinx.coroutines.flow.first
 import me.matsumo.fanbox.core.common.util.suspendRunCatching
+import me.matsumo.fanbox.core.model.fanbox.CreatorId
+import me.matsumo.fanbox.core.model.fanbox.Cursor
+import me.matsumo.fanbox.core.model.fanbox.Post
 import me.matsumo.fanbox.core.repository.FanboxRepository
-import me.matsumo.fankt.fanbox.domain.FanboxCursor
-import me.matsumo.fankt.fanbox.domain.model.FanboxPost
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxCreatorId
 
 class CreatorPostsPagingSource(
-    private val creatorId: FanboxCreatorId,
-    private val cursors: List<FanboxCursor>,
+    private val creatorId: CreatorId,
+    private val cursors: List<Cursor>,
     private val fanboxRepository: FanboxRepository,
-) : PagingSource<Int, FanboxPost>() {
+) : PagingSource<Int, Post>() {
 
     override val keyReuseSupported: Boolean = true
 
-    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, FanboxPost> {
+    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, Post> {
         val currentIndex = params.key ?: 0
         val nextIndex = currentIndex + 1
 
@@ -46,5 +46,5 @@ class CreatorPostsPagingSource(
         )
     }
 
-    override fun getRefreshKey(state: PagingState<Int, FanboxPost>): Int? = null
+    override fun getRefreshKey(state: PagingState<Int, Post>): Int? = null
 }

--- a/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/paging/HomePostsPagingSource.kt
+++ b/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/paging/HomePostsPagingSource.kt
@@ -3,28 +3,28 @@ package me.matsumo.fanbox.core.repository.paging
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
 import kotlinx.coroutines.flow.first
+import me.matsumo.fanbox.core.model.fanbox.Cursor
+import me.matsumo.fanbox.core.model.fanbox.Post
 import me.matsumo.fanbox.core.repository.FanboxRepository
-import me.matsumo.fankt.fanbox.domain.FanboxCursor
-import me.matsumo.fankt.fanbox.domain.model.FanboxPost
 import kotlin.coroutines.cancellation.CancellationException
 
 class HomePostsPagingSource(
     private val fanboxRepository: FanboxRepository,
     private val isHideRestricted: Boolean,
-) : PagingSource<FanboxCursor, FanboxPost>() {
+) : PagingSource<Cursor, Post>() {
 
     override val keyReuseSupported: Boolean = true
 
-    override suspend fun load(params: LoadParams<FanboxCursor>): LoadResult<FanboxCursor, FanboxPost> {
+    override suspend fun load(params: LoadParams<Cursor>): LoadResult<Cursor, Post> {
         return try {
             val blockedCreators = fanboxRepository.blockedCreators.first()
             var cursor = params.key
-            val visitedCursor = mutableSetOf<FanboxCursor?>()
-            var loadResult: LoadResult<FanboxCursor, FanboxPost>? = null
+            val visitedCursor = mutableSetOf<Cursor?>()
+            var loadResult: LoadResult<Cursor, Post>? = null
 
             while (loadResult == null) {
                 if (!visitedCursor.add(cursor)) {
-                    loadResult = LoadResult.Page<FanboxCursor, FanboxPost>(
+                    loadResult = LoadResult.Page<Cursor, Post>(
                         data = emptyList(),
                         nextKey = null,
                         prevKey = null,
@@ -58,7 +58,7 @@ class HomePostsPagingSource(
                 }
             }
 
-            loadResult ?: LoadResult.Page<FanboxCursor, FanboxPost>(
+            loadResult ?: LoadResult.Page<Cursor, Post>(
                 data = emptyList(),
                 nextKey = null,
                 prevKey = null,
@@ -70,5 +70,5 @@ class HomePostsPagingSource(
         }
     }
 
-    override fun getRefreshKey(state: PagingState<FanboxCursor, FanboxPost>): FanboxCursor? = null
+    override fun getRefreshKey(state: PagingState<Cursor, Post>): Cursor? = null
 }

--- a/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/paging/SearchCreatorsPagingSource.kt
+++ b/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/paging/SearchCreatorsPagingSource.kt
@@ -3,17 +3,17 @@ package me.matsumo.fanbox.core.repository.paging
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
 import me.matsumo.fanbox.core.common.util.suspendRunCatching
+import me.matsumo.fanbox.core.model.fanbox.CreatorDetail
 import me.matsumo.fanbox.core.repository.FanboxRepository
-import me.matsumo.fankt.fanbox.domain.model.FanboxCreatorDetail
 
 class SearchCreatorsPagingSource(
     private val fanboxRepository: FanboxRepository,
     private val query: String,
-) : PagingSource<Int, FanboxCreatorDetail>() {
+) : PagingSource<Int, CreatorDetail>() {
 
     override val keyReuseSupported: Boolean = true
 
-    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, FanboxCreatorDetail> {
+    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, CreatorDetail> {
         return suspendRunCatching {
             fanboxRepository.getCreatorFromQuery(query, params.key ?: 0)
         }.fold(
@@ -30,5 +30,5 @@ class SearchCreatorsPagingSource(
         )
     }
 
-    override fun getRefreshKey(state: PagingState<Int, FanboxCreatorDetail>): Int? = null
+    override fun getRefreshKey(state: PagingState<Int, CreatorDetail>): Int? = null
 }

--- a/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/paging/SearchPostsPagingSource.kt
+++ b/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/paging/SearchPostsPagingSource.kt
@@ -3,19 +3,19 @@ package me.matsumo.fanbox.core.repository.paging
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
 import me.matsumo.fanbox.core.common.util.suspendRunCatching
+import me.matsumo.fanbox.core.model.fanbox.CreatorId
+import me.matsumo.fanbox.core.model.fanbox.Post
 import me.matsumo.fanbox.core.repository.FanboxRepository
-import me.matsumo.fankt.fanbox.domain.model.FanboxPost
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxCreatorId
 
 class SearchPostsPagingSource(
     private val fanboxRepository: FanboxRepository,
-    private val creatorId: FanboxCreatorId?,
+    private val creatorId: CreatorId?,
     private val tag: String,
-) : PagingSource<Int, FanboxPost>() {
+) : PagingSource<Int, Post>() {
 
     override val keyReuseSupported: Boolean = true
 
-    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, FanboxPost> {
+    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, Post> {
         return suspendRunCatching {
             fanboxRepository.getPostFromQuery(tag, creatorId, params.key ?: 0)
         }.fold(
@@ -32,5 +32,5 @@ class SearchPostsPagingSource(
         )
     }
 
-    override fun getRefreshKey(state: PagingState<Int, FanboxPost>): Int? = null
+    override fun getRefreshKey(state: PagingState<Int, Post>): Int? = null
 }

--- a/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/paging/SupportedPostsPagingSource.kt
+++ b/core/repository/src/commonMain/kotlin/me/matsumo/fanbox/core/repository/paging/SupportedPostsPagingSource.kt
@@ -3,28 +3,28 @@ package me.matsumo.fanbox.core.repository.paging
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
 import kotlinx.coroutines.flow.first
+import me.matsumo.fanbox.core.model.fanbox.Cursor
+import me.matsumo.fanbox.core.model.fanbox.Post
 import me.matsumo.fanbox.core.repository.FanboxRepository
-import me.matsumo.fankt.fanbox.domain.FanboxCursor
-import me.matsumo.fankt.fanbox.domain.model.FanboxPost
 import kotlin.coroutines.cancellation.CancellationException
 
 class SupportedPostsPagingSource(
     private val fanboxRepository: FanboxRepository,
     private val isHideRestricted: Boolean,
-) : PagingSource<FanboxCursor, FanboxPost>() {
+) : PagingSource<Cursor, Post>() {
 
     override val keyReuseSupported: Boolean = true
 
-    override suspend fun load(params: LoadParams<FanboxCursor>): LoadResult<FanboxCursor, FanboxPost> {
+    override suspend fun load(params: LoadParams<Cursor>): LoadResult<Cursor, Post> {
         return try {
             val blockedCreators = fanboxRepository.blockedCreators.first()
             var cursor = params.key
-            val visitedCursor = mutableSetOf<FanboxCursor?>()
-            var loadResult: LoadResult<FanboxCursor, FanboxPost>? = null
+            val visitedCursor = mutableSetOf<Cursor?>()
+            var loadResult: LoadResult<Cursor, Post>? = null
 
             while (loadResult == null) {
                 if (!visitedCursor.add(cursor)) {
-                    loadResult = LoadResult.Page<FanboxCursor, FanboxPost>(
+                    loadResult = LoadResult.Page<Cursor, Post>(
                         data = emptyList(),
                         nextKey = null,
                         prevKey = null,
@@ -58,7 +58,7 @@ class SupportedPostsPagingSource(
                 }
             }
 
-            loadResult ?: LoadResult.Page<FanboxCursor, FanboxPost>(
+            loadResult ?: LoadResult.Page<Cursor, Post>(
                 data = emptyList(),
                 nextKey = null,
                 prevKey = null,
@@ -70,5 +70,5 @@ class SupportedPostsPagingSource(
         }
     }
 
-    override fun getRefreshKey(state: PagingState<FanboxCursor, FanboxPost>): FanboxCursor? = null
+    override fun getRefreshKey(state: PagingState<Cursor, Post>): Cursor? = null
 }

--- a/core/repository/src/iosMain/kotlin/me/matsumo/fanbox/core/repository/DownloadPostsRepository.ios.kt
+++ b/core/repository/src/iosMain/kotlin/me/matsumo/fanbox/core/repository/DownloadPostsRepository.ios.kt
@@ -25,9 +25,9 @@ import me.matsumo.fanbox.core.logs.logger.send
 import me.matsumo.fanbox.core.model.DownloadFileType
 import me.matsumo.fanbox.core.model.DownloadState
 import me.matsumo.fanbox.core.model.FanboxDownloadItems
-import me.matsumo.fankt.fanbox.domain.model.FanboxPost
-import me.matsumo.fankt.fanbox.domain.model.FanboxPostDetail
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxPostId
+import me.matsumo.fanbox.core.model.fanbox.Post
+import me.matsumo.fanbox.core.model.fanbox.PostDetail
+import me.matsumo.fanbox.core.model.fanbox.PostId
 import platform.Foundation.NSData
 import platform.Foundation.NSFileHandle
 import platform.Foundation.NSFileManager
@@ -71,7 +71,7 @@ class DownloadPostsRepositoryImpl(
                 val items = when (val type = downloadItems.requestType) {
                     FanboxDownloadItems.RequestType.File -> downloadItems.items
                     FanboxDownloadItems.RequestType.Image -> downloadItems.items
-                    is FanboxDownloadItems.RequestType.Post -> {
+                    is FanboxDownloadItems.RequestType.WholePost -> {
                         val postDetail = fanboxRepository.getPostDetail(downloadItems.postId)
                         val images = postDetail.body.imageItems.map { it.toDownloadItem() }
                         val files = postDetail.body.fileItems.map { it.toDownloadItem() }
@@ -111,13 +111,13 @@ class DownloadPostsRepositoryImpl(
         }
     }
 
-    override fun requestDownloadPost(post: FanboxPost, isIgnoreFiles: Boolean) {
+    override fun requestDownloadPost(post: Post, isIgnoreFiles: Boolean) {
         scope.launch {
             val items = FanboxDownloadItems(
                 postId = post.id,
                 title = post.title,
                 items = emptyList(),
-                requestType = FanboxDownloadItems.RequestType.Post(post, isIgnoreFiles),
+                requestType = FanboxDownloadItems.RequestType.WholePost(post, isIgnoreFiles),
                 key = Uuid.random().toHexString(),
             )
 
@@ -125,7 +125,7 @@ class DownloadPostsRepositoryImpl(
         }
     }
 
-    override fun requestDownloadImages(postId: FanboxPostId, title: String, images: List<FanboxPostDetail.ImageItem>) {
+    override fun requestDownloadImages(postId: PostId, title: String, images: List<PostDetail.ImageItem>) {
         val items = FanboxDownloadItems(
             postId = postId,
             title = title,
@@ -137,7 +137,7 @@ class DownloadPostsRepositoryImpl(
         _reservingPosts.update { it + items }
     }
 
-    override fun requestDownloadFiles(postId: FanboxPostId, title: String, files: List<FanboxPostDetail.FileItem>) {
+    override fun requestDownloadFiles(postId: PostId, title: String, files: List<PostDetail.FileItem>) {
         val items = FanboxDownloadItems(
             postId = postId,
             title = title,
@@ -153,7 +153,7 @@ class DownloadPostsRepositoryImpl(
         return "Unknown"
     }
 
-    private fun FanboxPostDetail.ImageItem.toDownloadItem(): FanboxDownloadItems.Item {
+    private fun PostDetail.ImageItem.toDownloadItem(): FanboxDownloadItems.Item {
         return FanboxDownloadItems.Item(
             postId = postId,
             itemId = id,
@@ -165,7 +165,7 @@ class DownloadPostsRepositoryImpl(
         )
     }
 
-    private fun FanboxPostDetail.FileItem.toDownloadItem(): FanboxDownloadItems.Item {
+    private fun PostDetail.FileItem.toDownloadItem(): FanboxDownloadItems.Item {
         return FanboxDownloadItems.Item(
             postId = postId,
             itemId = id,
@@ -245,7 +245,7 @@ class DownloadPostsRepositoryImpl(
     private fun getParentDirName(requestType: FanboxDownloadItems.RequestType?): String = when (requestType) {
         is FanboxDownloadItems.RequestType.Image -> "images"
         is FanboxDownloadItems.RequestType.File -> "files"
-        is FanboxDownloadItems.RequestType.Post -> requestType.post?.user?.name ?: "UnknownUser"
+        is FanboxDownloadItems.RequestType.WholePost -> requestType.post?.user?.name ?: "UnknownUser"
         else -> "FANBOX"
     }
 }

--- a/core/ui/src/commonMain/kotlin/me/matsumo/fanbox/core/ui/NavTypes.kt
+++ b/core/ui/src/commonMain/kotlin/me/matsumo/fanbox/core/ui/NavTypes.kt
@@ -8,18 +8,18 @@ import kotlinx.serialization.json.Json
 import me.matsumo.fanbox.core.model.BillingPlan
 import me.matsumo.fanbox.core.model.Destination
 import me.matsumo.fanbox.core.model.SimpleAlertContents
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxCreatorId
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxPostId
+import me.matsumo.fanbox.core.model.fanbox.CreatorId
+import me.matsumo.fanbox.core.model.fanbox.PostId
 import kotlin.reflect.typeOf
 
-val PostIdNavType = provideNavType<FanboxPostId>(
+val PostIdNavType = provideNavType<PostId>(
     encode = { it.value },
-    decode = { FanboxPostId(it) },
+    decode = { PostId(it) },
 )
 
-val creatorIdNavType = provideNavType<FanboxCreatorId>(
+val creatorIdNavType = provideNavType<CreatorId>(
     encode = { it.value },
-    decode = { FanboxCreatorId(it) },
+    decode = { CreatorId(it) },
 )
 
 val simpleAlertContentsNavType = provideNavType<SimpleAlertContents>(
@@ -39,8 +39,8 @@ val billingPlanTypeNavType = provideNavType<BillingPlan.Type?>(
 )
 
 val customNavTypes = mapOf(
-    typeOf<FanboxPostId>() to PostIdNavType,
-    typeOf<FanboxCreatorId>() to creatorIdNavType,
+    typeOf<PostId>() to PostIdNavType,
+    typeOf<CreatorId>() to creatorIdNavType,
     typeOf<SimpleAlertContents>() to simpleAlertContentsNavType,
     typeOf<Destination.PostDetail.PagingType>() to postDetailPagingTypeNavType,
     typeOf<BillingPlan.Type?>() to billingPlanTypeNavType,

--- a/core/ui/src/commonMain/kotlin/me/matsumo/fanbox/core/ui/component/CreatorItem.kt
+++ b/core/ui/src/commonMain/kotlin/me/matsumo/fanbox/core/ui/component/CreatorItem.kt
@@ -42,6 +42,9 @@ import coil3.compose.AsyncImage
 import coil3.compose.LocalPlatformContext
 import coil3.compose.SubcomposeAsyncImage
 import coil3.request.ImageRequest
+import me.matsumo.fanbox.core.model.fanbox.CreatorDetail
+import me.matsumo.fanbox.core.model.fanbox.CreatorId
+import me.matsumo.fanbox.core.model.fanbox.UserId
 import me.matsumo.fanbox.core.resources.Res
 import me.matsumo.fanbox.core.resources.common_follow
 import me.matsumo.fanbox.core.resources.common_supporting
@@ -52,17 +55,14 @@ import me.matsumo.fanbox.core.ui.extensition.SimmerPlaceHolder
 import me.matsumo.fanbox.core.ui.extensition.asCoilImage
 import me.matsumo.fanbox.core.ui.extensition.fanboxHeader
 import me.matsumo.fanbox.core.ui.theme.bold
-import me.matsumo.fankt.fanbox.domain.model.FanboxCreatorDetail
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxCreatorId
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxUserId
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
 fun CreatorItem(
-    creatorDetail: FanboxCreatorDetail,
-    onClickCreator: (FanboxCreatorId) -> Unit,
-    onClickFollow: (FanboxUserId) -> Unit,
-    onClickUnfollow: (FanboxUserId) -> Unit,
+    creatorDetail: CreatorDetail,
+    onClickCreator: (CreatorId) -> Unit,
+    onClickFollow: (UserId) -> Unit,
+    onClickUnfollow: (UserId) -> Unit,
     onClickSupporting: (String) -> Unit,
     modifier: Modifier = Modifier,
     isFollowed: Boolean = creatorDetail.isFollowed,
@@ -74,7 +74,7 @@ fun CreatorItem(
 
     // Unknown はサムネイルを持たないためページャに空ページとして現れる。表示できるものだけを残す。
     val displayableProfileItems = remember(creatorDetail.profileItems) {
-        creatorDetail.profileItems.filter { it !is FanboxCreatorDetail.ProfileItem.Unknown }
+        creatorDetail.profileItems.filter { it !is CreatorDetail.ProfileItem.Unknown }
     }
 
     Card(
@@ -111,9 +111,9 @@ fun CreatorItem(
                 ) { page ->
                     val profileItem = displayableProfileItems[page]
                     val thumbnailUrl = when (profileItem) {
-                        is FanboxCreatorDetail.ProfileItem.Image -> profileItem.thumbnailUrl
-                        is FanboxCreatorDetail.ProfileItem.Video -> profileItem.thumbnailUrl
-                        is FanboxCreatorDetail.ProfileItem.Unknown -> null
+                        is CreatorDetail.ProfileItem.Image -> profileItem.thumbnailUrl
+                        is CreatorDetail.ProfileItem.Video -> profileItem.thumbnailUrl
+                        is CreatorDetail.ProfileItem.Unknown -> null
                     }
 
                     Box(modifier = Modifier.fillMaxWidth()) {
@@ -130,7 +130,7 @@ fun CreatorItem(
                             contentDescription = null,
                         )
 
-                        if (profileItem is FanboxCreatorDetail.ProfileItem.Video) {
+                        if (profileItem is CreatorDetail.ProfileItem.Video) {
                             Icon(
                                 modifier = Modifier
                                     .align(Alignment.Center)
@@ -196,10 +196,10 @@ fun CreatorItem(
 
 @Composable
 private fun UserSection(
-    creatorDetail: FanboxCreatorDetail,
+    creatorDetail: CreatorDetail,
     isFollowed: Boolean,
-    onClickFollow: (FanboxUserId) -> Unit,
-    onClickUnfollow: (FanboxUserId) -> Unit,
+    onClickFollow: (UserId) -> Unit,
+    onClickUnfollow: (UserId) -> Unit,
     onClickSupporting: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {

--- a/core/ui/src/commonMain/kotlin/me/matsumo/fanbox/core/ui/component/PostGridItem.kt
+++ b/core/ui/src/commonMain/kotlin/me/matsumo/fanbox/core/ui/component/PostGridItem.kt
@@ -23,15 +23,15 @@ import androidx.compose.ui.unit.dp
 import coil3.compose.LocalPlatformContext
 import coil3.compose.SubcomposeAsyncImage
 import coil3.request.ImageRequest
+import me.matsumo.fanbox.core.model.fanbox.Post
+import me.matsumo.fanbox.core.model.fanbox.PostId
 import me.matsumo.fanbox.core.ui.extensition.SimmerPlaceHolder
 import me.matsumo.fanbox.core.ui.extensition.fanboxHeader
-import me.matsumo.fankt.fanbox.domain.model.FanboxPost
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxPostId
 
 @Composable
 fun PostGridItem(
-    post: FanboxPost,
-    onClickPost: (FanboxPostId) -> Unit,
+    post: Post,
+    onClickPost: (PostId) -> Unit,
     isHideAdultContents: Boolean,
     isOverrideAdultContents: Boolean,
     modifier: Modifier = Modifier,

--- a/core/ui/src/commonMain/kotlin/me/matsumo/fanbox/core/ui/component/PostItem.kt
+++ b/core/ui/src/commonMain/kotlin/me/matsumo/fanbox/core/ui/component/PostItem.kt
@@ -43,6 +43,9 @@ import coil3.compose.SubcomposeAsyncImage
 import coil3.request.ImageRequest
 import io.github.aakira.napier.Napier
 import me.matsumo.fanbox.core.common.util.format
+import me.matsumo.fanbox.core.model.fanbox.CreatorId
+import me.matsumo.fanbox.core.model.fanbox.Post
+import me.matsumo.fanbox.core.model.fanbox.PostId
 import me.matsumo.fanbox.core.resources.Res
 import me.matsumo.fanbox.core.resources.fanbox_free_fee
 import me.matsumo.fanbox.core.resources.im_default_user
@@ -51,19 +54,16 @@ import me.matsumo.fanbox.core.ui.extensition.FadePlaceHolder
 import me.matsumo.fanbox.core.ui.extensition.asCoilImage
 import me.matsumo.fanbox.core.ui.extensition.fanboxHeader
 import me.matsumo.fanbox.core.ui.theme.bold
-import me.matsumo.fankt.fanbox.domain.model.FanboxPost
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxCreatorId
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxPostId
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
 fun PostItem(
-    post: FanboxPost,
-    onClickPost: (FanboxPostId) -> Unit,
-    onClickCreator: (FanboxCreatorId) -> Unit,
-    onClickPlanList: (FanboxCreatorId) -> Unit,
-    onClickLike: (FanboxPostId) -> Unit,
-    onClickBookmark: (FanboxPostId, Boolean) -> Unit,
+    post: Post,
+    onClickPost: (PostId) -> Unit,
+    onClickCreator: (CreatorId) -> Unit,
+    onClickPlanList: (CreatorId) -> Unit,
+    onClickLike: (PostId) -> Unit,
+    onClickBookmark: (PostId, Boolean) -> Unit,
     isHideAdultContents: Boolean,
     isOverrideAdultContents: Boolean,
     isTestUser: Boolean,
@@ -209,8 +209,8 @@ fun PostItem(
 
 @Composable
 private fun UserSection(
-    post: FanboxPost,
-    onClickCreator: (FanboxCreatorId?) -> Unit,
+    post: Post,
+    onClickCreator: (CreatorId?) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Row(

--- a/core/ui/src/commonMain/kotlin/me/matsumo/fanbox/core/ui/extensition/CoilExtension.kt
+++ b/core/ui/src/commonMain/kotlin/me/matsumo/fanbox/core/ui/extensition/CoilExtension.kt
@@ -21,7 +21,7 @@ import com.eygraber.compose.placeholder.material3.fade
 import com.eygraber.compose.placeholder.material3.shimmer
 import com.eygraber.compose.placeholder.placeholder
 import io.github.aakira.napier.Napier
-import me.matsumo.fankt.fanbox.domain.model.FanboxMetaData
+import me.matsumo.fanbox.core.model.fanbox.MetaData
 import org.jetbrains.compose.resources.DrawableResource
 
 @Immutable
@@ -107,16 +107,16 @@ fun IndicatorPlaceHolder(
     }
 }
 
-fun getFanboxMetadataDummy() = FanboxMetaData(
+fun getFanboxMetadataDummy() = MetaData(
     apiUrl = "https://duckduckgo.com/?q=sodales",
-    context = FanboxMetaData.Context(
-        privacyPolicy = FanboxMetaData.Context.PrivacyPolicy(
+    context = MetaData.Context(
+        privacyPolicy = MetaData.Context.PrivacyPolicy(
             policyUrl = "https://search.yahoo.com/search?p=commodo",
             revisionHistoryUrl = "https://search.yahoo.com/search?p=lorem",
             shouldShowNotice = false,
             updateDate = "vix",
         ),
-        user = FanboxMetaData.Context.User(
+        user = MetaData.Context.User(
             creatorId = null,
             fanboxUserStatus = 8439,
             hasAdultContent = false,

--- a/core/ui/src/commonMain/kotlin/me/matsumo/fanbox/core/ui/theme/Theme.kt
+++ b/core/ui/src/commonMain/kotlin/me/matsumo/fanbox/core/ui/theme/Theme.kt
@@ -16,6 +16,7 @@ import kotlinx.collections.immutable.persistentMapOf
 import me.matsumo.fanbox.core.common.PixiViewConfig
 import me.matsumo.fanbox.core.model.ThemeColorConfig
 import me.matsumo.fanbox.core.model.ThemeConfig
+import me.matsumo.fanbox.core.model.fanbox.MetaData
 import me.matsumo.fanbox.core.ui.extensition.FanboxSessionId
 import me.matsumo.fanbox.core.ui.extensition.LocalFanboxMetadata
 import me.matsumo.fanbox.core.ui.extensition.LocalFanboxSessionId
@@ -34,7 +35,6 @@ import me.matsumo.fanbox.core.ui.theme.color.LightPurpleColorScheme
 import me.matsumo.fanbox.core.ui.view.LocalNativeViewsProvider
 import me.matsumo.fanbox.core.ui.view.NativeView
 import me.matsumo.fanbox.core.ui.view.NativeViews
-import me.matsumo.fankt.fanbox.domain.model.FanboxMetaData
 
 val LightDefaultColorScheme = lightColorScheme(
     primary = Purple40,
@@ -97,7 +97,7 @@ val LocalColorScheme = staticCompositionLocalOf { LightDefaultColorScheme }
 @Composable
 fun PixiViewTheme(
     sessionId: String = "",
-    fanboxMetadata: FanboxMetaData = getFanboxMetadataDummy(),
+    fanboxMetadata: MetaData = getFanboxMetadataDummy(),
     pixiViewConfig: PixiViewConfig = PixiViewConfig.dummy(),
     isAdsSdkInitialized: Boolean = true,
     themeConfig: ThemeConfig = ThemeConfig.System,

--- a/core/ui/src/commonTest/kotlin/me/matsumo/fanbox/core/ui/NavTypesTest.kt
+++ b/core/ui/src/commonTest/kotlin/me/matsumo/fanbox/core/ui/NavTypesTest.kt
@@ -11,6 +11,8 @@ import androidx.savedstate.read
 import androidx.savedstate.write
 import me.matsumo.fanbox.core.model.BillingPlan
 import me.matsumo.fanbox.core.model.Destination
+import me.matsumo.fanbox.core.model.fanbox.CreatorId
+import me.matsumo.fanbox.core.model.fanbox.PostId
 import me.matsumo.fanbox.core.ui.component.sheet.BottomSheetNavigator
 import me.matsumo.fanbox.core.ui.component.sheet.BottomSheetNavigatorDestinationBuilder
 import kotlin.reflect.typeOf
@@ -106,6 +108,24 @@ class NavTypesTest {
             content = {},
             onDismissed = {},
         ).build()
+    }
+
+    /**
+     * 投稿 ID の符号化が置き換え前と変わらないことを確認する。
+     *
+     * 符号化された文字列は既存のリンクに現れる。形が変わると解決できなくなる。
+     */
+    @Test
+    fun postIdNavTypeEncodesTheRawValue() {
+        assertEquals("post-1", PostIdNavType.serializeAsValue(PostId("post-1")))
+        assertEquals(PostId("post-1"), PostIdNavType.parseValue("post-1"))
+    }
+
+    /** クリエイター ID の符号化が置き換え前と変わらないことを確認する。 */
+    @Test
+    fun creatorIdNavTypeEncodesTheRawValue() {
+        assertEquals("creator-1", creatorIdNavType.serializeAsValue(CreatorId("creator-1")))
+        assertEquals(CreatorId("creator-1"), creatorIdNavType.parseValue("creator-1"))
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/download/CreatorPostsDownloadScreen.kt
+++ b/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/download/CreatorPostsDownloadScreen.kt
@@ -42,6 +42,7 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.launch
 import me.matsumo.fanbox.core.model.Destination
+import me.matsumo.fanbox.core.model.fanbox.CreatorDetail
 import me.matsumo.fanbox.core.resources.Res
 import me.matsumo.fanbox.core.resources.creator_posts_download_button
 import me.matsumo.fanbox.core.resources.creator_posts_download_dialog_title
@@ -55,7 +56,6 @@ import me.matsumo.fanbox.core.ui.view.LoadingDialog
 import me.matsumo.fanbox.feature.creator.download.items.CreatorPostsDownloadItem
 import me.matsumo.fanbox.feature.creator.download.items.CreatorPostsDownloadSettingsSection
 import me.matsumo.fanbox.feature.creator.download.items.CreatorPostsDownloadUserSection
-import me.matsumo.fankt.fanbox.domain.model.FanboxCreatorDetail
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
@@ -117,7 +117,7 @@ internal fun CreatorPostsDownloadRoute(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun CreatorPostsDownloadScreen(
-    creatorDetail: FanboxCreatorDetail,
+    creatorDetail: CreatorDetail,
     posts: ImmutableList<CreatorPostsDownloadData>,
     isIgnoreFreePosts: Boolean,
     isIgnoreFiles: Boolean,

--- a/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/download/CreatorPostsDownloadViewModel.kt
+++ b/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/download/CreatorPostsDownloadViewModel.kt
@@ -11,14 +11,14 @@ import kotlinx.coroutines.launch
 import me.matsumo.fanbox.core.common.util.suspendRunCatching
 import me.matsumo.fanbox.core.model.Destination
 import me.matsumo.fanbox.core.model.ScreenState
+import me.matsumo.fanbox.core.model.fanbox.CreatorDetail
+import me.matsumo.fanbox.core.model.fanbox.Cursor
+import me.matsumo.fanbox.core.model.fanbox.Post
 import me.matsumo.fanbox.core.model.toScreenStateError
 import me.matsumo.fanbox.core.model.updateWhenIdle
 import me.matsumo.fanbox.core.repository.DownloadPostsRepository
 import me.matsumo.fanbox.core.repository.FanboxRepository
 import me.matsumo.fanbox.core.ui.customNavTypes
-import me.matsumo.fankt.fanbox.domain.FanboxCursor
-import me.matsumo.fankt.fanbox.domain.model.FanboxCreatorDetail
-import me.matsumo.fankt.fanbox.domain.model.FanboxPost
 
 class CreatorPostsDownloadViewModel(
     savedStateHandle: SavedStateHandle,
@@ -60,11 +60,11 @@ class CreatorPostsDownloadViewModel(
     }
 
     suspend fun fetchPosts(
-        paginate: List<FanboxCursor>,
+        paginate: List<Cursor>,
         updateCallback: (Float) -> Unit,
     ) {
         val max = paginate.sumOf { it.limit ?: 10 }
-        val posts = mutableListOf<FanboxPost>()
+        val posts = mutableListOf<Post>()
 
         for (cursor in paginate) {
             posts.addAll(fanboxRepository.getCreatorPosts(creatorId, cursor, null).contents)
@@ -134,8 +134,8 @@ class CreatorPostsDownloadViewModel(
 
 @Stable
 data class CreatorPostsDownloadUiState(
-    val creatorDetail: FanboxCreatorDetail,
-    val postsPaginate: List<FanboxCursor>,
+    val creatorDetail: CreatorDetail,
+    val postsPaginate: List<Cursor>,
     val posts: List<CreatorPostsDownloadData>,
     val targetPosts: List<CreatorPostsDownloadData>,
     val ignoreKeyword: String,
@@ -146,6 +146,6 @@ data class CreatorPostsDownloadUiState(
 
 @Stable
 data class CreatorPostsDownloadData(
-    val post: FanboxPost,
+    val post: Post,
     var isDownloaded: Boolean,
 )

--- a/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/download/items/CreatorPostsDownloadItem.kt
+++ b/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/download/items/CreatorPostsDownloadItem.kt
@@ -35,13 +35,13 @@ import coil3.compose.LocalPlatformContext
 import coil3.compose.SubcomposeAsyncImage
 import coil3.request.ImageRequest
 import io.github.aakira.napier.Napier
+import me.matsumo.fanbox.core.model.fanbox.Post
 import me.matsumo.fanbox.core.resources.Res
 import me.matsumo.fanbox.core.resources.fanbox_free_fee
 import me.matsumo.fanbox.core.resources.unit_jpy
 import me.matsumo.fanbox.core.ui.extensition.fanboxHeader
 import me.matsumo.fanbox.core.ui.theme.bold
 import me.matsumo.fanbox.feature.creator.download.CreatorPostsDownloadData
-import me.matsumo.fankt.fanbox.domain.model.FanboxPost
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
@@ -119,7 +119,7 @@ internal fun CreatorPostsDownloadItem(
 
 @Composable
 private fun CommentLikeItem(
-    post: FanboxPost,
+    post: Post,
     modifier: Modifier = Modifier,
 ) {
     val likeColor = if (post.isLiked) Color(0xffe0405e) else MaterialTheme.colorScheme.onSurfaceVariant

--- a/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/download/items/CreatorPostsDownloadUserSection.kt
+++ b/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/download/items/CreatorPostsDownloadUserSection.kt
@@ -17,16 +17,16 @@ import androidx.compose.ui.unit.dp
 import coil3.compose.LocalPlatformContext
 import coil3.compose.SubcomposeAsyncImage
 import coil3.request.ImageRequest
+import me.matsumo.fanbox.core.model.fanbox.CreatorDetail
 import me.matsumo.fanbox.core.resources.Res
 import me.matsumo.fanbox.core.resources.im_default_user
 import me.matsumo.fanbox.core.ui.extensition.FadePlaceHolder
 import me.matsumo.fanbox.core.ui.extensition.asCoilImage
 import me.matsumo.fanbox.core.ui.theme.bold
-import me.matsumo.fankt.fanbox.domain.model.FanboxCreatorDetail
 
 @Composable
 internal fun CreatorPostsDownloadUserSection(
-    creatorDetail: FanboxCreatorDetail,
+    creatorDetail: CreatorDetail,
     modifier: Modifier = Modifier,
 ) {
     Row(

--- a/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/fancard/FanCardScreen.kt
+++ b/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/fancard/FanCardScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.flow.collectLatest
+import me.matsumo.fanbox.core.model.fanbox.CreatorPlanDetail
 import me.matsumo.fanbox.core.resources.Res
 import me.matsumo.fanbox.core.resources.common_downloaded
 import me.matsumo.fanbox.core.resources.error_network
@@ -25,7 +26,6 @@ import me.matsumo.fanbox.core.ui.component.PixiViewTopBar
 import me.matsumo.fanbox.core.ui.extensition.LocalSnackbarHostState
 import me.matsumo.fanbox.core.ui.extensition.ToastExtension
 import me.matsumo.fanbox.feature.creator.fancard.items.FanCardItem
-import me.matsumo.fankt.fanbox.domain.model.FanboxCreatorPlanDetail
 import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 
@@ -62,7 +62,7 @@ internal fun FanCardRoute(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun FanCardScreen(
-    planDetail: FanboxCreatorPlanDetail,
+    planDetail: CreatorPlanDetail,
     onTerminate: () -> Unit,
     modifier: Modifier = Modifier,
 ) {

--- a/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/fancard/FanCardViewModel.kt
+++ b/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/fancard/FanCardViewModel.kt
@@ -13,13 +13,13 @@ import kotlinx.coroutines.launch
 import me.matsumo.fanbox.core.common.util.suspendRunCatching
 import me.matsumo.fanbox.core.model.Destination
 import me.matsumo.fanbox.core.model.ScreenState
+import me.matsumo.fanbox.core.model.fanbox.CreatorPlanDetail
 import me.matsumo.fanbox.core.model.toScreenStateError
 import me.matsumo.fanbox.core.repository.FanboxRepository
 import me.matsumo.fanbox.core.resources.Res
 import me.matsumo.fanbox.core.resources.common_back
 import me.matsumo.fanbox.core.resources.creator_fan_card_not_supported
 import me.matsumo.fanbox.core.ui.customNavTypes
-import me.matsumo.fankt.fanbox.domain.model.FanboxCreatorPlanDetail
 
 class FanCardViewModel(
     savedStateHandle: SavedStateHandle,
@@ -60,5 +60,5 @@ class FanCardViewModel(
 
 @Stable
 data class FanCardUiState(
-    val planDetail: FanboxCreatorPlanDetail,
+    val planDetail: CreatorPlanDetail,
 )

--- a/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/fancard/items/FanCardItem.kt
+++ b/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/fancard/items/FanCardItem.kt
@@ -28,18 +28,18 @@ import coil3.compose.LocalPlatformContext
 import coil3.compose.SubcomposeAsyncImage
 import coil3.request.ImageRequest
 import me.matsumo.fanbox.core.common.util.format
+import me.matsumo.fanbox.core.model.fanbox.CreatorPlanDetail
 import me.matsumo.fanbox.core.resources.Res
 import me.matsumo.fanbox.core.resources.im_fanbox_logo_dark
 import me.matsumo.fanbox.core.resources.im_fanbox_logo_light
 import me.matsumo.fanbox.core.ui.extensition.FadePlaceHolder
 import me.matsumo.fanbox.core.ui.extensition.fanboxHeader
-import me.matsumo.fankt.fanbox.domain.model.FanboxCreatorPlanDetail
 import org.jetbrains.compose.resources.painterResource
 import kotlin.time.ExperimentalTime
 
 @Composable
 internal fun FanCardItem(
-    planDetail: FanboxCreatorPlanDetail,
+    planDetail: CreatorPlanDetail,
     isDisplayName: Boolean,
     modifier: Modifier = Modifier,
 ) {
@@ -91,7 +91,7 @@ internal fun FanCardItem(
 @OptIn(ExperimentalTime::class)
 @Composable
 private fun NameItem(
-    planDetail: FanboxCreatorPlanDetail,
+    planDetail: CreatorPlanDetail,
     isDisplayName: Boolean,
     modifier: Modifier = Modifier,
 ) {
@@ -133,7 +133,7 @@ private fun NameItem(
 
 @Composable
 private fun TitleItem(
-    planDetail: FanboxCreatorPlanDetail,
+    planDetail: CreatorPlanDetail,
     modifier: Modifier = Modifier,
 ) {
     Column(

--- a/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/follow/FollowingCreatorsScreen.kt
+++ b/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/follow/FollowingCreatorsScreen.kt
@@ -31,6 +31,9 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.launch
 import me.matsumo.fanbox.core.model.Destination
+import me.matsumo.fanbox.core.model.fanbox.CreatorDetail
+import me.matsumo.fanbox.core.model.fanbox.CreatorId
+import me.matsumo.fanbox.core.model.fanbox.UserId
 import me.matsumo.fanbox.core.resources.Res
 import me.matsumo.fanbox.core.resources.error_no_data
 import me.matsumo.fanbox.core.resources.error_no_data_following
@@ -43,9 +46,6 @@ import me.matsumo.fanbox.core.ui.extensition.NavigatorExtension
 import me.matsumo.fanbox.core.ui.extensition.PixiViewNavigationType
 import me.matsumo.fanbox.core.ui.extensition.drawVerticalScrollbar
 import me.matsumo.fanbox.core.ui.view.EmptyView
-import me.matsumo.fankt.fanbox.domain.model.FanboxCreatorDetail
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxCreatorId
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxUserId
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
@@ -81,10 +81,10 @@ internal fun FollowingCreatorsRoute(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun FollowingCreatorsScreen(
-    followingCreators: ImmutableList<FanboxCreatorDetail>,
-    onClickCreator: (FanboxCreatorId) -> Unit,
-    onClickFollow: suspend (FanboxUserId) -> Result<Unit>,
-    onClickUnfollow: suspend (FanboxUserId) -> Result<Unit>,
+    followingCreators: ImmutableList<CreatorDetail>,
+    onClickCreator: (CreatorId) -> Unit,
+    onClickFollow: suspend (UserId) -> Result<Unit>,
+    onClickUnfollow: suspend (UserId) -> Result<Unit>,
     onClickSupporting: (String) -> Unit,
     terminate: () -> Unit,
     modifier: Modifier = Modifier,

--- a/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/follow/FollowingCreatorsViewModel.kt
+++ b/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/follow/FollowingCreatorsViewModel.kt
@@ -8,10 +8,10 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import me.matsumo.fanbox.core.common.util.suspendRunCatching
 import me.matsumo.fanbox.core.model.ScreenState
+import me.matsumo.fanbox.core.model.fanbox.CreatorDetail
+import me.matsumo.fanbox.core.model.fanbox.UserId
 import me.matsumo.fanbox.core.model.toScreenStateError
 import me.matsumo.fanbox.core.repository.FanboxRepository
-import me.matsumo.fankt.fanbox.domain.model.FanboxCreatorDetail
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxUserId
 
 class FollowingCreatorsViewModel(
     private val fanboxRepository: FanboxRepository,
@@ -39,13 +39,13 @@ class FollowingCreatorsViewModel(
         }
     }
 
-    suspend fun follow(creatorUserId: FanboxUserId): Result<Unit> {
+    suspend fun follow(creatorUserId: UserId): Result<Unit> {
         return suspendRunCatching {
             fanboxRepository.followCreator(creatorUserId)
         }
     }
 
-    suspend fun unfollow(creatorUserId: FanboxUserId): Result<Unit> {
+    suspend fun unfollow(creatorUserId: UserId): Result<Unit> {
         return suspendRunCatching {
             fanboxRepository.unfollowCreator(creatorUserId)
         }
@@ -54,5 +54,5 @@ class FollowingCreatorsViewModel(
 
 @Stable
 data class FollowingCreatorsUiState(
-    val followingCreators: List<FanboxCreatorDetail>,
+    val followingCreators: List<CreatorDetail>,
 )

--- a/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/payment/PaymentsScreen.kt
+++ b/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/payment/PaymentsScreen.kt
@@ -26,6 +26,7 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 import me.matsumo.fanbox.core.common.util.format
 import me.matsumo.fanbox.core.model.Destination
+import me.matsumo.fanbox.core.model.fanbox.CreatorId
 import me.matsumo.fanbox.core.resources.Res
 import me.matsumo.fanbox.core.resources.error_no_data
 import me.matsumo.fanbox.core.resources.error_no_data_payments
@@ -36,7 +37,6 @@ import me.matsumo.fanbox.core.ui.extensition.drawVerticalScrollbar
 import me.matsumo.fanbox.core.ui.view.EmptyView
 import me.matsumo.fanbox.feature.creator.payment.items.MonthItem
 import me.matsumo.fanbox.feature.creator.payment.items.PaymentItem
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxCreatorId
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
 import kotlin.time.ExperimentalTime
@@ -68,7 +68,7 @@ internal fun PaymentsRoute(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun PaymentsScreen(
-    onClickCreatorPosts: (FanboxCreatorId) -> Unit,
+    onClickCreatorPosts: (CreatorId) -> Unit,
     onTerminate: () -> Unit,
     payments: ImmutableList<Payment>,
     modifier: Modifier = Modifier,

--- a/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/payment/PaymentsViewModel.kt
+++ b/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/payment/PaymentsViewModel.kt
@@ -9,9 +9,9 @@ import kotlinx.coroutines.launch
 import me.matsumo.fanbox.core.common.util.format
 import me.matsumo.fanbox.core.common.util.suspendRunCatching
 import me.matsumo.fanbox.core.model.ScreenState
+import me.matsumo.fanbox.core.model.fanbox.PaidRecord
 import me.matsumo.fanbox.core.model.toScreenStateError
 import me.matsumo.fanbox.core.repository.FanboxRepository
-import me.matsumo.fankt.fanbox.domain.model.FanboxPaidRecord
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 
@@ -42,7 +42,7 @@ class PaymentsViewModel(
     }
 
     @OptIn(ExperimentalTime::class)
-    private fun List<FanboxPaidRecord>.translate(): List<Payment> {
+    private fun List<PaidRecord>.translate(): List<Payment> {
         val paymentDates = map { it.paymentDateTime }.distinctBy { it.format("yyyy-MM-dd") }
 
         return paymentDates.map { paymentDate ->
@@ -64,5 +64,5 @@ data class Payment
 @OptIn(ExperimentalTime::class)
 constructor(
     val paymentDateTime: Instant,
-    val paidRecords: List<FanboxPaidRecord>,
+    val paidRecords: List<PaidRecord>,
 )

--- a/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/payment/items/PaymentItem.kt
+++ b/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/payment/items/PaymentItem.kt
@@ -25,6 +25,9 @@ import coil3.compose.AsyncImage
 import coil3.compose.LocalPlatformContext
 import coil3.request.ImageRequest
 import me.matsumo.fanbox.core.common.util.format
+import me.matsumo.fanbox.core.model.fanbox.CreatorId
+import me.matsumo.fanbox.core.model.fanbox.PaidRecord
+import me.matsumo.fanbox.core.model.fanbox.PaymentMethod
 import me.matsumo.fanbox.core.resources.Res
 import me.matsumo.fanbox.core.resources.creator_supporting_payment_method_card
 import me.matsumo.fanbox.core.resources.creator_supporting_payment_method_cvs
@@ -35,9 +38,6 @@ import me.matsumo.fanbox.core.resources.unit_jpy
 import me.matsumo.fanbox.core.ui.extensition.asCoilImage
 import me.matsumo.fanbox.core.ui.theme.bold
 import me.matsumo.fanbox.feature.creator.payment.Payment
-import me.matsumo.fankt.fanbox.domain.model.FanboxPaidRecord
-import me.matsumo.fankt.fanbox.domain.model.FanboxPaymentMethod
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxCreatorId
 import org.jetbrains.compose.resources.stringResource
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
@@ -46,7 +46,7 @@ import kotlin.time.Instant
 @Composable
 internal fun PaymentItem(
     payment: Payment,
-    onClickCreator: (FanboxCreatorId) -> Unit,
+    onClickCreator: (CreatorId) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Card(
@@ -118,8 +118,8 @@ private fun TitleItem(
 
 @Composable
 private fun PaidItem(
-    paidRecord: FanboxPaidRecord,
-    onClickCreator: (FanboxCreatorId) -> Unit,
+    paidRecord: PaidRecord,
+    onClickCreator: (CreatorId) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Row(
@@ -165,10 +165,10 @@ private fun PaidItem(
                 Text(
                     modifier = Modifier.fillMaxWidth(),
                     text = when (paidRecord.paymentMethod) {
-                        FanboxPaymentMethod.CARD -> stringResource(Res.string.creator_supporting_payment_method_card)
-                        FanboxPaymentMethod.PAYPAL -> stringResource(Res.string.creator_supporting_payment_method_paypal)
-                        FanboxPaymentMethod.CVS -> stringResource(Res.string.creator_supporting_payment_method_cvs)
-                        FanboxPaymentMethod.UNKNOWN -> stringResource(Res.string.creator_supporting_payment_method_unknown)
+                        PaymentMethod.CARD -> stringResource(Res.string.creator_supporting_payment_method_card)
+                        PaymentMethod.PAYPAL -> stringResource(Res.string.creator_supporting_payment_method_paypal)
+                        PaymentMethod.CVS -> stringResource(Res.string.creator_supporting_payment_method_cvs)
+                        PaymentMethod.UNKNOWN -> stringResource(Res.string.creator_supporting_payment_method_unknown)
                     },
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,

--- a/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/support/SupportingCreatorsScreen.kt
+++ b/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/support/SupportingCreatorsScreen.kt
@@ -26,6 +26,8 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 import me.matsumo.fanbox.core.model.Destination
+import me.matsumo.fanbox.core.model.fanbox.CreatorId
+import me.matsumo.fanbox.core.model.fanbox.CreatorPlan
 import me.matsumo.fanbox.core.resources.Res
 import me.matsumo.fanbox.core.resources.error_no_data
 import me.matsumo.fanbox.core.resources.error_no_data_supported
@@ -38,8 +40,6 @@ import me.matsumo.fanbox.core.ui.extensition.PixiViewNavigationType
 import me.matsumo.fanbox.core.ui.extensition.drawVerticalScrollbar
 import me.matsumo.fanbox.core.ui.view.EmptyView
 import me.matsumo.fanbox.feature.creator.support.item.SupportingCreatorItem
-import me.matsumo.fankt.fanbox.domain.model.FanboxCreatorPlan
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxCreatorId
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
@@ -74,10 +74,10 @@ internal fun SupportingCreatorsRoute(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun SupportingCreatorsScreen(
-    supportedCreators: ImmutableList<FanboxCreatorPlan>,
+    supportedCreators: ImmutableList<CreatorPlan>,
     onClickPlanDetail: (String) -> Unit,
-    onClickFanCard: (FanboxCreatorId) -> Unit,
-    onClickCreatorPosts: (FanboxCreatorId) -> Unit,
+    onClickFanCard: (CreatorId) -> Unit,
+    onClickCreatorPosts: (CreatorId) -> Unit,
     terminate: () -> Unit,
     modifier: Modifier = Modifier,
 ) {

--- a/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/support/SupportingCreatorsViewModel.kt
+++ b/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/support/SupportingCreatorsViewModel.kt
@@ -8,9 +8,9 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import me.matsumo.fanbox.core.common.util.suspendRunCatching
 import me.matsumo.fanbox.core.model.ScreenState
+import me.matsumo.fanbox.core.model.fanbox.CreatorPlan
 import me.matsumo.fanbox.core.model.toScreenStateError
 import me.matsumo.fanbox.core.repository.FanboxRepository
-import me.matsumo.fankt.fanbox.domain.model.FanboxCreatorPlan
 
 class SupportingCreatorsViewModel(
     private val fanboxRepository: FanboxRepository,
@@ -41,5 +41,5 @@ class SupportingCreatorsViewModel(
 
 @Stable
 data class SupportingCreatorsUiState(
-    val supportedPlans: List<FanboxCreatorPlan>,
+    val supportedPlans: List<CreatorPlan>,
 )

--- a/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/support/item/SupportingCreatorItem.kt
+++ b/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/support/item/SupportingCreatorItem.kt
@@ -27,6 +27,9 @@ import coil3.compose.AsyncImage
 import coil3.compose.LocalPlatformContext
 import coil3.compose.SubcomposeAsyncImage
 import coil3.request.ImageRequest
+import me.matsumo.fanbox.core.model.fanbox.CreatorId
+import me.matsumo.fanbox.core.model.fanbox.CreatorPlan
+import me.matsumo.fanbox.core.model.fanbox.PaymentMethod
 import me.matsumo.fanbox.core.resources.Res
 import me.matsumo.fanbox.core.resources.creator_supporting_fan_card
 import me.matsumo.fanbox.core.resources.creator_supporting_payment_method_card
@@ -40,17 +43,14 @@ import me.matsumo.fanbox.core.ui.extensition.SimmerPlaceHolder
 import me.matsumo.fanbox.core.ui.extensition.asCoilImage
 import me.matsumo.fanbox.core.ui.extensition.fanboxHeader
 import me.matsumo.fanbox.core.ui.theme.bold
-import me.matsumo.fankt.fanbox.domain.model.FanboxCreatorPlan
-import me.matsumo.fankt.fanbox.domain.model.FanboxPaymentMethod
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxCreatorId
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
 internal fun SupportingCreatorItem(
-    supportingPlan: FanboxCreatorPlan,
+    supportingPlan: CreatorPlan,
     onClickPlanDetail: (String) -> Unit,
-    onClickFanCard: (FanboxCreatorId) -> Unit,
-    onClickCreatorPosts: (FanboxCreatorId) -> Unit,
+    onClickFanCard: (CreatorId) -> Unit,
+    onClickCreatorPosts: (CreatorId) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Card(
@@ -129,8 +129,8 @@ internal fun SupportingCreatorItem(
 
 @Composable
 private fun UserSection(
-    plan: FanboxCreatorPlan,
-    onClickCreator: (FanboxCreatorId) -> Unit,
+    plan: CreatorPlan,
+    onClickCreator: (CreatorId) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Row(
@@ -172,10 +172,10 @@ private fun UserSection(
                 Text(
                     modifier = Modifier.fillMaxWidth(),
                     text = when (plan.paymentMethod) {
-                        FanboxPaymentMethod.CARD -> stringResource(Res.string.creator_supporting_payment_method_card)
-                        FanboxPaymentMethod.PAYPAL -> stringResource(Res.string.creator_supporting_payment_method_paypal)
-                        FanboxPaymentMethod.CVS -> stringResource(Res.string.creator_supporting_payment_method_cvs)
-                        FanboxPaymentMethod.UNKNOWN -> stringResource(Res.string.creator_supporting_payment_method_unknown)
+                        PaymentMethod.CARD -> stringResource(Res.string.creator_supporting_payment_method_card)
+                        PaymentMethod.PAYPAL -> stringResource(Res.string.creator_supporting_payment_method_paypal)
+                        PaymentMethod.CVS -> stringResource(Res.string.creator_supporting_payment_method_cvs)
+                        PaymentMethod.UNKNOWN -> stringResource(Res.string.creator_supporting_payment_method_unknown)
                     },
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,

--- a/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/top/CreatorTopScreen.kt
+++ b/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/top/CreatorTopScreen.kt
@@ -71,6 +71,13 @@ import me.matsumo.fanbox.core.model.RewardUsage
 import me.matsumo.fanbox.core.model.Setting
 import me.matsumo.fanbox.core.model.SimpleAlertContents
 import me.matsumo.fanbox.core.model.TranslationState
+import me.matsumo.fanbox.core.model.fanbox.CreatorDetail
+import me.matsumo.fanbox.core.model.fanbox.CreatorId
+import me.matsumo.fanbox.core.model.fanbox.CreatorPlan
+import me.matsumo.fanbox.core.model.fanbox.Post
+import me.matsumo.fanbox.core.model.fanbox.PostId
+import me.matsumo.fanbox.core.model.fanbox.Tag
+import me.matsumo.fanbox.core.model.fanbox.UserId
 import me.matsumo.fanbox.core.resources.Res
 import me.matsumo.fanbox.core.resources.billing_plus_toast_require_plus
 import me.matsumo.fanbox.core.resources.creator_download_require_plus_title
@@ -104,13 +111,6 @@ import me.matsumo.fanbox.feature.creator.top.items.CreatorTopPostsScreen
 import me.matsumo.fanbox.feature.creator.top.items.CreatorTopRewardAdDialog
 import me.matsumo.fanbox.feature.creator.top.items.CreatorTopRewardAdPreloader
 import me.matsumo.fanbox.feature.creator.top.items.CreatorTopTopAppBar
-import me.matsumo.fankt.fanbox.domain.model.FanboxCreatorDetail
-import me.matsumo.fankt.fanbox.domain.model.FanboxCreatorPlan
-import me.matsumo.fankt.fanbox.domain.model.FanboxPost
-import me.matsumo.fankt.fanbox.domain.model.FanboxTag
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxCreatorId
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxPostId
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxUserId
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.koinInject
@@ -228,24 +228,24 @@ private fun CreatorTopScreen(
     isBlocked: Boolean,
     rewardAvailability: CreatorTopRewardAvailability,
     shouldShowReveal: Boolean,
-    creatorDetail: FanboxCreatorDetail,
+    creatorDetail: CreatorDetail,
     setting: Setting,
-    bookmarkedPostsIds: ImmutableList<FanboxPostId>,
-    creatorPlans: ImmutableList<FanboxCreatorPlan>,
-    creatorTags: ImmutableList<FanboxTag>,
-    creatorPostsPaging: LazyPagingItems<FanboxPost>,
+    bookmarkedPostsIds: ImmutableList<PostId>,
+    creatorPlans: ImmutableList<CreatorPlan>,
+    creatorTags: ImmutableList<Tag>,
+    creatorPostsPaging: LazyPagingItems<Post>,
     descriptionTransState: TranslationState<String>,
-    onClickSearch: (FanboxCreatorId) -> Unit,
-    onClickAllDownload: (FanboxCreatorId) -> Unit,
+    onClickSearch: (CreatorId) -> Unit,
+    onClickAllDownload: (CreatorId) -> Unit,
     onClickBillingPlus: (String?) -> Unit,
-    onClickPost: (FanboxPostId) -> Unit,
-    onClickPostLike: (FanboxPostId) -> Unit,
-    onClickPostBookmark: (FanboxPost, Boolean) -> Unit,
-    onClickPlan: (FanboxCreatorPlan) -> Unit,
-    onClickTag: (FanboxTag) -> Unit,
+    onClickPost: (PostId) -> Unit,
+    onClickPostLike: (PostId) -> Unit,
+    onClickPostBookmark: (Post, Boolean) -> Unit,
+    onClickPlan: (CreatorPlan) -> Unit,
+    onClickTag: (Tag) -> Unit,
     onClickLink: (String) -> Unit,
-    onClickFollow: suspend (FanboxUserId) -> Result<Unit>,
-    onClickUnfollow: suspend (FanboxUserId) -> Result<Unit>,
+    onClickFollow: suspend (UserId) -> Result<Unit>,
+    onClickUnfollow: suspend (UserId) -> Result<Unit>,
     onShowBlockDialog: (SimpleAlertContents) -> Unit,
     onShowUnblockDialog: (SimpleAlertContents) -> Unit,
     onClickTranslateDescription: (String) -> Unit,

--- a/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/top/CreatorTopViewModel.kt
+++ b/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/top/CreatorTopViewModel.kt
@@ -21,6 +21,12 @@ import me.matsumo.fanbox.core.model.RewardUsage
 import me.matsumo.fanbox.core.model.ScreenState
 import me.matsumo.fanbox.core.model.Setting
 import me.matsumo.fanbox.core.model.TranslationState
+import me.matsumo.fanbox.core.model.fanbox.CreatorDetail
+import me.matsumo.fanbox.core.model.fanbox.CreatorPlan
+import me.matsumo.fanbox.core.model.fanbox.Post
+import me.matsumo.fanbox.core.model.fanbox.PostId
+import me.matsumo.fanbox.core.model.fanbox.Tag
+import me.matsumo.fanbox.core.model.fanbox.UserId
 import me.matsumo.fanbox.core.model.toScreenStateError
 import me.matsumo.fanbox.core.model.updateWhenIdle
 import me.matsumo.fanbox.core.repository.FanboxRepository
@@ -31,12 +37,6 @@ import me.matsumo.fanbox.core.repository.TranslationRepository
 import me.matsumo.fanbox.core.resources.Res
 import me.matsumo.fanbox.core.resources.error_network
 import me.matsumo.fanbox.core.ui.customNavTypes
-import me.matsumo.fankt.fanbox.domain.model.FanboxCreatorDetail
-import me.matsumo.fankt.fanbox.domain.model.FanboxCreatorPlan
-import me.matsumo.fankt.fanbox.domain.model.FanboxPost
-import me.matsumo.fankt.fanbox.domain.model.FanboxTag
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxPostId
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxUserId
 import org.jetbrains.compose.resources.getString
 
 class CreatorTopViewModel(
@@ -49,7 +49,7 @@ class CreatorTopViewModel(
 ) : ViewModel() {
 
     private val creatorId = savedStateHandle.toRoute<Destination.CreatorTop>(customNavTypes).creatorId
-    private var postsPagingCache: Flow<PagingData<FanboxPost>>? = null
+    private var postsPagingCache: Flow<PagingData<Post>>? = null
 
     private val _screenState = MutableStateFlow<ScreenState<CreatorTopUiState>>(ScreenState.Loading)
     val screenState = _screenState.asStateFlow()
@@ -113,19 +113,19 @@ class CreatorTopViewModel(
         }
     }
 
-    suspend fun follow(creatorUserId: FanboxUserId): Result<Unit> {
+    suspend fun follow(creatorUserId: UserId): Result<Unit> {
         return suspendRunCatching {
             fanboxRepository.followCreator(creatorUserId)
         }
     }
 
-    suspend fun unfollow(creatorUserId: FanboxUserId): Result<Unit> {
+    suspend fun unfollow(creatorUserId: UserId): Result<Unit> {
         return suspendRunCatching {
             fanboxRepository.unfollowCreator(creatorUserId)
         }
     }
 
-    fun postLike(postId: FanboxPostId) {
+    fun postLike(postId: PostId) {
         viewModelScope.launch {
             suspendRunCatching {
                 fanboxRepository.likePost(postId)
@@ -133,7 +133,7 @@ class CreatorTopViewModel(
         }
     }
 
-    fun postBookmark(post: FanboxPost, isBookmarked: Boolean) {
+    fun postBookmark(post: Post, isBookmarked: Boolean) {
         viewModelScope.launch {
             (screenState.value as? ScreenState.Idle)?.also {
                 suspendRunCatching {
@@ -226,11 +226,11 @@ data class CreatorTopRewardAvailability(
 @Stable
 data class CreatorTopUiState(
     val setting: Setting,
-    val bookmarkedPostsIds: List<FanboxPostId>,
-    val creatorDetail: FanboxCreatorDetail,
-    val creatorPlans: List<FanboxCreatorPlan>,
-    val creatorTags: List<FanboxTag>,
-    val creatorPostsPaging: Flow<PagingData<FanboxPost>>,
+    val bookmarkedPostsIds: List<PostId>,
+    val creatorDetail: CreatorDetail,
+    val creatorPlans: List<CreatorPlan>,
+    val creatorTags: List<Tag>,
+    val creatorPostsPaging: Flow<PagingData<Post>>,
     val isBlocked: Boolean,
     val rewardAvailability: CreatorTopRewardAvailability,
     val shouldShowReveal: Boolean,

--- a/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/top/items/CreatorTopHeader.kt
+++ b/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/top/items/CreatorTopHeader.kt
@@ -43,6 +43,8 @@ import coil3.request.ImageRequest
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.launch
+import me.matsumo.fanbox.core.model.fanbox.CreatorDetail
+import me.matsumo.fanbox.core.model.fanbox.UserId
 import me.matsumo.fanbox.core.resources.Res
 import me.matsumo.fanbox.core.resources.common_follow
 import me.matsumo.fanbox.core.resources.common_supporting
@@ -67,18 +69,16 @@ import me.matsumo.fanbox.core.ui.extensition.FadePlaceHolder
 import me.matsumo.fanbox.core.ui.extensition.asCoilImage
 import me.matsumo.fanbox.core.ui.extensition.fanboxHeader
 import me.matsumo.fanbox.core.ui.theme.bold
-import me.matsumo.fankt.fanbox.domain.model.FanboxCreatorDetail
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxUserId
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
 internal fun CreatorTopHeader(
-    creatorDetail: FanboxCreatorDetail,
+    creatorDetail: CreatorDetail,
     onClickLink: (String) -> Unit,
     onClickDescription: (String) -> Unit,
-    onClickFollow: suspend (FanboxUserId) -> Result<Unit>,
-    onClickUnfollow: suspend (FanboxUserId) -> Result<Unit>,
+    onClickFollow: suspend (UserId) -> Result<Unit>,
+    onClickUnfollow: suspend (UserId) -> Result<Unit>,
     onClickSupporting: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -202,7 +202,7 @@ private fun FollowStateButton(
 
 @Composable
 private fun ProfileLinkItem(
-    profileLinks: ImmutableList<FanboxCreatorDetail.ProfileLink>,
+    profileLinks: ImmutableList<CreatorDetail.ProfileLink>,
     onClickLink: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -225,16 +225,16 @@ private fun ProfileLinkItem(
                         .padding(4.dp),
                     painter = painterResource(
                         when (profileLink.link) {
-                            FanboxCreatorDetail.Platform.BOOTH -> Res.drawable.vec_booth
-                            FanboxCreatorDetail.Platform.FACEBOOK -> Res.drawable.vec_facebook
-                            FanboxCreatorDetail.Platform.FANZA -> Res.drawable.vec_fanza
-                            FanboxCreatorDetail.Platform.INSTAGRAM -> Res.drawable.vec_instagram
-                            FanboxCreatorDetail.Platform.LINE -> Res.drawable.vec_line
-                            FanboxCreatorDetail.Platform.PIXIV -> Res.drawable.vec_pixiv
-                            FanboxCreatorDetail.Platform.TUMBLR -> Res.drawable.vec_tumblr
-                            FanboxCreatorDetail.Platform.TWITTER -> Res.drawable.vec_twitter
-                            FanboxCreatorDetail.Platform.YOUTUBE -> Res.drawable.vec_youtube
-                            FanboxCreatorDetail.Platform.UNKNOWN -> Res.drawable.vec_unknown_link
+                            CreatorDetail.Platform.BOOTH -> Res.drawable.vec_booth
+                            CreatorDetail.Platform.FACEBOOK -> Res.drawable.vec_facebook
+                            CreatorDetail.Platform.FANZA -> Res.drawable.vec_fanza
+                            CreatorDetail.Platform.INSTAGRAM -> Res.drawable.vec_instagram
+                            CreatorDetail.Platform.LINE -> Res.drawable.vec_line
+                            CreatorDetail.Platform.PIXIV -> Res.drawable.vec_pixiv
+                            CreatorDetail.Platform.TUMBLR -> Res.drawable.vec_tumblr
+                            CreatorDetail.Platform.TWITTER -> Res.drawable.vec_twitter
+                            CreatorDetail.Platform.YOUTUBE -> Res.drawable.vec_youtube
+                            CreatorDetail.Platform.UNKNOWN -> Res.drawable.vec_unknown_link
                         },
                     ),
                     tint = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -247,7 +247,7 @@ private fun ProfileLinkItem(
 
 @Composable
 private fun HeaderTop(
-    creatorDetail: FanboxCreatorDetail,
+    creatorDetail: CreatorDetail,
     isSupported: Boolean,
     isFollowed: Boolean,
     onClickSupport: () -> Unit,
@@ -386,7 +386,7 @@ private fun DescriptionItem(
 }
 
 @Composable
-private fun createTags(creatorDetail: FanboxCreatorDetail): List<String> {
+private fun createTags(creatorDetail: CreatorDetail): List<String> {
     return mutableListOf<String>().apply {
         if (creatorDetail.isSupported) {
             add(stringResource(Res.string.creator_tag_is_supported))

--- a/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/top/items/CreatorTopPlansScreen.kt
+++ b/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/top/items/CreatorTopPlansScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.ImmutableList
+import me.matsumo.fanbox.core.model.fanbox.CreatorPlan
 import me.matsumo.fanbox.core.resources.Res
 import me.matsumo.fanbox.core.resources.creator_plans_for_ios_error
 import me.matsumo.fanbox.core.resources.creator_plans_for_ios_error_button
@@ -19,13 +20,12 @@ import me.matsumo.fanbox.core.resources.creator_plans_for_ios_error_description
 import me.matsumo.fanbox.core.ui.extensition.Platform
 import me.matsumo.fanbox.core.ui.extensition.currentPlatform
 import me.matsumo.fanbox.core.ui.view.ErrorView
-import me.matsumo.fankt.fanbox.domain.model.FanboxCreatorPlan
 
 @Composable
 internal fun CreatorTopPlansScreen(
     state: LazyListState,
-    creatorPlans: ImmutableList<FanboxCreatorPlan>,
-    onClickPlan: (FanboxCreatorPlan) -> Unit,
+    creatorPlans: ImmutableList<CreatorPlan>,
+    onClickPlan: (CreatorPlan) -> Unit,
     onClickFanbox: () -> Unit,
     modifier: Modifier = Modifier,
 ) {

--- a/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/top/items/CreatorTopPlansSection.kt
+++ b/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/top/items/CreatorTopPlansSection.kt
@@ -24,18 +24,18 @@ import coil3.compose.LocalPlatformContext
 import coil3.compose.SubcomposeAsyncImage
 import coil3.request.ImageRequest
 import kotlinx.collections.immutable.ImmutableList
+import me.matsumo.fanbox.core.model.fanbox.CreatorPlan
 import me.matsumo.fanbox.core.resources.Res
 import me.matsumo.fanbox.core.resources.unit_jpy
 import me.matsumo.fanbox.core.ui.extensition.SimmerPlaceHolder
 import me.matsumo.fanbox.core.ui.extensition.fanboxHeader
 import me.matsumo.fanbox.core.ui.theme.bold
-import me.matsumo.fankt.fanbox.domain.model.FanboxCreatorPlan
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
 internal fun CreatorTopPlansSection(
-    creatorPlans: ImmutableList<FanboxCreatorPlan>,
-    onClickPlan: (FanboxCreatorPlan) -> Unit,
+    creatorPlans: ImmutableList<CreatorPlan>,
+    onClickPlan: (CreatorPlan) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(

--- a/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/top/items/CreatorTopPostsScreen.kt
+++ b/feature/creator/src/commonMain/kotlin/me/matsumo/fanbox/feature/creator/top/items/CreatorTopPostsScreen.kt
@@ -43,6 +43,10 @@ import coil3.compose.SubcomposeAsyncImage
 import coil3.request.ImageRequest
 import kotlinx.collections.immutable.ImmutableList
 import me.matsumo.fanbox.core.model.Setting
+import me.matsumo.fanbox.core.model.fanbox.CreatorId
+import me.matsumo.fanbox.core.model.fanbox.Post
+import me.matsumo.fanbox.core.model.fanbox.PostId
+import me.matsumo.fanbox.core.model.fanbox.Tag
 import me.matsumo.fanbox.core.ui.ads.NativeAdView
 import me.matsumo.fanbox.core.ui.component.PostGridItem
 import me.matsumo.fanbox.core.ui.component.PostItem
@@ -55,24 +59,20 @@ import me.matsumo.fanbox.core.ui.extensition.drawVerticalScrollbar
 import me.matsumo.fanbox.core.ui.extensition.fanboxHeader
 import me.matsumo.fanbox.core.ui.theme.bold
 import me.matsumo.fanbox.core.ui.view.PagingErrorSection
-import me.matsumo.fankt.fanbox.domain.model.FanboxPost
-import me.matsumo.fankt.fanbox.domain.model.FanboxTag
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxCreatorId
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxPostId
 
 @Composable
 internal fun CreatorTopPostsScreen(
     state: LazyGridState,
     setting: Setting,
-    bookmarkedPostsIds: ImmutableList<FanboxPostId>,
-    pagingAdapter: LazyPagingItems<FanboxPost>,
-    creatorTags: ImmutableList<FanboxTag>,
-    onClickPost: (FanboxPostId) -> Unit,
-    onClickPostBookmark: (FanboxPost, Boolean) -> Unit,
-    onClickCreator: (FanboxCreatorId) -> Unit,
-    onClickTag: (FanboxTag) -> Unit,
-    onClickPostLike: (FanboxPostId) -> Unit,
-    onClickPlanList: (FanboxCreatorId) -> Unit,
+    bookmarkedPostsIds: ImmutableList<PostId>,
+    pagingAdapter: LazyPagingItems<Post>,
+    creatorTags: ImmutableList<Tag>,
+    onClickPost: (PostId) -> Unit,
+    onClickPostBookmark: (Post, Boolean) -> Unit,
+    onClickCreator: (CreatorId) -> Unit,
+    onClickTag: (Tag) -> Unit,
+    onClickPostLike: (PostId) -> Unit,
+    onClickPlanList: (CreatorId) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val adOffset: Int
@@ -129,16 +129,16 @@ private fun PagingItems(
     adOffset: Int,
     adInterval: Int,
     setting: Setting,
-    bookmarkedPostIds: ImmutableList<FanboxPostId>,
-    pagingAdapter: LazyPagingItems<FanboxPost>,
-    creatorTags: ImmutableList<FanboxTag>,
+    bookmarkedPostIds: ImmutableList<PostId>,
+    pagingAdapter: LazyPagingItems<Post>,
+    creatorTags: ImmutableList<Tag>,
     isGridMode: Boolean,
-    onClickPost: (FanboxPostId) -> Unit,
-    onClickPostBookmark: (FanboxPost, Boolean) -> Unit,
-    onClickCreator: (FanboxCreatorId) -> Unit,
-    onClickTag: (FanboxTag) -> Unit,
-    onClickPostLike: (FanboxPostId) -> Unit,
-    onClickPlanList: (FanboxCreatorId) -> Unit,
+    onClickPost: (PostId) -> Unit,
+    onClickPostBookmark: (Post, Boolean) -> Unit,
+    onClickCreator: (CreatorId) -> Unit,
+    onClickTag: (Tag) -> Unit,
+    onClickPostLike: (PostId) -> Unit,
+    onClickPlanList: (CreatorId) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     LazyVerticalGrid(
@@ -233,8 +233,8 @@ private fun PagingItems(
 
 @Composable
 private fun TagItem(
-    tag: FanboxTag,
-    onClickTag: (FanboxTag) -> Unit,
+    tag: Tag,
+    onClickTag: (Tag) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Box(

--- a/feature/library/src/commonMain/kotlin/me/matsumo/fanbox/feature/library/discovery/LibraryDiscoveryScreen.kt
+++ b/feature/library/src/commonMain/kotlin/me/matsumo/fanbox/feature/library/discovery/LibraryDiscoveryScreen.kt
@@ -40,6 +40,9 @@ import kotlinx.coroutines.launch
 import me.matsumo.fanbox.core.model.Destination
 import me.matsumo.fanbox.core.model.ScreenState
 import me.matsumo.fanbox.core.model.Setting
+import me.matsumo.fanbox.core.model.fanbox.CreatorDetail
+import me.matsumo.fanbox.core.model.fanbox.CreatorId
+import me.matsumo.fanbox.core.model.fanbox.UserId
 import me.matsumo.fanbox.core.resources.Res
 import me.matsumo.fanbox.core.resources.billing_plus_toast_require_plus
 import me.matsumo.fanbox.core.resources.creator_following_pixiv
@@ -58,9 +61,6 @@ import me.matsumo.fanbox.core.ui.extensition.ToastExtension
 import me.matsumo.fanbox.core.ui.extensition.drawVerticalScrollbar
 import me.matsumo.fanbox.core.ui.theme.bold
 import me.matsumo.fanbox.feature.library.discovery.components.LibraryDiscoverySearchPostCreatorItem
-import me.matsumo.fankt.fanbox.domain.model.FanboxCreatorDetail
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxCreatorId
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxUserId
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
@@ -99,7 +99,7 @@ internal fun LibraryDiscoveryRoute(
             followingPixivCreators = uiState.followingPixivCreators.toImmutableList(),
             openDrawer = openDrawer,
             fetch = viewModel::fetch,
-            onClickSearch = { navigateTo(Destination.PostSearch(FanboxCreatorId(""), null, null)) },
+            onClickSearch = { navigateTo(Destination.PostSearch(CreatorId(""), null, null)) },
             onClickPostByCreatorSearch = { navigateTo(Destination.PostByCreatorSearch(it)) },
             onClickCreator = { navigateTo(Destination.CreatorTop(it, true)) },
             onClickFollow = viewModel::follow,
@@ -117,16 +117,16 @@ internal fun LibraryDiscoveryRoute(
 @Composable
 private fun LibraryDiscoveryScreen(
     setting: Setting,
-    followingCreators: ImmutableList<FanboxCreatorDetail>,
-    recommendedCreators: ImmutableList<FanboxCreatorDetail>,
-    followingPixivCreators: ImmutableList<FanboxCreatorDetail>,
+    followingCreators: ImmutableList<CreatorDetail>,
+    recommendedCreators: ImmutableList<CreatorDetail>,
+    followingPixivCreators: ImmutableList<CreatorDetail>,
     openDrawer: () -> Unit,
     fetch: () -> Unit,
     onClickSearch: () -> Unit,
-    onClickPostByCreatorSearch: (FanboxCreatorId) -> Unit,
-    onClickCreator: (FanboxCreatorId) -> Unit,
-    onClickFollow: suspend (FanboxUserId) -> Result<Unit>,
-    onClickUnfollow: suspend (FanboxUserId) -> Result<Unit>,
+    onClickPostByCreatorSearch: (CreatorId) -> Unit,
+    onClickCreator: (CreatorId) -> Unit,
+    onClickFollow: suspend (UserId) -> Result<Unit>,
+    onClickUnfollow: suspend (UserId) -> Result<Unit>,
     onClickSupporting: (String) -> Unit,
     onClickBillingPlus: (String?) -> Unit,
     modifier: Modifier = Modifier,

--- a/feature/library/src/commonMain/kotlin/me/matsumo/fanbox/feature/library/discovery/LibraryDiscoveryViewModel.kt
+++ b/feature/library/src/commonMain/kotlin/me/matsumo/fanbox/feature/library/discovery/LibraryDiscoveryViewModel.kt
@@ -11,14 +11,14 @@ import kotlinx.coroutines.launch
 import me.matsumo.fanbox.core.common.util.suspendRunCatching
 import me.matsumo.fanbox.core.model.ScreenState
 import me.matsumo.fanbox.core.model.Setting
+import me.matsumo.fanbox.core.model.fanbox.CreatorDetail
+import me.matsumo.fanbox.core.model.fanbox.UserId
 import me.matsumo.fanbox.core.model.toScreenStateError
 import me.matsumo.fanbox.core.model.updateWhenIdle
 import me.matsumo.fanbox.core.repository.FanboxRepository
 import me.matsumo.fanbox.core.repository.SettingRepository
 import me.matsumo.fanbox.core.resources.Res
 import me.matsumo.fanbox.core.resources.error_no_data_discovery
-import me.matsumo.fankt.fanbox.domain.model.FanboxCreatorDetail
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxUserId
 
 class LibraryDiscoveryViewModel(
     private val settingRepository: SettingRepository,
@@ -63,13 +63,13 @@ class LibraryDiscoveryViewModel(
         }
     }
 
-    suspend fun follow(creatorUserId: FanboxUserId): Result<Unit> {
+    suspend fun follow(creatorUserId: UserId): Result<Unit> {
         return suspendRunCatching {
             fanboxRepository.followCreator(creatorUserId)
         }
     }
 
-    suspend fun unfollow(creatorUserId: FanboxUserId): Result<Unit> {
+    suspend fun unfollow(creatorUserId: UserId): Result<Unit> {
         return suspendRunCatching {
             fanboxRepository.unfollowCreator(creatorUserId)
         }
@@ -79,7 +79,7 @@ class LibraryDiscoveryViewModel(
 @Stable
 data class LibraryDiscoveryUiState(
     val setting: Setting,
-    val followingCreators: List<FanboxCreatorDetail>,
-    val recommendedCreators: List<FanboxCreatorDetail>,
-    val followingPixivCreators: List<FanboxCreatorDetail>,
+    val followingCreators: List<CreatorDetail>,
+    val recommendedCreators: List<CreatorDetail>,
+    val followingPixivCreators: List<CreatorDetail>,
 )

--- a/feature/library/src/commonMain/kotlin/me/matsumo/fanbox/feature/library/discovery/components/LibraryDiscoverySearchPostCreatorItem.kt
+++ b/feature/library/src/commonMain/kotlin/me/matsumo/fanbox/feature/library/discovery/components/LibraryDiscoverySearchPostCreatorItem.kt
@@ -27,17 +27,17 @@ import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import coil3.compose.LocalPlatformContext
 import coil3.request.ImageRequest
+import me.matsumo.fanbox.core.model.fanbox.CreatorDetail
+import me.matsumo.fanbox.core.model.fanbox.CreatorId
 import me.matsumo.fanbox.core.resources.Res
 import me.matsumo.fanbox.core.resources.im_default_user
 import me.matsumo.fanbox.core.ui.extensition.asCoilImage
 import me.matsumo.fanbox.core.ui.theme.bold
-import me.matsumo.fankt.fanbox.domain.model.FanboxCreatorDetail
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxCreatorId
 
 @Composable
 internal fun LibraryDiscoverySearchPostCreatorItem(
-    creatorDetail: FanboxCreatorDetail,
-    onSearchPostClicked: (FanboxCreatorId) -> Unit,
+    creatorDetail: CreatorDetail,
+    onSearchPostClicked: (CreatorId) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Card(

--- a/feature/library/src/commonMain/kotlin/me/matsumo/fanbox/feature/library/home/LibraryHomeViewModel.kt
+++ b/feature/library/src/commonMain/kotlin/me/matsumo/fanbox/feature/library/home/LibraryHomeViewModel.kt
@@ -11,11 +11,11 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import me.matsumo.fanbox.core.common.util.suspendRunCatching
 import me.matsumo.fanbox.core.model.Setting
+import me.matsumo.fanbox.core.model.fanbox.Post
+import me.matsumo.fanbox.core.model.fanbox.PostId
 import me.matsumo.fanbox.core.repository.FanboxRepository
 import me.matsumo.fanbox.core.repository.SettingRepository
 import me.matsumo.fanbox.core.ui.extensition.emptyPaging
-import me.matsumo.fankt.fanbox.domain.model.FanboxPost
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxPostId
 
 class LibraryHomeViewModel(
     private val settingRepository: SettingRepository,
@@ -55,7 +55,7 @@ class LibraryHomeViewModel(
         }
     }
 
-    fun postLike(postId: FanboxPostId) {
+    fun postLike(postId: PostId) {
         viewModelScope.launch {
             suspendRunCatching {
                 fanboxRepository.likePost(postId)
@@ -63,7 +63,7 @@ class LibraryHomeViewModel(
         }
     }
 
-    fun postBookmark(post: FanboxPost, isBookmarked: Boolean) {
+    fun postBookmark(post: Post, isBookmarked: Boolean) {
         viewModelScope.launch {
             suspendRunCatching {
                 if (isBookmarked) {
@@ -79,7 +79,7 @@ class LibraryHomeViewModel(
 @Stable
 data class LibraryUiState(
     val setting: Setting,
-    val bookmarkedPostsIds: List<FanboxPostId>,
-    val homePaging: Flow<PagingData<FanboxPost>>,
-    val supportedPaging: Flow<PagingData<FanboxPost>>,
+    val bookmarkedPostsIds: List<PostId>,
+    val homePaging: Flow<PagingData<Post>>,
+    val supportedPaging: Flow<PagingData<Post>>,
 )

--- a/feature/library/src/commonMain/kotlin/me/matsumo/fanbox/feature/library/home/items/LibraryHomeIdleSection.kt
+++ b/feature/library/src/commonMain/kotlin/me/matsumo/fanbox/feature/library/home/items/LibraryHomeIdleSection.kt
@@ -6,24 +6,24 @@ import androidx.compose.ui.Modifier
 import app.cash.paging.compose.LazyPagingItems
 import kotlinx.collections.immutable.ImmutableList
 import me.matsumo.fanbox.core.model.Setting
+import me.matsumo.fanbox.core.model.fanbox.CreatorId
+import me.matsumo.fanbox.core.model.fanbox.Post
+import me.matsumo.fanbox.core.model.fanbox.PostId
 import me.matsumo.fanbox.core.ui.extensition.LocalNavigationType
 import me.matsumo.fanbox.core.ui.extensition.PixiViewNavigationType
 import me.matsumo.fanbox.core.ui.extensition.Platform
 import me.matsumo.fanbox.core.ui.extensition.currentPlatform
-import me.matsumo.fankt.fanbox.domain.model.FanboxPost
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxCreatorId
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxPostId
 
 @Composable
 internal fun LibraryHomeIdleSection(
-    pagingAdapter: LazyPagingItems<FanboxPost>,
+    pagingAdapter: LazyPagingItems<Post>,
     setting: Setting,
-    bookmarkedPostsIds: ImmutableList<FanboxPostId>,
-    onClickPost: (FanboxPostId) -> Unit,
-    onClickPostLike: (FanboxPostId) -> Unit,
-    onClickPostBookmark: (FanboxPost, Boolean) -> Unit,
-    onClickCreator: (FanboxCreatorId) -> Unit,
-    onClickPlanList: (FanboxCreatorId) -> Unit,
+    bookmarkedPostsIds: ImmutableList<PostId>,
+    onClickPost: (PostId) -> Unit,
+    onClickPostLike: (PostId) -> Unit,
+    onClickPostBookmark: (Post, Boolean) -> Unit,
+    onClickCreator: (CreatorId) -> Unit,
+    onClickPlanList: (CreatorId) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val state = rememberLazyGridState()

--- a/feature/library/src/commonMain/kotlin/me/matsumo/fanbox/feature/library/home/items/LibraryHomePagingItems.kt
+++ b/feature/library/src/commonMain/kotlin/me/matsumo/fanbox/feature/library/home/items/LibraryHomePagingItems.kt
@@ -18,14 +18,14 @@ import app.cash.paging.compose.LazyPagingItems
 import app.cash.paging.compose.itemKey
 import kotlinx.collections.immutable.ImmutableList
 import me.matsumo.fanbox.core.model.Setting
+import me.matsumo.fanbox.core.model.fanbox.CreatorId
+import me.matsumo.fanbox.core.model.fanbox.Post
+import me.matsumo.fanbox.core.model.fanbox.PostId
 import me.matsumo.fanbox.core.ui.ads.NativeAdView
 import me.matsumo.fanbox.core.ui.component.PostGridItem
 import me.matsumo.fanbox.core.ui.component.PostItem
 import me.matsumo.fanbox.core.ui.extensition.drawVerticalScrollbar
 import me.matsumo.fanbox.core.ui.view.PagingErrorSection
-import me.matsumo.fankt.fanbox.domain.model.FanboxPost
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxCreatorId
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxPostId
 
 @Composable
 internal fun LibraryHomePagingItems(
@@ -33,15 +33,15 @@ internal fun LibraryHomePagingItems(
     columns: Int,
     adOffset: Int,
     adInterval: Int,
-    pagingAdapter: LazyPagingItems<FanboxPost>,
+    pagingAdapter: LazyPagingItems<Post>,
     setting: Setting,
-    bookmarkedPostsIds: ImmutableList<FanboxPostId>,
+    bookmarkedPostsIds: ImmutableList<PostId>,
     isGridMode: Boolean,
-    onClickPost: (FanboxPostId) -> Unit,
-    onClickPostLike: (FanboxPostId) -> Unit,
-    onClickPostBookmark: (FanboxPost, Boolean) -> Unit,
-    onClickCreator: (FanboxCreatorId) -> Unit,
-    onClickPlanList: (FanboxCreatorId) -> Unit,
+    onClickPost: (PostId) -> Unit,
+    onClickPostLike: (PostId) -> Unit,
+    onClickPostBookmark: (Post, Boolean) -> Unit,
+    onClickCreator: (CreatorId) -> Unit,
+    onClickPlanList: (CreatorId) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     LazyVerticalGrid(

--- a/feature/library/src/commonMain/kotlin/me/matsumo/fanbox/feature/library/home/items/LibrarySupportedIdleSection.kt
+++ b/feature/library/src/commonMain/kotlin/me/matsumo/fanbox/feature/library/home/items/LibrarySupportedIdleSection.kt
@@ -6,24 +6,24 @@ import androidx.compose.ui.Modifier
 import app.cash.paging.compose.LazyPagingItems
 import kotlinx.collections.immutable.ImmutableList
 import me.matsumo.fanbox.core.model.Setting
+import me.matsumo.fanbox.core.model.fanbox.CreatorId
+import me.matsumo.fanbox.core.model.fanbox.Post
+import me.matsumo.fanbox.core.model.fanbox.PostId
 import me.matsumo.fanbox.core.ui.extensition.LocalNavigationType
 import me.matsumo.fanbox.core.ui.extensition.PixiViewNavigationType
 import me.matsumo.fanbox.core.ui.extensition.Platform
 import me.matsumo.fanbox.core.ui.extensition.currentPlatform
-import me.matsumo.fankt.fanbox.domain.model.FanboxPost
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxCreatorId
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxPostId
 
 @Composable
 internal fun LibrarySupportedIdleSection(
-    pagingAdapter: LazyPagingItems<FanboxPost>,
+    pagingAdapter: LazyPagingItems<Post>,
     setting: Setting,
-    bookmarkedPostsIds: ImmutableList<FanboxPostId>,
-    onClickPost: (FanboxPostId) -> Unit,
-    onClickPostLike: (FanboxPostId) -> Unit,
-    onClickPostBookmark: (FanboxPost, Boolean) -> Unit,
-    onClickCreator: (FanboxCreatorId) -> Unit,
-    onClickPlanList: (FanboxCreatorId) -> Unit,
+    bookmarkedPostsIds: ImmutableList<PostId>,
+    onClickPost: (PostId) -> Unit,
+    onClickPostLike: (PostId) -> Unit,
+    onClickPostBookmark: (Post, Boolean) -> Unit,
+    onClickCreator: (CreatorId) -> Unit,
+    onClickPlanList: (CreatorId) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val state = rememberLazyGridState()

--- a/feature/library/src/commonMain/kotlin/me/matsumo/fanbox/feature/library/message/LibraryMessageScreen.kt
+++ b/feature/library/src/commonMain/kotlin/me/matsumo/fanbox/feature/library/message/LibraryMessageScreen.kt
@@ -21,6 +21,8 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 import me.matsumo.fanbox.core.model.Destination
+import me.matsumo.fanbox.core.model.fanbox.CreatorId
+import me.matsumo.fanbox.core.model.fanbox.NewsLetter
 import me.matsumo.fanbox.core.resources.Res
 import me.matsumo.fanbox.core.resources.error_no_data
 import me.matsumo.fanbox.core.resources.error_no_data_message
@@ -32,8 +34,6 @@ import me.matsumo.fanbox.core.ui.extensition.PixiViewNavigationType
 import me.matsumo.fanbox.core.ui.extensition.drawVerticalScrollbar
 import me.matsumo.fanbox.core.ui.view.EmptyView
 import me.matsumo.fanbox.feature.library.message.items.LibraryMessageItem
-import me.matsumo.fankt.fanbox.domain.model.FanboxNewsLetter
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxCreatorId
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
 
@@ -63,9 +63,9 @@ internal fun LibraryMessageRoute(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun LibraryMessageScreen(
-    messages: ImmutableList<FanboxNewsLetter>,
+    messages: ImmutableList<NewsLetter>,
     openDrawer: () -> Unit,
-    onClickCreator: (FanboxCreatorId) -> Unit,
+    onClickCreator: (CreatorId) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val navigationType = LocalNavigationType.current.type

--- a/feature/library/src/commonMain/kotlin/me/matsumo/fanbox/feature/library/message/LibraryMessageViewModel.kt
+++ b/feature/library/src/commonMain/kotlin/me/matsumo/fanbox/feature/library/message/LibraryMessageViewModel.kt
@@ -8,9 +8,9 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import me.matsumo.fanbox.core.common.util.suspendRunCatching
 import me.matsumo.fanbox.core.model.ScreenState
+import me.matsumo.fanbox.core.model.fanbox.NewsLetter
 import me.matsumo.fanbox.core.model.toScreenStateError
 import me.matsumo.fanbox.core.repository.FanboxRepository
-import me.matsumo.fankt.fanbox.domain.model.FanboxNewsLetter
 
 class LibraryMessageViewModel(
     private val fanboxRepository: FanboxRepository,
@@ -41,5 +41,5 @@ class LibraryMessageViewModel(
 
 @Stable
 data class LibraryMessageUiState(
-    val messages: List<FanboxNewsLetter>,
+    val messages: List<NewsLetter>,
 )

--- a/feature/library/src/commonMain/kotlin/me/matsumo/fanbox/feature/library/message/items/LibraryMessageItem.kt
+++ b/feature/library/src/commonMain/kotlin/me/matsumo/fanbox/feature/library/message/items/LibraryMessageItem.kt
@@ -27,20 +27,20 @@ import coil3.compose.AsyncImage
 import coil3.compose.LocalPlatformContext
 import coil3.request.ImageRequest
 import me.matsumo.fanbox.core.common.util.format
+import me.matsumo.fanbox.core.model.fanbox.CreatorId
+import me.matsumo.fanbox.core.model.fanbox.NewsLetter
 import me.matsumo.fanbox.core.resources.Res
 import me.matsumo.fanbox.core.resources.im_default_user
 import me.matsumo.fanbox.core.ui.extensition.asCoilImage
 import me.matsumo.fanbox.core.ui.theme.bold
-import me.matsumo.fankt.fanbox.domain.model.FanboxNewsLetter
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxCreatorId
 import sh.calvin.autolinktext.rememberAutoLinkText
 import kotlin.time.ExperimentalTime
 
 @OptIn(ExperimentalTime::class)
 @Composable
 internal fun LibraryMessageItem(
-    message: FanboxNewsLetter,
-    onClickCreator: (FanboxCreatorId) -> Unit,
+    message: NewsLetter,
+    onClickCreator: (CreatorId) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     var isShowBigBody by rememberSaveable { mutableStateOf(false) }

--- a/feature/library/src/commonMain/kotlin/me/matsumo/fanbox/feature/library/notify/LibraryNotifyScreen.kt
+++ b/feature/library/src/commonMain/kotlin/me/matsumo/fanbox/feature/library/notify/LibraryNotifyScreen.kt
@@ -24,6 +24,8 @@ import app.cash.paging.compose.collectAsLazyPagingItems
 import app.cash.paging.compose.itemContentType
 import app.cash.paging.compose.itemKey
 import me.matsumo.fanbox.core.model.Destination
+import me.matsumo.fanbox.core.model.fanbox.Bell
+import me.matsumo.fanbox.core.model.fanbox.PostId
 import me.matsumo.fanbox.core.resources.Res
 import me.matsumo.fanbox.core.resources.error_no_data_notify
 import me.matsumo.fanbox.core.resources.library_navigation_notify
@@ -35,8 +37,6 @@ import me.matsumo.fanbox.core.ui.extensition.PixiViewNavigationType
 import me.matsumo.fanbox.core.ui.extensition.drawVerticalScrollbar
 import me.matsumo.fanbox.core.ui.view.PagingErrorSection
 import me.matsumo.fanbox.feature.library.notify.items.LibraryNotifyBellItem
-import me.matsumo.fankt.fanbox.domain.model.FanboxBell
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxPostId
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
 
@@ -67,9 +67,9 @@ internal fun LibraryNotifyRoute(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun LibraryNotifyScreen(
-    pagingAdapter: LazyPagingItems<FanboxBell>,
+    pagingAdapter: LazyPagingItems<Bell>,
     openDrawer: () -> Unit,
-    onClickBell: (FanboxPostId) -> Unit,
+    onClickBell: (PostId) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val navigationType = LocalNavigationType.current.type
@@ -109,9 +109,9 @@ private fun LibraryNotifyScreen(
                     key = { index ->
                         pagingAdapter.itemKey {
                             when (it) {
-                                is FanboxBell.Comment -> "comment-${it.id.value}-$index"
-                                is FanboxBell.Like -> "like-${it.id}-$index"
-                                is FanboxBell.PostPublished -> "post-${it.id.value}-$index"
+                                is Bell.Comment -> "comment-${it.id.value}-$index"
+                                is Bell.Like -> "like-${it.id}-$index"
+                                is Bell.PostPublished -> "post-${it.id.value}-$index"
                             }
                         }(index)
                     },

--- a/feature/library/src/commonMain/kotlin/me/matsumo/fanbox/feature/library/notify/LibraryNotifyViewModel.kt
+++ b/feature/library/src/commonMain/kotlin/me/matsumo/fanbox/feature/library/notify/LibraryNotifyViewModel.kt
@@ -13,10 +13,10 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import me.matsumo.fanbox.core.model.ScreenState
 import me.matsumo.fanbox.core.model.Setting
+import me.matsumo.fanbox.core.model.fanbox.Bell
 import me.matsumo.fanbox.core.repository.FanboxRepository
 import me.matsumo.fanbox.core.repository.SettingRepository
 import me.matsumo.fanbox.feature.library.notify.paging.LibraryNotifyPagingSource
-import me.matsumo.fankt.fanbox.domain.model.FanboxBell
 
 class LibraryNotifyViewModel(
     private val fanboxRepository: FanboxRepository,
@@ -49,6 +49,6 @@ class LibraryNotifyViewModel(
 
 @Stable
 data class LibraryNotifyUiState(
-    val paging: Flow<PagingData<FanboxBell>>,
+    val paging: Flow<PagingData<Bell>>,
     val setting: Setting,
 )

--- a/feature/library/src/commonMain/kotlin/me/matsumo/fanbox/feature/library/notify/items/LibraryNotifyBellItem.kt
+++ b/feature/library/src/commonMain/kotlin/me/matsumo/fanbox/feature/library/notify/items/LibraryNotifyBellItem.kt
@@ -29,6 +29,8 @@ import coil3.compose.AsyncImage
 import coil3.compose.LocalPlatformContext
 import coil3.compose.SubcomposeAsyncImage
 import coil3.request.ImageRequest
+import me.matsumo.fanbox.core.model.fanbox.Bell
+import me.matsumo.fanbox.core.model.fanbox.PostId
 import me.matsumo.fanbox.core.resources.Res
 import me.matsumo.fanbox.core.resources.im_default_user
 import me.matsumo.fanbox.core.resources.notify_title_comment
@@ -41,8 +43,6 @@ import me.matsumo.fanbox.core.resources.unit_second_before
 import me.matsumo.fanbox.core.ui.extensition.FadePlaceHolder
 import me.matsumo.fanbox.core.ui.extensition.asCoilImage
 import me.matsumo.fanbox.core.ui.extensition.fanboxHeader
-import me.matsumo.fankt.fanbox.domain.model.FanboxBell
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxPostId
 import org.jetbrains.compose.resources.stringResource
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
@@ -50,26 +50,26 @@ import kotlin.time.Instant
 
 @Composable
 internal fun LibraryNotifyBellItem(
-    bell: FanboxBell,
-    onClickBell: (FanboxPostId) -> Unit,
+    bell: Bell,
+    onClickBell: (PostId) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     when (bell) {
-        is FanboxBell.Comment -> {
+        is Bell.Comment -> {
             CommentItem(
                 modifier = modifier,
                 bell = bell,
                 onClickBell = onClickBell,
             )
         }
-        is FanboxBell.Like -> {
+        is Bell.Like -> {
             LikeItem(
                 modifier = modifier,
                 bell = bell,
                 onClickBell = onClickBell,
             )
         }
-        is FanboxBell.PostPublished -> {
+        is Bell.PostPublished -> {
             PostPublishedItem(
                 modifier = modifier,
                 bell = bell,
@@ -82,8 +82,8 @@ internal fun LibraryNotifyBellItem(
 @OptIn(ExperimentalTime::class)
 @Composable
 private fun PostPublishedItem(
-    bell: FanboxBell.PostPublished,
-    onClickBell: (FanboxPostId) -> Unit,
+    bell: Bell.PostPublished,
+    onClickBell: (PostId) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val isShowCard = (bell.post.cover != null && bell.post.excerpt.isNotBlank())
@@ -173,8 +173,8 @@ private fun PostPublishedItem(
 @OptIn(ExperimentalCoilApi::class, ExperimentalTime::class)
 @Composable
 private fun CommentItem(
-    bell: FanboxBell.Comment,
-    onClickBell: (FanboxPostId) -> Unit,
+    bell: Bell.Comment,
+    onClickBell: (PostId) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Row(
@@ -229,8 +229,8 @@ private fun CommentItem(
 @OptIn(ExperimentalTime::class)
 @Composable
 private fun LikeItem(
-    bell: FanboxBell.Like,
-    onClickBell: (FanboxPostId) -> Unit,
+    bell: Bell.Like,
+    onClickBell: (PostId) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Row(

--- a/feature/library/src/commonMain/kotlin/me/matsumo/fanbox/feature/library/notify/paging/LibraryNotifyPagingSource.kt
+++ b/feature/library/src/commonMain/kotlin/me/matsumo/fanbox/feature/library/notify/paging/LibraryNotifyPagingSource.kt
@@ -3,16 +3,16 @@ package me.matsumo.fanbox.feature.library.notify.paging
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
 import me.matsumo.fanbox.core.common.util.suspendRunCatching
+import me.matsumo.fanbox.core.model.fanbox.Bell
 import me.matsumo.fanbox.core.repository.FanboxRepository
-import me.matsumo.fankt.fanbox.domain.model.FanboxBell
 
 class LibraryNotifyPagingSource(
     private val fanboxRepository: FanboxRepository,
-) : PagingSource<Int, FanboxBell>() {
+) : PagingSource<Int, Bell>() {
 
     override val keyReuseSupported: Boolean = true
 
-    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, FanboxBell> {
+    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, Bell> {
         return suspendRunCatching {
             fanboxRepository.getBells(params.key ?: 1)
         }.fold(
@@ -29,5 +29,5 @@ class LibraryNotifyPagingSource(
         )
     }
 
-    override fun getRefreshKey(state: PagingState<Int, FanboxBell>): Int? = null
+    override fun getRefreshKey(state: PagingState<Int, Bell>): Int? = null
 }

--- a/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/bookmark/BookmarkedPostsScreen.kt
+++ b/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/bookmark/BookmarkedPostsScreen.kt
@@ -32,6 +32,9 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 import me.matsumo.fanbox.core.model.Destination
 import me.matsumo.fanbox.core.model.Setting
+import me.matsumo.fanbox.core.model.fanbox.CreatorId
+import me.matsumo.fanbox.core.model.fanbox.Post
+import me.matsumo.fanbox.core.model.fanbox.PostId
 import me.matsumo.fanbox.core.resources.Res
 import me.matsumo.fanbox.core.resources.bookmark_empty_description
 import me.matsumo.fanbox.core.resources.bookmark_empty_title
@@ -42,9 +45,6 @@ import me.matsumo.fanbox.core.ui.extensition.PixiViewNavigationType
 import me.matsumo.fanbox.core.ui.extensition.drawVerticalScrollbar
 import me.matsumo.fanbox.core.ui.view.ErrorView
 import me.matsumo.fanbox.feature.post.bookmark.items.BookmarkedPostsTopBar
-import me.matsumo.fankt.fanbox.domain.model.FanboxPost
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxCreatorId
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxPostId
 import org.koin.compose.viewmodel.koinViewModel
 
 @Composable
@@ -81,14 +81,14 @@ internal fun BookmarkedPostsRoute(
 @Composable
 private fun BookmarkedPostsScreen(
     setting: Setting,
-    posts: ImmutableList<FanboxPost>,
-    bookmarkedPostIds: ImmutableList<FanboxPostId>,
+    posts: ImmutableList<Post>,
+    bookmarkedPostIds: ImmutableList<PostId>,
     onSearch: (String) -> Unit,
-    onClickPost: (FanboxPostId) -> Unit,
-    onCLickPostLike: (FanboxPostId) -> Unit,
-    onClickPostBookmark: (FanboxPost, Boolean) -> Unit,
-    onClickCreatorPosts: (FanboxCreatorId) -> Unit,
-    onClickCreatorPlans: (FanboxCreatorId) -> Unit,
+    onClickPost: (PostId) -> Unit,
+    onCLickPostLike: (PostId) -> Unit,
+    onClickPostBookmark: (Post, Boolean) -> Unit,
+    onClickCreatorPosts: (CreatorId) -> Unit,
+    onClickCreatorPlans: (CreatorId) -> Unit,
     onTerminate: () -> Unit,
     modifier: Modifier = Modifier,
 ) {

--- a/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/bookmark/BookmarkedPostsViewModel.kt
+++ b/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/bookmark/BookmarkedPostsViewModel.kt
@@ -11,14 +11,14 @@ import kotlinx.coroutines.launch
 import me.matsumo.fanbox.core.common.util.suspendRunCatching
 import me.matsumo.fanbox.core.model.ScreenState
 import me.matsumo.fanbox.core.model.Setting
+import me.matsumo.fanbox.core.model.fanbox.Post
+import me.matsumo.fanbox.core.model.fanbox.PostId
 import me.matsumo.fanbox.core.model.toScreenStateError
 import me.matsumo.fanbox.core.model.updateWhenIdle
 import me.matsumo.fanbox.core.repository.FanboxRepository
 import me.matsumo.fanbox.core.repository.SettingRepository
 import me.matsumo.fanbox.core.resources.Res
 import me.matsumo.fanbox.core.resources.error_no_data
-import me.matsumo.fankt.fanbox.domain.model.FanboxPost
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxPostId
 
 class BookmarkedPostsViewModel(
     private val settingRepository: SettingRepository,
@@ -78,7 +78,7 @@ class BookmarkedPostsViewModel(
         }
     }
 
-    fun postLike(postId: FanboxPostId) {
+    fun postLike(postId: PostId) {
         viewModelScope.launch {
             suspendRunCatching {
                 fanboxRepository.likePost(postId)
@@ -86,7 +86,7 @@ class BookmarkedPostsViewModel(
         }
     }
 
-    fun postBookmark(post: FanboxPost, isBookmarked: Boolean) {
+    fun postBookmark(post: Post, isBookmarked: Boolean) {
         viewModelScope.launch {
             suspendRunCatching {
                 if (isBookmarked) {
@@ -102,6 +102,6 @@ class BookmarkedPostsViewModel(
 @Stable
 data class LikedPostsUiState(
     val setting: Setting,
-    val posts: List<FanboxPost>,
-    val bookmarkedPostIds: List<FanboxPostId>,
+    val posts: List<Post>,
+    val bookmarkedPostIds: List<PostId>,
 )

--- a/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/detail/PostDetailRootViewModel.kt
+++ b/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/detail/PostDetailRootViewModel.kt
@@ -18,14 +18,14 @@ import me.matsumo.fanbox.core.common.util.suspendRunCatching
 import me.matsumo.fanbox.core.model.Destination
 import me.matsumo.fanbox.core.model.Flag
 import me.matsumo.fanbox.core.model.Setting
+import me.matsumo.fanbox.core.model.fanbox.Post
+import me.matsumo.fanbox.core.model.fanbox.PostId
 import me.matsumo.fanbox.core.repository.FanboxRepository
 import me.matsumo.fanbox.core.repository.FlagRepository
 import me.matsumo.fanbox.core.repository.SettingRepository
 import me.matsumo.fanbox.core.ui.customNavTypes
 import me.matsumo.fanbox.core.ui.extensition.createStaticPaging
 import me.matsumo.fanbox.core.ui.extensition.emptyPaging
-import me.matsumo.fankt.fanbox.domain.model.FanboxPost
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxPostId
 
 class PostDetailRootViewModel(
     savedStateHandle: SavedStateHandle,
@@ -88,7 +88,7 @@ class PostDetailRootViewModel(
         }
     }
 
-    fun postBookmark(post: FanboxPost, isBookmarked: Boolean) {
+    fun postBookmark(post: Post, isBookmarked: Boolean) {
         viewModelScope.launch {
             suspendRunCatching {
                 if (isBookmarked) {
@@ -107,15 +107,15 @@ class PostDetailRootViewModel(
         }
     }
 
-    private fun Flow<PagingData<FanboxPost>>.toIdFlow(): Flow<PagingData<FanboxPostId>> {
+    private fun Flow<PagingData<Post>>.toIdFlow(): Flow<PagingData<PostId>> {
         return map { list -> list.map { it.id } }
     }
 }
 
 @Stable
 data class PostDetailRootUiState(
-    val paging: Flow<PagingData<FanboxPostId>>?,
+    val paging: Flow<PagingData<PostId>>?,
     val setting: Setting,
-    val bookmarkedPostIds: List<FanboxPostId>,
+    val bookmarkedPostIds: List<PostId>,
     val shouldShowReveal: Boolean,
 )

--- a/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/detail/PostDetailScreen.kt
+++ b/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/detail/PostDetailScreen.kt
@@ -69,6 +69,17 @@ import me.matsumo.fanbox.core.model.ScreenState
 import me.matsumo.fanbox.core.model.Setting
 import me.matsumo.fanbox.core.model.SimpleAlertContents
 import me.matsumo.fanbox.core.model.TranslationState
+import me.matsumo.fanbox.core.model.fanbox.Comment
+import me.matsumo.fanbox.core.model.fanbox.CommentId
+import me.matsumo.fanbox.core.model.fanbox.Cover
+import me.matsumo.fanbox.core.model.fanbox.CreatorDetail
+import me.matsumo.fanbox.core.model.fanbox.CreatorId
+import me.matsumo.fanbox.core.model.fanbox.MetaData
+import me.matsumo.fanbox.core.model.fanbox.PageOffsetInfo
+import me.matsumo.fanbox.core.model.fanbox.Post
+import me.matsumo.fanbox.core.model.fanbox.PostDetail
+import me.matsumo.fanbox.core.model.fanbox.PostId
+import me.matsumo.fanbox.core.model.fanbox.UserId
 import me.matsumo.fanbox.core.resources.Res
 import me.matsumo.fanbox.core.resources.error_network
 import me.matsumo.fanbox.core.resources.queue_added
@@ -103,17 +114,6 @@ import me.matsumo.fanbox.feature.post.detail.items.postDetailCardSection
 import me.matsumo.fanbox.feature.post.detail.items.postDetailCommentItems
 import me.matsumo.fanbox.feature.post.detail.items.postDetailItems
 import me.matsumo.fanbox.feature.post.detail.items.postDetailTagsSection
-import me.matsumo.fankt.fanbox.domain.PageOffsetInfo
-import me.matsumo.fankt.fanbox.domain.model.FanboxComment
-import me.matsumo.fankt.fanbox.domain.model.FanboxCover
-import me.matsumo.fankt.fanbox.domain.model.FanboxCreatorDetail
-import me.matsumo.fankt.fanbox.domain.model.FanboxMetaData
-import me.matsumo.fankt.fanbox.domain.model.FanboxPost
-import me.matsumo.fankt.fanbox.domain.model.FanboxPostDetail
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxCommentId
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxCreatorId
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxPostId
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxUserId
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
@@ -128,7 +128,7 @@ internal enum class PostDetailRevealKeys {
 @OptIn(ExperimentalUuidApi::class, ExperimentalComposeUiApi::class, ExperimentalTime::class)
 @Composable
 internal fun PostDetailRoute(
-    postId: FanboxPostId,
+    postId: PostId,
     navigateTo: (Destination) -> Unit,
     navigateToCommentDeleteDialog: (SimpleAlertContents, () -> Unit) -> Unit,
     terminate: () -> Unit,
@@ -138,7 +138,7 @@ internal fun PostDetailRoute(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val paging = uiState.paging?.collectAsLazyPagingItems()
 
-    val postDetailMap = remember { mutableStateMapOf<FanboxPostId, FanboxPostDetail>() }
+    val postDetailMap = remember { mutableStateMapOf<PostId, PostDetail>() }
     var currentPostId by remember { mutableStateOf(postId) }
     val snackbarHostState = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
@@ -245,13 +245,13 @@ internal fun PostDetailRoute(
 
 @Composable
 private fun PostDetailView(
-    postId: FanboxPostId,
+    postId: PostId,
     shouldShowReveal: Boolean,
     revealState: RevealState,
     snackbarHostState: SnackbarHostState,
     navigateTo: (Destination) -> Unit,
     navigateToCommentDeleteDialog: (SimpleAlertContents, () -> Unit) -> Unit,
-    onPostDetailFetched: (FanboxPostDetail) -> Unit,
+    onPostDetailFetched: (PostDetail) -> Unit,
     onRevealCompleted: () -> Unit,
     terminate: () -> Unit,
     modifier: Modifier = Modifier,
@@ -384,33 +384,33 @@ private fun PostDetailView(
 @Composable
 private fun PostDetailScreen(
     revealState: RevealState,
-    postDetail: FanboxPostDetail,
-    comments: PageOffsetInfo<FanboxComment>,
-    creatorDetail: FanboxCreatorDetail,
-    bookmarkedPostIds: ImmutableList<FanboxPostId>,
+    postDetail: PostDetail,
+    comments: PageOffsetInfo<Comment>,
+    creatorDetail: CreatorDetail,
+    bookmarkedPostIds: ImmutableList<PostId>,
     setting: Setting,
-    metaData: FanboxMetaData,
-    bodyTransState: TranslationState<FanboxPostDetail>,
-    commentsTransState: TranslationState<PageOffsetInfo<FanboxComment>>,
+    metaData: MetaData,
+    bodyTransState: TranslationState<PostDetail>,
+    commentsTransState: TranslationState<PageOffsetInfo<Comment>>,
     shouldShowReveal: Boolean,
-    onClickBodyTranslate: (FanboxPostDetail) -> Unit,
-    onClickCommentsTranslate: (PageOffsetInfo<FanboxComment>) -> Unit,
-    onClickPost: (FanboxPostId) -> Unit,
-    onClickPostLike: (FanboxPostId) -> Unit,
-    onClickPostBookmark: (FanboxPost, Boolean) -> Unit,
-    onClickCommentLoadMore: (FanboxPostId, Int) -> Unit,
-    onClickCommentLike: (FanboxCommentId) -> Unit,
-    onClickCommentReply: (String, FanboxCommentId, FanboxCommentId) -> Unit,
-    onClickCommentDelete: (FanboxCommentId) -> Unit,
+    onClickBodyTranslate: (PostDetail) -> Unit,
+    onClickCommentsTranslate: (PageOffsetInfo<Comment>) -> Unit,
+    onClickPost: (PostId) -> Unit,
+    onClickPostLike: (PostId) -> Unit,
+    onClickPostBookmark: (Post, Boolean) -> Unit,
+    onClickCommentLoadMore: (PostId, Int) -> Unit,
+    onClickCommentLike: (CommentId) -> Unit,
+    onClickCommentReply: (String, CommentId, CommentId) -> Unit,
+    onClickCommentDelete: (CommentId) -> Unit,
     onClickTag: (String) -> Unit,
-    onClickCreator: (FanboxCreatorId) -> Unit,
-    onClickImage: (FanboxPostDetail.ImageItem) -> Unit,
-    onClickFile: (FanboxPostDetail.FileItem) -> Unit,
-    onClickDownloadImages: (List<FanboxPostDetail.ImageItem>) -> Unit,
-    onClickCreatorPosts: (FanboxCreatorId) -> Unit,
-    onClickCreatorPlans: (FanboxCreatorId) -> Unit,
-    onClickFollow: (FanboxUserId) -> Unit,
-    onClickUnfollow: (FanboxUserId) -> Unit,
+    onClickCreator: (CreatorId) -> Unit,
+    onClickImage: (PostDetail.ImageItem) -> Unit,
+    onClickFile: (PostDetail.FileItem) -> Unit,
+    onClickDownloadImages: (List<PostDetail.ImageItem>) -> Unit,
+    onClickCreatorPosts: (CreatorId) -> Unit,
+    onClickCreatorPlans: (CreatorId) -> Unit,
+    onClickFollow: (UserId) -> Unit,
+    onClickUnfollow: (UserId) -> Unit,
     onClickOpenBrowser: (String) -> Unit,
     onClickBillingPlus: (String?) -> Unit,
     onRevealCompleted: () -> Unit,
@@ -445,14 +445,14 @@ private fun PostDetailScreen(
 
     val isShowHeader = runCatching {
         when (val content = postDetail.body) {
-            is FanboxPostDetail.Body.Article -> content.blocks.first() !is FanboxPostDetail.Body.Article.Block.Image
-            is FanboxPostDetail.Body.File -> true
-            is FanboxPostDetail.Body.Image -> false
+            is PostDetail.Body.Article -> content.blocks.first() !is PostDetail.Body.Article.Block.Image
+            is PostDetail.Body.File -> true
+            is PostDetail.Body.Image -> false
             // 先頭が画像で始まらない本文はヘッダーを重ねても隠れないため表示する。
-            is FanboxPostDetail.Body.Text -> true
-            is FanboxPostDetail.Body.Video -> true
-            is FanboxPostDetail.Body.Html -> true
-            is FanboxPostDetail.Body.Unknown -> true
+            is PostDetail.Body.Text -> true
+            is PostDetail.Body.Video -> true
+            is PostDetail.Body.Html -> true
+            is PostDetail.Body.Unknown -> true
         }
     }.getOrDefault(true)
 
@@ -601,7 +601,7 @@ private fun PostDetailScreen(
 @OptIn(ExperimentalTime::class)
 @Composable
 private fun PostDetailHeader(
-    post: FanboxPostDetail,
+    post: PostDetail,
     modifier: Modifier = Modifier,
 ) {
     Box(modifier) {
@@ -712,12 +712,12 @@ private fun RevealOverlayScope.RevealOverlayContent(
     }
 }
 
-private fun FanboxPostDetail.adPost(): FanboxPost {
-    return FanboxPost(
+private fun PostDetail.adPost(): Post {
+    return Post(
         id = id,
         title = title,
         excerpt = excerpt,
-        cover = FanboxCover(
+        cover = Cover(
             url = coverImageUrl ?: body.imageItems.firstOrNull()?.thumbnailUrl.orEmpty(),
             type = "From Detail",
         ),

--- a/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/detail/PostDetailViewModel.kt
+++ b/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/detail/PostDetailViewModel.kt
@@ -15,6 +15,15 @@ import me.matsumo.fanbox.core.common.util.suspendRunCatching
 import me.matsumo.fanbox.core.model.ScreenState
 import me.matsumo.fanbox.core.model.Setting
 import me.matsumo.fanbox.core.model.TranslationState
+import me.matsumo.fanbox.core.model.fanbox.Comment
+import me.matsumo.fanbox.core.model.fanbox.CommentId
+import me.matsumo.fanbox.core.model.fanbox.CreatorDetail
+import me.matsumo.fanbox.core.model.fanbox.MetaData
+import me.matsumo.fanbox.core.model.fanbox.PageOffsetInfo
+import me.matsumo.fanbox.core.model.fanbox.Post
+import me.matsumo.fanbox.core.model.fanbox.PostDetail
+import me.matsumo.fanbox.core.model.fanbox.PostId
+import me.matsumo.fanbox.core.model.fanbox.UserId
 import me.matsumo.fanbox.core.model.toScreenStateError
 import me.matsumo.fanbox.core.model.updateWhenIdle
 import me.matsumo.fanbox.core.repository.DownloadPostsRepository
@@ -27,19 +36,10 @@ import me.matsumo.fanbox.core.resources.post_detail_comment_comment_failed
 import me.matsumo.fanbox.core.resources.post_detail_comment_commented
 import me.matsumo.fanbox.core.resources.post_detail_comment_delete_failed
 import me.matsumo.fanbox.core.resources.post_detail_comment_delete_success
-import me.matsumo.fankt.fanbox.domain.PageOffsetInfo
-import me.matsumo.fankt.fanbox.domain.model.FanboxComment
-import me.matsumo.fankt.fanbox.domain.model.FanboxCreatorDetail
-import me.matsumo.fankt.fanbox.domain.model.FanboxMetaData
-import me.matsumo.fankt.fanbox.domain.model.FanboxPost
-import me.matsumo.fankt.fanbox.domain.model.FanboxPostDetail
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxCommentId
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxPostId
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxUserId
 import org.jetbrains.compose.resources.StringResource
 
 class PostDetailViewModel(
-    private val postId: FanboxPostId,
+    private val postId: PostId,
     private val settingRepository: SettingRepository,
     private val fanboxRepository: FanboxRepository,
     private val translationRepository: TranslationRepository,
@@ -92,7 +92,7 @@ class PostDetailViewModel(
         }
     }
 
-    fun translate(postDetail: FanboxPostDetail) {
+    fun translate(postDetail: PostDetail) {
         viewModelScope.launch {
             (screenState.value as? ScreenState.Idle)?.also { data ->
                 if (data.data.bodyTransState is TranslationState.Translated) return@launch
@@ -120,7 +120,7 @@ class PostDetailViewModel(
         }
     }
 
-    fun translate(comments: PageOffsetInfo<FanboxComment>) {
+    fun translate(comments: PageOffsetInfo<Comment>) {
         viewModelScope.launch {
             (screenState.value as? ScreenState.Idle)?.also { data ->
                 _screenState.updateWhenIdle { it.copy(commentsTransState = TranslationState.Loading) }
@@ -144,7 +144,7 @@ class PostDetailViewModel(
         }
     }
 
-    fun postLike(postId: FanboxPostId) {
+    fun postLike(postId: PostId) {
         viewModelScope.launch {
             suspendRunCatching {
                 fanboxRepository.likePost(postId)
@@ -152,7 +152,7 @@ class PostDetailViewModel(
         }
     }
 
-    fun postBookmark(post: FanboxPost, isBookmarked: Boolean) {
+    fun postBookmark(post: Post, isBookmarked: Boolean) {
         viewModelScope.launch {
             suspendRunCatching {
                 if (isBookmarked) {
@@ -164,7 +164,7 @@ class PostDetailViewModel(
         }
     }
 
-    fun loadMoreComment(postId: FanboxPostId, offset: Int) {
+    fun loadMoreComment(postId: PostId, offset: Int) {
         viewModelScope.launch {
             suspendRunCatching {
                 val comments = fanboxRepository.getPostComment(postId, offset)
@@ -181,7 +181,7 @@ class PostDetailViewModel(
         }
     }
 
-    fun commentLike(commentId: FanboxCommentId) {
+    fun commentLike(commentId: CommentId) {
         viewModelScope.launch {
             suspendRunCatching {
                 fanboxRepository.likeComment(commentId)
@@ -189,7 +189,7 @@ class PostDetailViewModel(
         }
     }
 
-    fun commentReply(postId: FanboxPostId, body: String, parentFanboxCommentId: FanboxCommentId, rootFanboxCommentId: FanboxCommentId) {
+    fun commentReply(postId: PostId, body: String, parentFanboxCommentId: CommentId, rootFanboxCommentId: CommentId) {
         viewModelScope.launch {
             (screenState.value as? ScreenState.Idle)?.also { data ->
                 _screenState.value = suspendRunCatching {
@@ -216,7 +216,7 @@ class PostDetailViewModel(
         }
     }
 
-    fun commentDelete(postId: FanboxPostId, commentId: FanboxCommentId) {
+    fun commentDelete(postId: PostId, commentId: CommentId) {
         viewModelScope.launch {
             (screenState.value as? ScreenState.Idle)?.also { data ->
                 _screenState.value = suspendRunCatching {
@@ -243,7 +243,7 @@ class PostDetailViewModel(
         }
     }
 
-    fun follow(creatorUserId: FanboxUserId) {
+    fun follow(creatorUserId: UserId) {
         viewModelScope.launch {
             (screenState.value as? ScreenState.Idle)?.also { data ->
                 val creatorDetail = suspendRunCatching {
@@ -258,7 +258,7 @@ class PostDetailViewModel(
         }
     }
 
-    fun unfollow(creatorUserId: FanboxUserId) {
+    fun unfollow(creatorUserId: UserId) {
         viewModelScope.launch {
             (screenState.value as? ScreenState.Idle)?.also { data ->
                 val creatorDetail = suspendRunCatching {
@@ -281,11 +281,11 @@ class PostDetailViewModel(
         }
     }
 
-    fun downloadImages(postId: FanboxPostId, title: String, imageItems: List<FanboxPostDetail.ImageItem>) {
+    fun downloadImages(postId: PostId, title: String, imageItems: List<PostDetail.ImageItem>) {
         downloadPostsRepository.requestDownloadImages(postId, title, imageItems)
     }
 
-    fun downloadFiles(postId: FanboxPostId, title: String, fileItems: List<FanboxPostDetail.FileItem>) {
+    fun downloadFiles(postId: PostId, title: String, fileItems: List<PostDetail.FileItem>) {
         downloadPostsRepository.requestDownloadFiles(postId, title, fileItems)
     }
 }
@@ -293,12 +293,12 @@ class PostDetailViewModel(
 @Stable
 data class PostDetailUiState(
     val setting: Setting,
-    val metaData: FanboxMetaData,
-    val bookmarkedPostIds: List<FanboxPostId>,
-    val creatorDetail: FanboxCreatorDetail,
-    val postDetail: FanboxPostDetail,
-    val comments: PageOffsetInfo<FanboxComment>,
-    val bodyTransState: TranslationState<FanboxPostDetail> = TranslationState.None,
-    val commentsTransState: TranslationState<PageOffsetInfo<FanboxComment>> = TranslationState.None,
+    val metaData: MetaData,
+    val bookmarkedPostIds: List<PostId>,
+    val creatorDetail: CreatorDetail,
+    val postDetail: PostDetail,
+    val comments: PageOffsetInfo<Comment>,
+    val bodyTransState: TranslationState<PostDetail> = TranslationState.None,
+    val commentsTransState: TranslationState<PageOffsetInfo<Comment>> = TranslationState.None,
     val messageToast: StringResource? = null,
 )

--- a/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/detail/items/PostDetailArticleHeader.kt
+++ b/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/detail/items/PostDetailArticleHeader.kt
@@ -13,44 +13,44 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.ImmutableList
 import me.matsumo.fanbox.core.model.Setting
+import me.matsumo.fanbox.core.model.fanbox.CreatorId
+import me.matsumo.fanbox.core.model.fanbox.Post
+import me.matsumo.fanbox.core.model.fanbox.PostDetail
+import me.matsumo.fanbox.core.model.fanbox.PostId
 import me.matsumo.fanbox.core.resources.Res
 import me.matsumo.fanbox.core.resources.post_detail_unsupported_content
 import me.matsumo.fanbox.core.ui.component.AdultContentThumbnail
 import me.matsumo.fanbox.core.ui.component.PostItem
 import me.matsumo.fanbox.core.ui.extensition.LocalFanboxMetadata
-import me.matsumo.fankt.fanbox.domain.model.FanboxPost
-import me.matsumo.fankt.fanbox.domain.model.FanboxPostDetail
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxCreatorId
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxPostId
 import org.jetbrains.compose.resources.stringResource
 import sh.calvin.autolinktext.rememberAutoLinkText
 
 internal fun LazyListScope.postDetailArticleHeader(
-    content: FanboxPostDetail.Body.Article,
+    content: PostDetail.Body.Article,
     setting: Setting,
-    bookmarkedPostIds: ImmutableList<FanboxPostId>,
+    bookmarkedPostIds: ImmutableList<PostId>,
     isAdultContents: Boolean,
     isAutoImagePreview: Boolean,
-    onClickPost: (FanboxPostId) -> Unit,
-    onClickPostLike: (FanboxPostId) -> Unit,
-    onClickPostBookmark: (FanboxPost, Boolean) -> Unit,
-    onClickCreator: (FanboxCreatorId) -> Unit,
-    onClickImage: (FanboxPostDetail.ImageItem) -> Unit,
-    onClickFile: (FanboxPostDetail.FileItem) -> Unit,
-    onClickDownload: (List<FanboxPostDetail.ImageItem>) -> Unit,
+    onClickPost: (PostId) -> Unit,
+    onClickPostLike: (PostId) -> Unit,
+    onClickPostBookmark: (Post, Boolean) -> Unit,
+    onClickCreator: (CreatorId) -> Unit,
+    onClickImage: (PostDetail.ImageItem) -> Unit,
+    onClickFile: (PostDetail.FileItem) -> Unit,
+    onClickDownload: (List<PostDetail.ImageItem>) -> Unit,
 ) {
     items(content.blocks) {
         val metadata = LocalFanboxMetadata.current
 
         when (it) {
-            is FanboxPostDetail.Body.Article.Block.Text -> {
+            is PostDetail.Body.Article.Block.Text -> {
                 ArticleTextItem(
                     modifier = Modifier.fillMaxWidth(),
                     item = it,
                 )
             }
 
-            is FanboxPostDetail.Body.Article.Block.Image -> {
+            is PostDetail.Body.Article.Block.Image -> {
                 if (!setting.isAllowedShowAdultContents && metadata.context?.user?.showAdultContent == false && isAdultContents) {
                     AdultContentThumbnail(
                         modifier = Modifier
@@ -70,7 +70,7 @@ internal fun LazyListScope.postDetailArticleHeader(
                 }
             }
 
-            is FanboxPostDetail.Body.Article.Block.File -> {
+            is PostDetail.Body.Article.Block.File -> {
                 val imageItem = it.item.asImageItem()
 
                 if (isAutoImagePreview && imageItem != null) {
@@ -90,7 +90,7 @@ internal fun LazyListScope.postDetailArticleHeader(
                 }
             }
 
-            is FanboxPostDetail.Body.Article.Block.Link -> {
+            is PostDetail.Body.Article.Block.Link -> {
                 ArticleLinkItem(
                     modifier = Modifier.fillMaxWidth(),
                     item = it,
@@ -105,7 +105,7 @@ internal fun LazyListScope.postDetailArticleHeader(
                 )
             }
 
-            is FanboxPostDetail.Body.Article.Block.Embed -> {
+            is PostDetail.Body.Article.Block.Embed -> {
                 // fankt は既知のサービスについてのみ URL を復元する。復元できない場合は開く先が
                 // 無いため、未対応の要素として扱う。
                 val embedUrl = it.url
@@ -120,7 +120,7 @@ internal fun LazyListScope.postDetailArticleHeader(
                 }
             }
 
-            is FanboxPostDetail.Body.Article.Block.Unknown -> {
+            is PostDetail.Body.Article.Block.Unknown -> {
                 // rawJson は検証されていないネットワークデータのため表示しない。
                 ArticleUnsupportedItem(modifier = Modifier.fillMaxWidth())
             }
@@ -153,7 +153,7 @@ internal fun ArticleUnsupportedItem(modifier: Modifier = Modifier) {
 
 @Composable
 private fun ArticleTextItem(
-    item: FanboxPostDetail.Body.Article.Block.Text,
+    item: PostDetail.Body.Article.Block.Text,
     modifier: Modifier = Modifier,
 ) {
     Text(
@@ -165,15 +165,15 @@ private fun ArticleTextItem(
 
 @Composable
 private fun ArticleLinkItem(
-    item: FanboxPostDetail.Body.Article.Block.Link,
+    item: PostDetail.Body.Article.Block.Link,
     isHideAdultContents: Boolean,
     isOverrideAdultContents: Boolean,
     isTestUser: Boolean,
     isBookmarked: Boolean,
-    onClickPost: (FanboxPostId) -> Unit,
-    onClickPostLike: (FanboxPostId) -> Unit,
-    onClickPostBookmark: (FanboxPostId, Boolean) -> Unit,
-    onClickCreator: (FanboxCreatorId) -> Unit,
+    onClickPost: (PostId) -> Unit,
+    onClickPostLike: (PostId) -> Unit,
+    onClickPostBookmark: (PostId, Boolean) -> Unit,
+    onClickCreator: (CreatorId) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val post = item.post

--- a/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/detail/items/PostDetailBottomBar.kt
+++ b/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/detail/items/PostDetailBottomBar.kt
@@ -29,18 +29,18 @@ import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import coil3.compose.LocalPlatformContext
 import coil3.request.ImageRequest
+import me.matsumo.fanbox.core.model.fanbox.CreatorId
+import me.matsumo.fanbox.core.model.fanbox.PostDetail
 import me.matsumo.fanbox.core.resources.Res
 import me.matsumo.fanbox.core.resources.im_default_user
 import me.matsumo.fanbox.core.ui.extensition.asCoilImage
 import me.matsumo.fanbox.core.ui.theme.bold
-import me.matsumo.fankt.fanbox.domain.model.FanboxPostDetail
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxCreatorId
 
 @Composable
 internal fun PostDetailBottomBar(
-    postDetail: FanboxPostDetail?,
+    postDetail: PostDetail?,
     isBookmarked: Boolean,
-    onCreatorClicked: (FanboxCreatorId) -> Unit,
+    onCreatorClicked: (CreatorId) -> Unit,
     onBookmarkClicked: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {

--- a/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/detail/items/PostDetailCardSection.kt
+++ b/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/detail/items/PostDetailCardSection.kt
@@ -6,15 +6,15 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import me.matsumo.fanbox.core.model.fanbox.CreatorId
+import me.matsumo.fanbox.core.model.fanbox.PostDetail
 import me.matsumo.fanbox.core.ui.component.RestrictCardItem
 import me.matsumo.fanbox.core.ui.extensition.padding
-import me.matsumo.fankt.fanbox.domain.model.FanboxPostDetail
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxCreatorId
 
 internal fun LazyListScope.postDetailCardSection(
-    postDetail: FanboxPostDetail,
-    onClickCreatorPlans: (FanboxCreatorId) -> Unit,
-    onClickDownloadImages: (List<FanboxPostDetail.ImageItem>) -> Unit,
+    postDetail: PostDetail,
+    onClickCreatorPlans: (CreatorId) -> Unit,
+    onClickDownloadImages: (List<PostDetail.ImageItem>) -> Unit,
 ) {
     if (postDetail.isRestricted) {
         item {

--- a/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/detail/items/PostDetailCommentSection.kt
+++ b/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/detail/items/PostDetailCommentSection.kt
@@ -44,6 +44,12 @@ import coil3.compose.AsyncImage
 import coil3.compose.LocalPlatformContext
 import coil3.request.ImageRequest
 import me.matsumo.fanbox.core.model.TranslationState
+import me.matsumo.fanbox.core.model.fanbox.Comment
+import me.matsumo.fanbox.core.model.fanbox.CommentId
+import me.matsumo.fanbox.core.model.fanbox.MetaData
+import me.matsumo.fanbox.core.model.fanbox.PageOffsetInfo
+import me.matsumo.fanbox.core.model.fanbox.PostDetail
+import me.matsumo.fanbox.core.model.fanbox.PostId
 import me.matsumo.fanbox.core.resources.Res
 import me.matsumo.fanbox.core.resources.common_delete
 import me.matsumo.fanbox.core.resources.common_see_more
@@ -59,12 +65,6 @@ import me.matsumo.fanbox.core.ui.extensition.asCoilImage
 import me.matsumo.fanbox.core.ui.extensition.padding
 import me.matsumo.fanbox.core.ui.theme.bold
 import me.matsumo.fanbox.core.ui.theme.center
-import me.matsumo.fankt.fanbox.domain.PageOffsetInfo
-import me.matsumo.fankt.fanbox.domain.model.FanboxComment
-import me.matsumo.fankt.fanbox.domain.model.FanboxMetaData
-import me.matsumo.fankt.fanbox.domain.model.FanboxPostDetail
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxCommentId
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxPostId
 import org.jetbrains.compose.resources.stringResource
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
@@ -72,16 +72,16 @@ import kotlin.time.Instant
 
 internal fun LazyListScope.postDetailCommentItems(
     isShowCommentEditor: Boolean,
-    postDetail: FanboxPostDetail,
-    comments: PageOffsetInfo<FanboxComment>,
-    commentsTransState: TranslationState<PageOffsetInfo<FanboxComment>>,
-    metaData: FanboxMetaData,
-    onClickLoadMore: (FanboxPostId, Int) -> Unit,
-    onClickCommentLike: (FanboxCommentId) -> Unit,
-    onClickCommentReply: (String, FanboxCommentId, FanboxCommentId) -> Unit,
-    onClickCommentDelete: (FanboxCommentId) -> Unit,
+    postDetail: PostDetail,
+    comments: PageOffsetInfo<Comment>,
+    commentsTransState: TranslationState<PageOffsetInfo<Comment>>,
+    metaData: MetaData,
+    onClickLoadMore: (PostId, Int) -> Unit,
+    onClickCommentLike: (CommentId) -> Unit,
+    onClickCommentReply: (String, CommentId, CommentId) -> Unit,
+    onClickCommentDelete: (CommentId) -> Unit,
     onClickShowCommentEditor: (Boolean) -> Unit,
-    onClickTranslate: (PageOffsetInfo<FanboxComment>) -> Unit,
+    onClickTranslate: (PageOffsetInfo<Comment>) -> Unit,
 ) {
     item {
         Column(
@@ -131,8 +131,8 @@ internal fun LazyListScope.postDetailCommentItems(
                         .padding(top = 24.dp)
                         .padding(horizontal = 8.dp)
                         .fillMaxWidth(),
-                    parentFanboxCommentId = FanboxCommentId("0"),
-                    rootFanboxCommentId = FanboxCommentId("0"),
+                    parentFanboxCommentId = CommentId("0"),
+                    rootFanboxCommentId = CommentId("0"),
                     metaData = metaData,
                     onClickCommentReply = { body, parentFanboxCommentId, rootFanboxCommentId ->
                         onClickCommentReply.invoke(body, parentFanboxCommentId, rootFanboxCommentId)
@@ -218,11 +218,11 @@ internal fun LazyListScope.postDetailCommentItems(
 @OptIn(ExperimentalTime::class)
 @Composable
 private fun CommentItem(
-    comment: FanboxComment,
-    metaData: FanboxMetaData,
-    onClickCommentLike: (FanboxCommentId) -> Unit,
-    onClickCommentReply: (String, FanboxCommentId, FanboxCommentId) -> Unit,
-    onClickCommentDelete: (FanboxCommentId) -> Unit,
+    comment: Comment,
+    metaData: MetaData,
+    onClickCommentLike: (CommentId) -> Unit,
+    onClickCommentReply: (String, CommentId, CommentId) -> Unit,
+    onClickCommentDelete: (CommentId) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     var isShowReplyEditor by rememberSaveable(comment) { mutableStateOf(false) }
@@ -381,10 +381,10 @@ private fun CommentItem(
 @OptIn(ExperimentalCoilApi::class)
 @Composable
 private fun CommentEditor(
-    parentFanboxCommentId: FanboxCommentId,
-    rootFanboxCommentId: FanboxCommentId,
-    metaData: FanboxMetaData,
-    onClickCommentReply: (String, FanboxCommentId, FanboxCommentId) -> Unit,
+    parentFanboxCommentId: CommentId,
+    rootFanboxCommentId: CommentId,
+    metaData: MetaData,
+    onClickCommentReply: (String, CommentId, CommentId) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     var isError by rememberSaveable { mutableStateOf(false) }

--- a/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/detail/items/PostDetailCreatorSection.kt
+++ b/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/detail/items/PostDetailCreatorSection.kt
@@ -25,6 +25,10 @@ import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import coil3.compose.LocalPlatformContext
 import coil3.request.ImageRequest
+import me.matsumo.fanbox.core.model.fanbox.CreatorDetail
+import me.matsumo.fanbox.core.model.fanbox.CreatorId
+import me.matsumo.fanbox.core.model.fanbox.PostDetail
+import me.matsumo.fanbox.core.model.fanbox.UserId
 import me.matsumo.fanbox.core.resources.Res
 import me.matsumo.fanbox.core.resources.common_follow
 import me.matsumo.fanbox.core.resources.common_supporting
@@ -33,19 +37,15 @@ import me.matsumo.fanbox.core.resources.im_default_user
 import me.matsumo.fanbox.core.resources.post_detail_creator
 import me.matsumo.fanbox.core.ui.extensition.asCoilImage
 import me.matsumo.fanbox.core.ui.theme.bold
-import me.matsumo.fankt.fanbox.domain.model.FanboxCreatorDetail
-import me.matsumo.fankt.fanbox.domain.model.FanboxPostDetail
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxCreatorId
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxUserId
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
 internal fun PostDetailCreatorSection(
-    postDetail: FanboxPostDetail,
-    creatorDetail: FanboxCreatorDetail,
-    onClickCreator: (FanboxCreatorId) -> Unit,
-    onClickFollow: (FanboxUserId) -> Unit,
-    onClickUnfollow: (FanboxUserId) -> Unit,
+    postDetail: PostDetail,
+    creatorDetail: CreatorDetail,
+    onClickCreator: (CreatorId) -> Unit,
+    onClickFollow: (UserId) -> Unit,
+    onClickUnfollow: (UserId) -> Unit,
     onClickSupporting: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -82,10 +82,10 @@ internal fun PostDetailCreatorSection(
 
 @Composable
 private fun CreatorItem(
-    postDetail: FanboxPostDetail,
-    creatorDetail: FanboxCreatorDetail,
-    onClickFollow: (FanboxUserId) -> Unit,
-    onClickUnfollow: (FanboxUserId) -> Unit,
+    postDetail: PostDetail,
+    creatorDetail: CreatorDetail,
+    onClickFollow: (UserId) -> Unit,
+    onClickUnfollow: (UserId) -> Unit,
     onClickSupporting: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {

--- a/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/detail/items/PostDetailDownloadSection.kt
+++ b/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/detail/items/PostDetailDownloadSection.kt
@@ -15,18 +15,18 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import me.matsumo.fanbox.core.model.fanbox.PostDetail
 import me.matsumo.fanbox.core.resources.Res
 import me.matsumo.fanbox.core.resources.common_download
 import me.matsumo.fanbox.core.resources.post_detail_download_images
 import me.matsumo.fanbox.core.ui.theme.bold
 import me.matsumo.fanbox.core.ui.theme.center
-import me.matsumo.fankt.fanbox.domain.model.FanboxPostDetail
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
 internal fun PostDetailDownloadSection(
-    postDetail: FanboxPostDetail,
-    onClickDownload: (List<FanboxPostDetail.ImageItem>) -> Unit,
+    postDetail: PostDetail,
+    onClickDownload: (List<PostDetail.ImageItem>) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Card(

--- a/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/detail/items/PostDetailFileHeader.kt
+++ b/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/detail/items/PostDetailFileHeader.kt
@@ -9,15 +9,15 @@ import androidx.compose.material3.Text
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.unit.dp
-import me.matsumo.fankt.fanbox.domain.model.FanboxPostDetail
+import me.matsumo.fanbox.core.model.fanbox.PostDetail
 import sh.calvin.autolinktext.rememberAutoLinkText
 
 internal fun LazyListScope.postDetailFileHeader(
     isAutoImagePreview: Boolean,
-    content: FanboxPostDetail.Body.File,
-    onClickImage: (FanboxPostDetail.ImageItem) -> Unit,
-    onClickFile: (FanboxPostDetail.FileItem) -> Unit,
-    onClickDownload: (List<FanboxPostDetail.ImageItem>) -> Unit,
+    content: PostDetail.Body.File,
+    onClickImage: (PostDetail.ImageItem) -> Unit,
+    onClickFile: (PostDetail.FileItem) -> Unit,
+    onClickDownload: (List<PostDetail.ImageItem>) -> Unit,
 ) {
     items(content.files) {
         val imageItem = it.asImageItem()

--- a/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/detail/items/PostDetailFileItem.kt
+++ b/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/detail/items/PostDetailFileItem.kt
@@ -16,18 +16,18 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import me.matsumo.fanbox.core.common.util.toFileSizeString
+import me.matsumo.fanbox.core.model.fanbox.PostDetail
 import me.matsumo.fanbox.core.resources.Res
 import me.matsumo.fanbox.core.resources.common_download
 import me.matsumo.fanbox.core.ui.component.video.VideoPlayer
 import me.matsumo.fanbox.core.ui.theme.bold
 import me.matsumo.fanbox.core.ui.theme.center
-import me.matsumo.fankt.fanbox.domain.model.FanboxPostDetail
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
 internal fun PostDetailFileItem(
-    item: FanboxPostDetail.FileItem,
-    onClickDownload: (FanboxPostDetail.FileItem) -> Unit,
+    item: PostDetail.FileItem,
+    onClickDownload: (PostDetail.FileItem) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val videoItem = item.asVideoItem()

--- a/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/detail/items/PostDetailImageHeader.kt
+++ b/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/detail/items/PostDetailImageHeader.kt
@@ -10,18 +10,18 @@ import androidx.compose.material3.Text
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.unit.dp
+import me.matsumo.fanbox.core.model.fanbox.PostDetail
 import me.matsumo.fanbox.core.ui.component.AdultContentThumbnail
 import me.matsumo.fanbox.core.ui.extensition.LocalFanboxMetadata
-import me.matsumo.fankt.fanbox.domain.model.FanboxPostDetail
 import sh.calvin.autolinktext.rememberAutoLinkText
 
 internal fun LazyListScope.postDetailImageHeader(
-    content: FanboxPostDetail.Body.Image,
+    content: PostDetail.Body.Image,
     isAdultContents: Boolean,
     isOverrideAdultContents: Boolean,
     isTestUser: Boolean,
-    onClickImage: (FanboxPostDetail.ImageItem) -> Unit,
-    onClickDownload: (List<FanboxPostDetail.ImageItem>) -> Unit,
+    onClickImage: (PostDetail.ImageItem) -> Unit,
+    onClickDownload: (List<PostDetail.ImageItem>) -> Unit,
 ) {
     items(content.images) {
         val metadata = LocalFanboxMetadata.current

--- a/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/detail/items/PostDetailImageItem.kt
+++ b/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/detail/items/PostDetailImageItem.kt
@@ -22,6 +22,7 @@ import coil3.compose.LocalPlatformContext
 import coil3.compose.SubcomposeAsyncImage
 import coil3.request.ImageRequest
 import coil3.size.Size
+import me.matsumo.fanbox.core.model.fanbox.PostDetail
 import me.matsumo.fanbox.core.resources.Res
 import me.matsumo.fanbox.core.resources.error_ios_gif_support
 import me.matsumo.fanbox.core.ui.extensition.Platform
@@ -30,14 +31,13 @@ import me.matsumo.fanbox.core.ui.extensition.currentPlatform
 import me.matsumo.fanbox.core.ui.extensition.fanboxHeader
 import me.matsumo.fanbox.core.ui.theme.center
 import me.matsumo.fanbox.feature.post.image.items.PostImageMenuDialog
-import me.matsumo.fankt.fanbox.domain.model.FanboxPostDetail
 import org.jetbrains.compose.resources.stringResource
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 internal fun PostDetailImageItem(
-    item: FanboxPostDetail.ImageItem,
-    onClickImage: (FanboxPostDetail.ImageItem) -> Unit,
+    item: PostDetail.ImageItem,
+    onClickImage: (PostDetail.ImageItem) -> Unit,
     onClickDownload: () -> Unit,
     onClickAllDownload: () -> Unit,
     modifier: Modifier = Modifier,

--- a/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/detail/items/PostDetailItems.kt
+++ b/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/detail/items/PostDetailItems.kt
@@ -5,25 +5,25 @@ import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.ui.Modifier
 import kotlinx.collections.immutable.ImmutableList
 import me.matsumo.fanbox.core.model.Setting
-import me.matsumo.fankt.fanbox.domain.model.FanboxPost
-import me.matsumo.fankt.fanbox.domain.model.FanboxPostDetail
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxCreatorId
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxPostId
+import me.matsumo.fanbox.core.model.fanbox.CreatorId
+import me.matsumo.fanbox.core.model.fanbox.Post
+import me.matsumo.fanbox.core.model.fanbox.PostDetail
+import me.matsumo.fanbox.core.model.fanbox.PostId
 
 internal fun LazyListScope.postDetailItems(
-    post: FanboxPostDetail,
+    post: PostDetail,
     setting: Setting,
-    bookmarkedPostIds: ImmutableList<FanboxPostId>,
-    onClickPost: (FanboxPostId) -> Unit,
-    onClickPostLike: (FanboxPostId) -> Unit,
-    onClickPostBookmark: (FanboxPost, Boolean) -> Unit,
-    onClickCreator: (FanboxCreatorId) -> Unit,
-    onClickImage: (FanboxPostDetail.ImageItem) -> Unit,
-    onClickFile: (FanboxPostDetail.FileItem) -> Unit,
-    onClickDownload: (List<FanboxPostDetail.ImageItem>) -> Unit,
+    bookmarkedPostIds: ImmutableList<PostId>,
+    onClickPost: (PostId) -> Unit,
+    onClickPostLike: (PostId) -> Unit,
+    onClickPostBookmark: (Post, Boolean) -> Unit,
+    onClickCreator: (CreatorId) -> Unit,
+    onClickImage: (PostDetail.ImageItem) -> Unit,
+    onClickFile: (PostDetail.FileItem) -> Unit,
+    onClickDownload: (List<PostDetail.ImageItem>) -> Unit,
 ) {
     when (val content = post.body) {
-        is FanboxPostDetail.Body.Article -> {
+        is PostDetail.Body.Article -> {
             postDetailArticleHeader(
                 content = content,
                 setting = setting,
@@ -40,7 +40,7 @@ internal fun LazyListScope.postDetailItems(
             )
         }
 
-        is FanboxPostDetail.Body.Image -> {
+        is PostDetail.Body.Image -> {
             postDetailImageHeader(
                 content = content,
                 isAdultContents = post.hasAdultContent,
@@ -51,7 +51,7 @@ internal fun LazyListScope.postDetailItems(
             )
         }
 
-        is FanboxPostDetail.Body.File -> {
+        is PostDetail.Body.File -> {
             postDetailFileHeader(
                 content = content,
                 isAutoImagePreview = setting.isAutoImagePreview,
@@ -61,7 +61,7 @@ internal fun LazyListScope.postDetailItems(
             )
         }
 
-        is FanboxPostDetail.Body.Text -> {
+        is PostDetail.Body.Text -> {
             item {
                 ArticleUrlItem(
                     modifier = Modifier.fillMaxWidth(),
@@ -70,7 +70,7 @@ internal fun LazyListScope.postDetailItems(
             }
         }
 
-        is FanboxPostDetail.Body.Video -> {
+        is PostDetail.Body.Video -> {
             item {
                 // fankt は既知のサービスについてのみ URL を復元する。復元できない場合は開く先が
                 // 無いため、未対応の要素として扱う。
@@ -87,7 +87,7 @@ internal fun LazyListScope.postDetailItems(
             }
         }
 
-        is FanboxPostDetail.Body.Html -> {
+        is PostDetail.Body.Html -> {
             item {
                 // html は検証されていないネットワークデータで、そのまま描画するとスクリプトや
                 // 外部リソースの読み込みを許すことになる。描画方法が決まるまで未対応として扱う。
@@ -95,7 +95,7 @@ internal fun LazyListScope.postDetailItems(
             }
         }
 
-        is FanboxPostDetail.Body.Unknown -> {
+        is PostDetail.Body.Unknown -> {
             item {
                 // rawBodyJson は検証されていないネットワークデータのため表示しない。
                 ArticleUnsupportedItem(modifier = Modifier.fillMaxWidth())

--- a/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/detail/items/PostDetailTopAppBar.kt
+++ b/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/detail/items/PostDetailTopAppBar.kt
@@ -31,19 +31,19 @@ import com.svenjacobs.reveal.RevealShape
 import com.svenjacobs.reveal.RevealState
 import com.svenjacobs.reveal.revealable
 import me.matsumo.fanbox.core.model.TranslationState
+import me.matsumo.fanbox.core.model.fanbox.PostDetail
 import me.matsumo.fanbox.feature.post.detail.PostDetailRevealKeys
-import me.matsumo.fankt.fanbox.domain.model.FanboxPostDetail
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun PostDetailTopAppBar(
     state: LazyListState,
     revealState: RevealState,
-    postDetail: FanboxPostDetail,
-    bodyTransState: TranslationState<FanboxPostDetail>,
+    postDetail: PostDetail,
+    bodyTransState: TranslationState<PostDetail>,
     isShowHeader: Boolean,
     onClickNavigateUp: () -> Unit,
-    onClickTranslate: (FanboxPostDetail) -> Unit,
+    onClickTranslate: (PostDetail) -> Unit,
     onClickMenu: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -67,9 +67,9 @@ internal fun PostDetailTopAppBar(
     val threshold = remember(state) {
         val headerSize = if (isShowHeader) 1 else 0
         val itemSize = when (val content = postDetail.body) {
-            is FanboxPostDetail.Body.Article -> content.blocks.size
-            is FanboxPostDetail.Body.File -> content.files.size
-            is FanboxPostDetail.Body.Image -> content.images.size
+            is PostDetail.Body.Article -> content.blocks.size
+            is PostDetail.Body.File -> content.files.size
+            is PostDetail.Body.Image -> content.images.size
             else -> 0
         }
 

--- a/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/image/PostImageScreen.kt
+++ b/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/image/PostImageScreen.kt
@@ -33,6 +33,8 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import me.matsumo.fanbox.core.model.Destination
 import me.matsumo.fanbox.core.model.ScreenState
+import me.matsumo.fanbox.core.model.fanbox.PostDetail
+import me.matsumo.fanbox.core.model.fanbox.PostId
 import me.matsumo.fanbox.core.resources.Res
 import me.matsumo.fanbox.core.resources.error_ios_gif_support
 import me.matsumo.fanbox.core.resources.queue_added
@@ -49,8 +51,6 @@ import me.matsumo.fanbox.core.ui.extensition.currentPlatform
 import me.matsumo.fanbox.core.ui.extensition.fanboxHeader
 import me.matsumo.fanbox.core.ui.theme.center
 import me.matsumo.fanbox.feature.post.image.items.PostImageMenuDialog
-import me.matsumo.fankt.fanbox.domain.model.FanboxPostDetail
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxPostId
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
@@ -62,7 +62,7 @@ private const val TOP_BAR_AUTO_HIDE_DELAY_MILLIS = 3000L
 
 @Composable
 internal fun PostImageRoute(
-    postId: FanboxPostId,
+    postId: PostId,
     postImageIndex: Int,
     navigateTo: (Destination) -> Unit,
     terminate: () -> Unit,
@@ -114,8 +114,8 @@ internal fun PostImageRoute(
 @Composable
 private fun PostImageScreen(
     imageIndex: Int,
-    postDetail: FanboxPostDetail,
-    onClickDownload: (List<FanboxPostDetail.ImageItem>) -> Unit,
+    postDetail: PostDetail,
+    onClickDownload: (List<PostDetail.ImageItem>) -> Unit,
     onTerminate: () -> Unit,
     modifier: Modifier = Modifier,
 ) {

--- a/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/image/PostImageViewModel.kt
+++ b/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/image/PostImageViewModel.kt
@@ -8,11 +8,11 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import me.matsumo.fanbox.core.common.util.suspendRunCatching
 import me.matsumo.fanbox.core.model.ScreenState
+import me.matsumo.fanbox.core.model.fanbox.PostDetail
+import me.matsumo.fanbox.core.model.fanbox.PostId
 import me.matsumo.fanbox.core.model.toScreenStateError
 import me.matsumo.fanbox.core.repository.DownloadPostsRepository
 import me.matsumo.fanbox.core.repository.FanboxRepository
-import me.matsumo.fankt.fanbox.domain.model.FanboxPostDetail
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxPostId
 
 class PostImageViewModel(
     private val fanboxRepository: FanboxRepository,
@@ -23,7 +23,7 @@ class PostImageViewModel(
 
     val screenState = _screenState.asStateFlow()
 
-    fun fetch(postId: FanboxPostId) {
+    fun fetch(postId: PostId) {
         viewModelScope.launch {
             _screenState.value = ScreenState.Loading
             _screenState.value = suspendRunCatching {
@@ -37,12 +37,12 @@ class PostImageViewModel(
         }
     }
 
-    fun downloadImages(postId: FanboxPostId, title: String, imageItems: List<FanboxPostDetail.ImageItem>) {
+    fun downloadImages(postId: PostId, title: String, imageItems: List<PostDetail.ImageItem>) {
         downloadPostsRepository.requestDownloadImages(postId, title, imageItems)
     }
 }
 
 @Stable
 data class PostImageUiState(
-    val postDetail: FanboxPostDetail,
+    val postDetail: PostDetail,
 )

--- a/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/queue/components/DownloadQueueItem.kt
+++ b/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/queue/components/DownloadQueueItem.kt
@@ -80,7 +80,7 @@ internal fun DownloadQueueItem(
     val actualThumbnailItems: List<@Composable () -> Unit> = when (val type = items.requestType) {
         FanboxDownloadItems.RequestType.File -> thumbnailItems
         FanboxDownloadItems.RequestType.Image -> thumbnailItems
-        is FanboxDownloadItems.RequestType.Post -> {
+        is FanboxDownloadItems.RequestType.WholePost -> {
             listOf(
                 {
                     CoverThumbnail(
@@ -132,7 +132,7 @@ internal fun DownloadQueueItem(
                         }
 
                         else -> {
-                            if (items.requestType is FanboxDownloadItems.RequestType.Post) {
+                            if (items.requestType is FanboxDownloadItems.RequestType.WholePost) {
                                 stringResource(Res.string.queue_item_post)
                             } else {
                                 stringResource(Res.string.unit_tag, items.items.size)

--- a/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/search/common/PostSearchScreen.kt
+++ b/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/search/common/PostSearchScreen.kt
@@ -18,16 +18,16 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 import me.matsumo.fanbox.core.model.Destination
 import me.matsumo.fanbox.core.model.Setting
+import me.matsumo.fanbox.core.model.fanbox.CreatorDetail
+import me.matsumo.fanbox.core.model.fanbox.CreatorId
+import me.matsumo.fanbox.core.model.fanbox.Post
+import me.matsumo.fanbox.core.model.fanbox.PostId
+import me.matsumo.fanbox.core.model.fanbox.Tag
+import me.matsumo.fanbox.core.model.fanbox.UserId
 import me.matsumo.fanbox.core.ui.extensition.NavigatorExtension
 import me.matsumo.fanbox.feature.post.search.common.items.PostSearchCreatorScreen
 import me.matsumo.fanbox.feature.post.search.common.items.PostSearchTagScreen
 import me.matsumo.fanbox.feature.post.search.common.items.PostSearchTopBar
-import me.matsumo.fankt.fanbox.domain.model.FanboxCreatorDetail
-import me.matsumo.fankt.fanbox.domain.model.FanboxPost
-import me.matsumo.fankt.fanbox.domain.model.FanboxTag
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxCreatorId
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxPostId
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxUserId
 import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 
@@ -70,7 +70,7 @@ internal fun PostSearchRoute(
         onClickSupporting = { navigatorExtension.navigateToWebPage(it, "") },
         onSearch = {
             if (uiState.query.isNotBlank()) {
-                navigateTo(Destination.PostSearch(it.creatorId ?: FanboxCreatorId(""), it.creatorQuery, it.tag))
+                navigateTo(Destination.PostSearch(it.creatorId ?: CreatorId(""), it.creatorQuery, it.tag))
             } else {
                 viewModel.search(it)
             }
@@ -84,19 +84,19 @@ private fun PostSearchScreen(
     query: String,
     initialQuery: String,
     setting: Setting,
-    bookmarkedPosts: ImmutableList<FanboxPostId>,
-    suggestTags: ImmutableList<FanboxTag>,
-    creatorPaging: LazyPagingItems<FanboxCreatorDetail>,
-    tagPaging: LazyPagingItems<FanboxPost>,
+    bookmarkedPosts: ImmutableList<PostId>,
+    suggestTags: ImmutableList<Tag>,
+    creatorPaging: LazyPagingItems<CreatorDetail>,
+    tagPaging: LazyPagingItems<Post>,
     onSearch: (PostSearchQuery) -> Unit,
     onTerminate: () -> Unit,
-    onClickPost: (FanboxPostId) -> Unit,
-    onClickPostLike: (FanboxPostId) -> Unit,
-    onClickPostBookmark: (FanboxPost, Boolean) -> Unit,
-    onClickCreatorPosts: (FanboxCreatorId) -> Unit,
-    onClickCreatorPlans: (FanboxCreatorId) -> Unit,
-    onClickFollow: suspend (FanboxUserId) -> Result<Unit>,
-    onClickUnfollow: suspend (FanboxUserId) -> Result<Unit>,
+    onClickPost: (PostId) -> Unit,
+    onClickPostLike: (PostId) -> Unit,
+    onClickPostBookmark: (Post, Boolean) -> Unit,
+    onClickCreatorPosts: (CreatorId) -> Unit,
+    onClickCreatorPlans: (CreatorId) -> Unit,
+    onClickFollow: suspend (UserId) -> Result<Unit>,
+    onClickUnfollow: suspend (UserId) -> Result<Unit>,
     onClickSupporting: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -155,7 +155,7 @@ private fun PostSearchScreen(
 }
 
 internal fun buildQuery(
-    creatorId: FanboxCreatorId,
+    creatorId: CreatorId,
     creatorQuery: String?,
     tag: String?,
 ): String {
@@ -178,7 +178,7 @@ internal fun buildQuery(
 
 internal fun buildQuery(query: PostSearchQuery): String {
     return buildQuery(
-        creatorId = query.creatorId ?: FanboxCreatorId(""),
+        creatorId = query.creatorId ?: CreatorId(""),
         creatorQuery = query.creatorQuery,
         tag = query.tag,
     )
@@ -188,7 +188,7 @@ internal fun parseQuery(query: String): PostSearchQuery {
     val queryList = query.split(" ").filter { it.isNotBlank() }
 
     var mode = PostSearchMode.Unknown
-    var creatorId: FanboxCreatorId? = null
+    var creatorId: CreatorId? = null
     var creatorQuery: String? = null
     var tag: String? = null
 
@@ -196,7 +196,7 @@ internal fun parseQuery(query: String): PostSearchQuery {
         when {
             it.startsWith("from:@") -> {
                 mode = PostSearchMode.Tag
-                creatorId = FanboxCreatorId(it.removePrefix("from:@"))
+                creatorId = CreatorId(it.removePrefix("from:@"))
             }
 
             it.startsWith("#") -> {

--- a/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/search/common/PostSearchViewModel.kt
+++ b/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/search/common/PostSearchViewModel.kt
@@ -13,15 +13,15 @@ import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
 import me.matsumo.fanbox.core.common.util.suspendRunCatching
 import me.matsumo.fanbox.core.model.Setting
+import me.matsumo.fanbox.core.model.fanbox.CreatorDetail
+import me.matsumo.fanbox.core.model.fanbox.CreatorId
+import me.matsumo.fanbox.core.model.fanbox.Post
+import me.matsumo.fanbox.core.model.fanbox.PostId
+import me.matsumo.fanbox.core.model.fanbox.Tag
+import me.matsumo.fanbox.core.model.fanbox.UserId
 import me.matsumo.fanbox.core.repository.FanboxRepository
 import me.matsumo.fanbox.core.repository.SettingRepository
 import me.matsumo.fanbox.core.ui.extensition.emptyPaging
-import me.matsumo.fankt.fanbox.domain.model.FanboxCreatorDetail
-import me.matsumo.fankt.fanbox.domain.model.FanboxPost
-import me.matsumo.fankt.fanbox.domain.model.FanboxTag
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxCreatorId
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxPostId
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxUserId
 
 class PostSearchViewModel(
     private val settingRepository: SettingRepository,
@@ -94,19 +94,19 @@ class PostSearchViewModel(
         }
     }
 
-    suspend fun follow(creatorUserId: FanboxUserId): Result<Unit> {
+    suspend fun follow(creatorUserId: UserId): Result<Unit> {
         return suspendRunCatching {
             fanboxRepository.followCreator(creatorUserId)
         }
     }
 
-    suspend fun unfollow(creatorUserId: FanboxUserId): Result<Unit> {
+    suspend fun unfollow(creatorUserId: UserId): Result<Unit> {
         return suspendRunCatching {
             fanboxRepository.unfollowCreator(creatorUserId)
         }
     }
 
-    fun postLike(postId: FanboxPostId) {
+    fun postLike(postId: PostId) {
         viewModelScope.launch {
             suspendRunCatching {
                 fanboxRepository.likePost(postId)
@@ -114,7 +114,7 @@ class PostSearchViewModel(
         }
     }
 
-    fun postBookmark(post: FanboxPost, isBookmarked: Boolean) {
+    fun postBookmark(post: Post, isBookmarked: Boolean) {
         viewModelScope.launch {
             suspendRunCatching {
                 if (isBookmarked) {
@@ -131,11 +131,11 @@ class PostSearchViewModel(
 data class PostSearchUiState(
     val query: String,
     val setting: Setting,
-    val bookmarkedPosts: List<FanboxPostId>,
-    val suggestTags: List<FanboxTag>,
-    val creatorPaging: Flow<PagingData<FanboxCreatorDetail>>,
-    val tagPaging: Flow<PagingData<FanboxPost>>,
-    val postPaging: Flow<PagingData<FanboxPost>>,
+    val bookmarkedPosts: List<PostId>,
+    val suggestTags: List<Tag>,
+    val creatorPaging: Flow<PagingData<CreatorDetail>>,
+    val tagPaging: Flow<PagingData<Post>>,
+    val postPaging: Flow<PagingData<Post>>,
 )
 
 enum class PostSearchMode {
@@ -148,7 +148,7 @@ enum class PostSearchMode {
 @Serializable
 data class PostSearchQuery(
     val mode: PostSearchMode,
-    val creatorId: FanboxCreatorId?,
+    val creatorId: CreatorId?,
     val creatorQuery: String?,
     val postQuery: String?,
     val tag: String?,

--- a/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/search/common/items/PostSearchCreatorScreen.kt
+++ b/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/search/common/items/PostSearchCreatorScreen.kt
@@ -29,6 +29,10 @@ import app.cash.paging.compose.itemContentType
 import app.cash.paging.compose.itemKey
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.launch
+import me.matsumo.fanbox.core.model.fanbox.CreatorDetail
+import me.matsumo.fanbox.core.model.fanbox.CreatorId
+import me.matsumo.fanbox.core.model.fanbox.Tag
+import me.matsumo.fanbox.core.model.fanbox.UserId
 import me.matsumo.fanbox.core.resources.Res
 import me.matsumo.fanbox.core.resources.common_creator
 import me.matsumo.fanbox.core.resources.common_tag
@@ -40,20 +44,16 @@ import me.matsumo.fanbox.core.ui.extensition.PixiViewNavigationType
 import me.matsumo.fanbox.core.ui.extensition.drawVerticalScrollbar
 import me.matsumo.fanbox.core.ui.theme.bold
 import me.matsumo.fanbox.core.ui.view.PagingErrorSection
-import me.matsumo.fankt.fanbox.domain.model.FanboxCreatorDetail
-import me.matsumo.fankt.fanbox.domain.model.FanboxTag
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxCreatorId
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxUserId
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
 internal fun PostSearchCreatorScreen(
-    pagingAdapter: LazyPagingItems<FanboxCreatorDetail>,
-    suggestTags: ImmutableList<FanboxTag>,
-    onClickCreator: (FanboxCreatorId) -> Unit,
+    pagingAdapter: LazyPagingItems<CreatorDetail>,
+    suggestTags: ImmutableList<Tag>,
+    onClickCreator: (CreatorId) -> Unit,
     onClickTag: (String) -> Unit,
-    onClickFollow: suspend (FanboxUserId) -> Result<Unit>,
-    onClickUnfollow: suspend (FanboxUserId) -> Result<Unit>,
+    onClickFollow: suspend (UserId) -> Result<Unit>,
+    onClickUnfollow: suspend (UserId) -> Result<Unit>,
     onClickSupporting: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {

--- a/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/search/common/items/PostSearchSuggestTagsSection.kt
+++ b/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/search/common/items/PostSearchSuggestTagsSection.kt
@@ -27,16 +27,16 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.ImmutableList
+import me.matsumo.fanbox.core.model.fanbox.Tag
 import me.matsumo.fanbox.core.resources.Res
 import me.matsumo.fanbox.core.resources.common_see_more
 import me.matsumo.fanbox.core.resources.unit_tag
 import me.matsumo.fanbox.core.ui.theme.bold
-import me.matsumo.fankt.fanbox.domain.model.FanboxTag
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
 internal fun PostSearchSuggestTagsSection(
-    suggestTags: ImmutableList<FanboxTag>,
+    suggestTags: ImmutableList<Tag>,
     onClickTag: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -83,7 +83,7 @@ internal fun PostSearchSuggestTagsSection(
 
 @Composable
 private fun TagItem(
-    tag: FanboxTag,
+    tag: Tag,
     onClickTag: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {

--- a/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/search/common/items/PostSearchTagScreen.kt
+++ b/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/search/common/items/PostSearchTagScreen.kt
@@ -21,6 +21,9 @@ import app.cash.paging.compose.itemContentType
 import app.cash.paging.compose.itemKey
 import kotlinx.collections.immutable.ImmutableList
 import me.matsumo.fanbox.core.model.Setting
+import me.matsumo.fanbox.core.model.fanbox.CreatorId
+import me.matsumo.fanbox.core.model.fanbox.Post
+import me.matsumo.fanbox.core.model.fanbox.PostId
 import me.matsumo.fanbox.core.resources.Res
 import me.matsumo.fanbox.core.resources.error_no_data_search
 import me.matsumo.fanbox.core.ui.LazyPagingItemsLoadContents
@@ -29,20 +32,17 @@ import me.matsumo.fanbox.core.ui.extensition.LocalNavigationType
 import me.matsumo.fanbox.core.ui.extensition.PixiViewNavigationType
 import me.matsumo.fanbox.core.ui.extensition.drawVerticalScrollbar
 import me.matsumo.fanbox.core.ui.view.PagingErrorSection
-import me.matsumo.fankt.fanbox.domain.model.FanboxPost
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxCreatorId
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxPostId
 
 @Composable
 internal fun PostSearchTagScreen(
-    pagingAdapter: LazyPagingItems<FanboxPost>,
+    pagingAdapter: LazyPagingItems<Post>,
     setting: Setting,
-    bookmarkedPosts: ImmutableList<FanboxPostId>,
-    onClickPost: (FanboxPostId) -> Unit,
-    onClickPostLike: (FanboxPostId) -> Unit,
-    onClickPostBookmark: (FanboxPost, Boolean) -> Unit,
-    onClickCreator: (FanboxCreatorId) -> Unit,
-    onClickPlanList: (FanboxCreatorId) -> Unit,
+    bookmarkedPosts: ImmutableList<PostId>,
+    onClickPost: (PostId) -> Unit,
+    onClickPostLike: (PostId) -> Unit,
+    onClickPostBookmark: (Post, Boolean) -> Unit,
+    onClickCreator: (CreatorId) -> Unit,
+    onClickPlanList: (CreatorId) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current

--- a/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/search/common/paging/PostSearchCreatorPagingSource.kt
+++ b/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/search/common/paging/PostSearchCreatorPagingSource.kt
@@ -3,17 +3,17 @@ package me.matsumo.fanbox.feature.post.search.common.paging
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
 import me.matsumo.fanbox.core.common.util.suspendRunCatching
+import me.matsumo.fanbox.core.model.fanbox.CreatorDetail
 import me.matsumo.fanbox.core.repository.FanboxRepository
-import me.matsumo.fankt.fanbox.domain.model.FanboxCreatorDetail
 
 class PostSearchCreatorPagingSource(
     private val fanboxRepository: FanboxRepository,
     private val query: String,
-) : PagingSource<Int, FanboxCreatorDetail>() {
+) : PagingSource<Int, CreatorDetail>() {
 
     override val keyReuseSupported: Boolean = true
 
-    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, FanboxCreatorDetail> {
+    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, CreatorDetail> {
         return suspendRunCatching {
             fanboxRepository.getCreatorFromQuery(query, params.key ?: 0)
         }.fold(
@@ -30,5 +30,5 @@ class PostSearchCreatorPagingSource(
         )
     }
 
-    override fun getRefreshKey(state: PagingState<Int, FanboxCreatorDetail>): Int? = null
+    override fun getRefreshKey(state: PagingState<Int, CreatorDetail>): Int? = null
 }

--- a/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/search/creator/PostByCreatorSearchScreen.kt
+++ b/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/search/creator/PostByCreatorSearchScreen.kt
@@ -37,6 +37,11 @@ import kotlinx.coroutines.launch
 import me.matsumo.fanbox.core.common.util.format
 import me.matsumo.fanbox.core.model.Destination
 import me.matsumo.fanbox.core.model.Setting
+import me.matsumo.fanbox.core.model.fanbox.CreatorDetail
+import me.matsumo.fanbox.core.model.fanbox.CreatorId
+import me.matsumo.fanbox.core.model.fanbox.Post
+import me.matsumo.fanbox.core.model.fanbox.PostId
+import me.matsumo.fanbox.core.model.fanbox.UserId
 import me.matsumo.fanbox.core.resources.Res
 import me.matsumo.fanbox.core.resources.creator_posts_download_dialog_title
 import me.matsumo.fanbox.core.resources.error_no_data
@@ -49,11 +54,6 @@ import me.matsumo.fanbox.core.ui.extensition.plus
 import me.matsumo.fanbox.core.ui.theme.bold
 import me.matsumo.fanbox.core.ui.view.ErrorView
 import me.matsumo.fanbox.feature.post.search.common.items.PostSearchTopBar
-import me.matsumo.fankt.fanbox.domain.model.FanboxCreatorDetail
-import me.matsumo.fankt.fanbox.domain.model.FanboxPost
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxCreatorId
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxPostId
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxUserId
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
@@ -102,20 +102,20 @@ internal fun PostByCreatorSearchRoute(
 private fun PostByCreatorSearchScreen(
     query: String,
     setting: Setting,
-    creatorDetail: FanboxCreatorDetail,
-    searchedPosts: ImmutableList<FanboxPost>,
-    bookmarkedPostIds: ImmutableList<FanboxPostId>,
+    creatorDetail: CreatorDetail,
+    searchedPosts: ImmutableList<Post>,
+    bookmarkedPostIds: ImmutableList<PostId>,
     progress: Float,
     isPrepared: Boolean,
     onQueryChanged: (String) -> Unit,
-    onPostClicked: (FanboxPostId) -> Unit,
-    onCreatorPostsClicked: (FanboxCreatorId) -> Unit,
-    onCreatorPlansClicked: (FanboxCreatorId) -> Unit,
-    onFollowClicked: suspend (FanboxUserId) -> Result<Unit>,
-    onUnfollowClicked: suspend (FanboxUserId) -> Result<Unit>,
+    onPostClicked: (PostId) -> Unit,
+    onCreatorPostsClicked: (CreatorId) -> Unit,
+    onCreatorPlansClicked: (CreatorId) -> Unit,
+    onFollowClicked: suspend (UserId) -> Result<Unit>,
+    onUnfollowClicked: suspend (UserId) -> Result<Unit>,
     onSupportingClicked: (String) -> Unit,
-    onLikeClicked: (FanboxPostId) -> Unit,
-    onBookmarkClicked: (FanboxPost, Boolean) -> Unit,
+    onLikeClicked: (PostId) -> Unit,
+    onBookmarkClicked: (Post, Boolean) -> Unit,
     onBackClicked: () -> Unit,
     modifier: Modifier = Modifier,
 ) {

--- a/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/search/creator/PostByCreatorSearchViewModel.kt
+++ b/feature/post/src/commonMain/kotlin/me/matsumo/fanbox/feature/post/search/creator/PostByCreatorSearchViewModel.kt
@@ -19,16 +19,16 @@ import me.matsumo.fanbox.core.common.util.suspendRunCatching
 import me.matsumo.fanbox.core.model.Destination
 import me.matsumo.fanbox.core.model.ScreenState
 import me.matsumo.fanbox.core.model.Setting
+import me.matsumo.fanbox.core.model.fanbox.CreatorDetail
+import me.matsumo.fanbox.core.model.fanbox.CreatorId
+import me.matsumo.fanbox.core.model.fanbox.Post
+import me.matsumo.fanbox.core.model.fanbox.PostId
+import me.matsumo.fanbox.core.model.fanbox.UserId
 import me.matsumo.fanbox.core.model.toScreenStateError
 import me.matsumo.fanbox.core.model.updateWhenIdle
 import me.matsumo.fanbox.core.repository.FanboxRepository
 import me.matsumo.fanbox.core.repository.SettingRepository
 import me.matsumo.fanbox.core.ui.customNavTypes
-import me.matsumo.fankt.fanbox.domain.model.FanboxCreatorDetail
-import me.matsumo.fankt.fanbox.domain.model.FanboxPost
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxCreatorId
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxPostId
-import me.matsumo.fankt.fanbox.domain.model.id.FanboxUserId
 
 class PostByCreatorSearchViewModel(
     savedStateHandle: SavedStateHandle,
@@ -39,7 +39,7 @@ class PostByCreatorSearchViewModel(
 
     private val creatorId = savedStateHandle.toRoute<Destination.PostByCreatorSearch>(customNavTypes).creatorId
 
-    private val _allPosts = MutableSharedFlow<List<FanboxPost>>(replay = 1)
+    private val _allPosts = MutableSharedFlow<List<Post>>(replay = 1)
     private val _query = MutableStateFlow("")
     private val _screenState = MutableStateFlow<ScreenState<PostByCreatorSearchUiState>>(ScreenState.Loading)
 
@@ -86,7 +86,7 @@ class PostByCreatorSearchViewModel(
             return
         }
 
-        val posts = mutableListOf<FanboxPost>()
+        val posts = mutableListOf<Post>()
         val paginate = withContext(ioDispatcher) { fanboxRepository.getCreatorPostsPagination(creatorId) }
         val max = paginate.sumOf { it.limit ?: 10 }
 
@@ -113,7 +113,7 @@ class PostByCreatorSearchViewModel(
         }
     }
 
-    private suspend fun searchPosts(query: String): List<FanboxPost> {
+    private suspend fun searchPosts(query: String): List<Post> {
         return _allPosts.first().filter { post ->
             val title = post.title.contains(query)
             val excerpt = post.excerpt.contains(query)
@@ -127,19 +127,19 @@ class PostByCreatorSearchViewModel(
         _query.value = query
     }
 
-    suspend fun follow(creatorUserId: FanboxUserId): Result<Unit> {
+    suspend fun follow(creatorUserId: UserId): Result<Unit> {
         return suspendRunCatching {
             fanboxRepository.unfollowCreator(creatorUserId)
         }
     }
 
-    suspend fun unfollow(creatorUserId: FanboxUserId): Result<Unit> {
+    suspend fun unfollow(creatorUserId: UserId): Result<Unit> {
         return suspendRunCatching {
             fanboxRepository.unfollowCreator(creatorUserId)
         }
     }
 
-    fun postLike(postId: FanboxPostId) {
+    fun postLike(postId: PostId) {
         viewModelScope.launch {
             suspendRunCatching {
                 fanboxRepository.likePost(postId)
@@ -147,7 +147,7 @@ class PostByCreatorSearchViewModel(
         }
     }
 
-    fun postBookmark(post: FanboxPost, isBookmarked: Boolean) {
+    fun postBookmark(post: Post, isBookmarked: Boolean) {
         viewModelScope.launch {
             (screenState.value as? ScreenState.Idle)?.also {
                 if (isBookmarked) {
@@ -162,11 +162,11 @@ class PostByCreatorSearchViewModel(
 
 @Stable
 data class PostByCreatorSearchUiState(
-    val creatorId: FanboxCreatorId,
-    val creatorDetail: FanboxCreatorDetail,
+    val creatorId: CreatorId,
+    val creatorDetail: CreatorDetail,
     val setting: Setting,
-    val bookmarkedPostsIds: List<FanboxPostId>,
-    val searchedPosts: List<FanboxPost>,
+    val bookmarkedPostsIds: List<PostId>,
+    val searchedPosts: List<Post>,
     val progress: Float,
     val isPrepared: Boolean,
 )

--- a/feature/setting/src/commonMain/kotlin/me/matsumo/fanbox/feature/setting/directory/SettingDirectoryViewModel.kt
+++ b/feature/setting/src/commonMain/kotlin/me/matsumo/fanbox/feature/setting/directory/SettingDirectoryViewModel.kt
@@ -22,7 +22,7 @@ class SettingDirectoryViewModel(
             SettingDirectoryUiState(
                 imageDirectory = downloadPostsRepository.getSaveDirectory(FanboxDownloadItems.RequestType.Image),
                 fileDirectory = downloadPostsRepository.getSaveDirectory(FanboxDownloadItems.RequestType.File),
-                postDirectory = downloadPostsRepository.getSaveDirectory(FanboxDownloadItems.RequestType.Post(null, false)),
+                postDirectory = downloadPostsRepository.getSaveDirectory(FanboxDownloadItems.RequestType.WholePost(null, false)),
             ),
         )
     }.stateIn(

--- a/feature/setting/src/commonMain/kotlin/me/matsumo/fanbox/feature/setting/top/SettingTopScreen.kt
+++ b/feature/setting/src/commonMain/kotlin/me/matsumo/fanbox/feature/setting/top/SettingTopScreen.kt
@@ -31,6 +31,7 @@ import me.matsumo.fanbox.core.model.Destination
 import me.matsumo.fanbox.core.model.DownloadFileType
 import me.matsumo.fanbox.core.model.Setting
 import me.matsumo.fanbox.core.model.SimpleAlertContents
+import me.matsumo.fanbox.core.model.fanbox.MetaData
 import me.matsumo.fanbox.core.resources.Res
 import me.matsumo.fanbox.core.resources.billing_plus_toast_require_plus
 import me.matsumo.fanbox.core.resources.setting_title
@@ -48,7 +49,6 @@ import me.matsumo.fanbox.feature.setting.top.items.SettingTopGeneralSection
 import me.matsumo.fanbox.feature.setting.top.items.SettingTopInformationSection
 import me.matsumo.fanbox.feature.setting.top.items.SettingTopOthersSection
 import me.matsumo.fanbox.feature.setting.top.items.SettingTopThemeSection
-import me.matsumo.fankt.fanbox.domain.model.FanboxMetaData
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
@@ -163,7 +163,7 @@ internal fun SettingTopRoute(
 @Composable
 private fun SettingTopScreen(
     setting: Setting,
-    metaData: FanboxMetaData,
+    metaData: MetaData,
     fanboxSessionId: String,
     config: PixiViewConfig,
     onClickThemeSetting: () -> Unit,

--- a/feature/setting/src/commonMain/kotlin/me/matsumo/fanbox/feature/setting/top/SettingTopViewModel.kt
+++ b/feature/setting/src/commonMain/kotlin/me/matsumo/fanbox/feature/setting/top/SettingTopViewModel.kt
@@ -16,6 +16,7 @@ import me.matsumo.fanbox.core.model.DownloadFileType
 import me.matsumo.fanbox.core.model.Flag
 import me.matsumo.fanbox.core.model.ScreenState
 import me.matsumo.fanbox.core.model.Setting
+import me.matsumo.fanbox.core.model.fanbox.MetaData
 import me.matsumo.fanbox.core.repository.FanboxRepository
 import me.matsumo.fanbox.core.repository.FlagRepository
 import me.matsumo.fanbox.core.repository.SettingRepository
@@ -24,7 +25,6 @@ import me.matsumo.fanbox.core.resources.error_no_data
 import me.matsumo.fanbox.core.resources.home_app_lock_message
 import me.matsumo.fanbox.core.resources.home_app_lock_title
 import me.matsumo.fanbox.core.ui.extensition.getFanboxMetadataDummy
-import me.matsumo.fankt.fanbox.domain.model.FanboxMetaData
 import org.jetbrains.compose.resources.getString
 
 class SettingTopViewModel(
@@ -139,7 +139,7 @@ class SettingTopViewModel(
 @Stable
 data class SettingTopUiState(
     val setting: Setting,
-    val metaData: FanboxMetaData,
+    val metaData: MetaData,
     val fanboxSessionId: String,
     val config: PixiViewConfig,
 )

--- a/feature/setting/src/commonMain/kotlin/me/matsumo/fanbox/feature/setting/top/items/SettingTopInformationSection.kt
+++ b/feature/setting/src/commonMain/kotlin/me/matsumo/fanbox/feature/setting/top/items/SettingTopInformationSection.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.text.AnnotatedString
 import me.matsumo.fanbox.core.common.PixiViewConfig
 import me.matsumo.fanbox.core.model.Setting
+import me.matsumo.fanbox.core.model.fanbox.MetaData
 import me.matsumo.fanbox.core.resources.Res
 import me.matsumo.fanbox.core.resources.setting_top_information
 import me.matsumo.fanbox.core.resources.setting_top_information_csrf_token
@@ -15,13 +16,12 @@ import me.matsumo.fanbox.core.resources.setting_top_information_fanbox_session_i
 import me.matsumo.fanbox.core.resources.setting_top_information_id
 import me.matsumo.fanbox.core.resources.setting_top_information_version
 import me.matsumo.fanbox.core.ui.component.SettingTextItem
-import me.matsumo.fankt.fanbox.domain.model.FanboxMetaData
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
 internal fun SettingTopInformationSection(
     setting: Setting,
-    fanboxMetaData: FanboxMetaData,
+    fanboxMetaData: MetaData,
     fanboxSessionId: String,
     config: PixiViewConfig,
     modifier: Modifier = Modifier,

--- a/openspec/changes/replace-fankt-models-with-app-owned/tasks.md
+++ b/openspec/changes/replace-fankt-models-with-app-owned/tasks.md
@@ -31,28 +31,28 @@
 
 ## 4. 公開契約の置き換え（段 3 / `-swap`）
 
-- [ ] 4.1 `FanboxRepository` の interface とその実装をアプリ所有のモデルへ差し替え、`BookmarkDataStore` / `BlockDataStore` との境界で変換する
-- [ ] 4.2 `core/repository/paging/` の 5 本の `PagingSource` を差し替える
-- [ ] 4.3 `TranslationRepository` の `translate` 2 つと、`DownloadPostsRepository` の interface および android / ios の実装を差し替える（D5）
-- [ ] 4.4 `core/model` の既存ファイル（`Destination` / `FanboxDownloadItems` / `PostDownloader` / `TransPostDetail` / `TransComments`）を差し替え、`RequestType.Post` を `WholePost` へ改名する（D8）
-- [ ] 4.5 `core/ui` の 6 ファイルを差し替える（`NavTypes` の符号化が変わらないことを含む）
-- [ ] 4.6 `feature/post` 27 ファイルを差し替える
-- [ ] 4.7 `feature/creator` 21 ファイルを差し替える
-- [ ] 4.8 `feature/library` 14 ファイルを差し替える
-- [ ] 4.9 `feature/setting` 3 / `feature/welcome` 1 / `shared` 1 を差し替える
+- [x] 4.1 `FanboxRepository` の interface とその実装をアプリ所有のモデルへ差し替え、`BookmarkDataStore` / `BlockDataStore` との境界で変換する
+- [x] 4.2 `core/repository/paging/` の 5 本の `PagingSource` を差し替える
+- [x] 4.3 `TranslationRepository` の `translate` 2 つと、`DownloadPostsRepository` の interface および android / ios の実装を差し替える（D5）
+- [x] 4.4 `core/model` の既存ファイル（`Destination` / `FanboxDownloadItems` / `PostDownloader` / `TransPostDetail` / `TransComments`）を差し替え、`RequestType.Post` を `WholePost` へ改名する（D8）
+- [x] 4.5 `core/ui` の 6 ファイルを差し替える（`NavTypes` の符号化が変わらないことを含む）
+- [x] 4.6 `feature/post` 27 ファイルを差し替える
+- [x] 4.7 `feature/creator` 21 ファイルを差し替える
+- [x] 4.8 `feature/library` 14 ファイルを差し替える
+- [x] 4.9 `feature/setting` 3 / `feature/welcome` 1 / `shared` 1 を差し替える
 
 ## 5. 永続化の非退行（段 3 / `-swap`）
 
-- [ ] 5.1 `core/datastore` が変更されていないことを確認する
-- [ ] 5.2 置き換え前の形式で保存されたブックマーク JSON が読めることを固定する
-- [ ] 5.3 保存される JSON が置き換え前と同じ形式であることを固定する
-- [ ] 5.4 ブロック済みクリエイターが読めることを固定する
-- [ ] 5.5 `PostId` / `CreatorId` の画面遷移引数の符号化が変わらないことを固定する
+- [x] 5.1 `core/datastore` が変更されていないことを確認する
+- [x] 5.2 置き換え前の形式で保存されたブックマーク JSON が読めることを固定する
+- [x] 5.3 保存される JSON が置き換え前と同じ形式であることを固定する
+- [x] 5.4 ブロック済みクリエイターが読めることを固定する
+- [x] 5.5 `PostId` / `CreatorId` の画面遷移引数の符号化が変わらないことを固定する
 
 ## 6. 検証とドキュメント（段 3 / `-swap`）
 
-- [ ] 6.1 `feature/*` / `core/ui` / `core/model` / `shared` に `me.matsumo.fankt.fanbox.domain` の import が残っていないことを走査で確認する
-- [ ] 6.2 `./gradlew detekt` と既存テストを通す
-- [ ] 6.3 Android と iOS の両方でコンパイルが通ることを確認する
-- [ ] 6.4 `README.md` の Architecture 節に `core/model` と `core/repository` の責務を反映する
-- [ ] 6.5 変更した機能名・クラス名で `docs/` と `README.md` を走査し、誤りになった記述がないか確認する
+- [x] 6.1 `feature/*` / `core/ui` / `core/model` / `shared` に `me.matsumo.fankt.fanbox.domain` の import が残っていないことを走査で確認する
+- [x] 6.2 `./gradlew detekt` と既存テストを通す
+- [x] 6.3 Android と iOS の両方でコンパイルが通ることを確認する
+- [x] 6.4 `README.md` の Architecture 節に `core/model` と `core/repository` の責務を反映する
+- [x] 6.5 変更した機能名・クラス名で `docs/` と `README.md` を走査し、誤りになった記述がないか確認する

--- a/openspec/changes/replace-fankt-models-with-app-owned/tasks.md
+++ b/openspec/changes/replace-fankt-models-with-app-owned/tasks.md
@@ -18,7 +18,7 @@
 ## 2. 変換層（段 2 / `-defs`）
 
 - [x] 2.1 `core/repository/src/commonMain/.../repository/mapper/` に fankt → app の変換を全型分置く
-- [x] 2.2 app → fankt の変換を D5 の 4 種（ID / `Post` / `Cursor`、およびページング型）に限って置く
+- [x] 2.2 app → fankt の変換を D5 の表が挙げる 3 種（ID 4 つ / `Post` / `Cursor`）に限って置く
 - [x] 2.3 `PostDetail.Body` と記事ブロックの変換を、`when` を exhaustive に書いて全 variant 分置く
 
 ## 3. 変換のテスト（段 2 / `-defs`）
@@ -39,7 +39,7 @@
 - [x] 4.6 `feature/post` 27 ファイルを差し替える
 - [x] 4.7 `feature/creator` 21 ファイルを差し替える
 - [x] 4.8 `feature/library` 14 ファイルを差し替える
-- [x] 4.9 `feature/setting` 3 / `feature/welcome` 1 / `shared` 1 を差し替える
+- [x] 4.9 `feature/setting` と `shared` を差し替える（`feature/welcome` の fankt 参照は cookie の契約のみで対象外）
 
 ## 5. 永続化の非退行（段 3 / `-swap`）
 

--- a/openspec/changes/replace-fankt-models-with-app-owned/tasks.md
+++ b/openspec/changes/replace-fankt-models-with-app-owned/tasks.md
@@ -18,7 +18,7 @@
 ## 2. 変換層（段 2 / `-defs`）
 
 - [x] 2.1 `core/repository/src/commonMain/.../repository/mapper/` に fankt → app の変換を全型分置く
-- [x] 2.2 app → fankt の変換を D5 の表が挙げる 3 種（ID 4 つ / `Post` / `Cursor`）に限って置く
+- [x] 2.2 app → fankt の変換を D5 の 4 種（ID / `Post` / `Cursor`、およびページング型）に限って置く
 - [x] 2.3 `PostDetail.Body` と記事ブロックの変換を、`when` を exhaustive に書いて全 variant 分置く
 
 ## 3. 変換のテスト（段 2 / `-defs`）
@@ -39,7 +39,7 @@
 - [ ] 4.6 `feature/post` 27 ファイルを差し替える
 - [ ] 4.7 `feature/creator` 21 ファイルを差し替える
 - [ ] 4.8 `feature/library` 14 ファイルを差し替える
-- [ ] 4.9 `feature/setting` と `shared` を差し替える（`feature/welcome` の fankt 参照は cookie の契約のみで対象外）
+- [ ] 4.9 `feature/setting` 3 / `feature/welcome` 1 / `shared` 1 を差し替える
 
 ## 5. 永続化の非退行（段 3 / `-swap`）
 

--- a/shared/src/commonMain/kotlin/me/matsumo/fanbox/PixiViewViewModel.kt
+++ b/shared/src/commonMain/kotlin/me/matsumo/fanbox/PixiViewViewModel.kt
@@ -26,6 +26,7 @@ import me.matsumo.fanbox.core.logs.logger.send
 import me.matsumo.fanbox.core.model.DownloadState
 import me.matsumo.fanbox.core.model.ScreenState
 import me.matsumo.fanbox.core.model.Setting
+import me.matsumo.fanbox.core.model.fanbox.MetaData
 import me.matsumo.fanbox.core.repository.DownloadPostsRepository
 import me.matsumo.fanbox.core.repository.FanboxRepository
 import me.matsumo.fanbox.core.repository.SettingRepository
@@ -34,7 +35,6 @@ import me.matsumo.fanbox.core.resources.error_no_data
 import me.matsumo.fanbox.core.resources.home_app_lock_message
 import me.matsumo.fanbox.core.resources.home_app_lock_title
 import me.matsumo.fanbox.core.ui.extensition.getFanboxMetadataDummy
-import me.matsumo.fankt.fanbox.domain.model.FanboxMetaData
 import org.jetbrains.compose.resources.getString
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.minutes
@@ -53,7 +53,7 @@ class PixiViewViewModel(
 
     private val _isLoggedInFlow: MutableSharedFlow<Boolean> = MutableSharedFlow(replay = 1)
     private val _isAppLockedFlow: MutableStateFlow<Boolean> = MutableStateFlow(true)
-    private val _metadataFlow: MutableStateFlow<FanboxMetaData> = MutableStateFlow(getFanboxMetadataDummy())
+    private val _metadataFlow: MutableStateFlow<MetaData> = MutableStateFlow(getFanboxMetadataDummy())
     private val _isBillingSyncSucceededFlow: MutableStateFlow<Boolean> = MutableStateFlow(false)
 
     // インタースティシャル広告の頻度判定用。永続化せずプロセス内のみ保持する
@@ -74,7 +74,7 @@ class PixiViewViewModel(
         val setting = flows[0] as Setting
         val sessionId = flows[1] as String?
         val downloadState = flows[2] as DownloadState
-        val fanboxMetadata = flows[3] as FanboxMetaData
+        val fanboxMetadata = flows[3] as MetaData
         val isLoggedIn = flows[4] as Boolean
         val isAppLocked = flows[5] as Boolean
         val isBillingSyncSucceeded = flows[6] as Boolean
@@ -276,7 +276,7 @@ private const val INTERSTITIAL_AD_COOLDOWN_SECONDS = 180L
 data class MainUiState(
     val setting: Setting,
     val sessionId: String,
-    val fanboxMetadata: FanboxMetaData,
+    val fanboxMetadata: MetaData,
     val downloadState: DownloadState,
     val isLoggedIn: Boolean,
     val isAppLocked: Boolean,


### PR DESCRIPTION
Closes #137
base: #152（**#151 → #152 → この PR の順に merge する必要がある**）

`FanboxRepository` の公開契約と全呼び出し元を、#152 が追加したアプリ所有のモデルへ置き換える。設計と delta spec は #151 の `openspec/changes/replace-fankt-models-with-app-owned/` にある。

担当は tasks.md のセクション 4（公開契約の置き換え）/ 5（永続化の非退行）/ 6（検証とドキュメント）。

ドキュメント影響: あり（`README.md` の Architecture 節）

## 受け入れ条件の達成状況

```
$ grep -rn "me.matsumo.fankt.fanbox.domain" --include="*.kt" feature core/ui core/model shared
(ゼロ件)
```

`me.matsumo.fankt` の参照が残るのは次の 2 箇所だけで、どちらも design.md の Non-Goals に挙げた対象外である。

| 残存箇所 | 型 | 対象外の理由 |
| --- | --- | --- |
| `core/model/.../FanboxErrorKind.kt:12` | `FanboxException` | 例外の契約。`fanbox-error-classification` が既に規定している |
| `feature/welcome/.../WebViewCookieConverter.kt:3` | `FanboxCookieRecord` | cookie の基盤契約。domain model ではない |
| `FanboxRepository.setCookies` の引数 | `FanboxCookieRecord` | 同上。レビュー対応中に自分で見つけた 3 件目 |

`core/datastore` の 11 ファイルも fankt を参照し続ける（cookie / session と、ブックマークの保存形式）。

## `core/datastore` を変更していない

```
$ git diff --stat feature/app-owned-fanbox-models-defs..HEAD -- core/datastore
(空)
```

ブックマークは `BookmarkDataStore` が `Json.encodeToString(FanboxPost.serializer(), post)` で fankt の型を丸ごと保存している。保存形式を変えると既存ユーザーのブックマークが読めなくなるため、`FanboxRepositoryImpl` が境界で相互変換する。

```kotlin
override suspend fun getBookmarkedPosts(): List<Post> = withContext(ioDispatcher) {
    bookmarkDataStore.get().map { it.toPost() }
}

override suspend fun bookmarkPost(post: Post) = withContext(ioDispatcher) {
    bookmarkDataStore.save(post.toFanboxPost())
}
```

## 検証結果

すべて HEAD `008b6e89` で実施。

```
./gradlew detekt test \
          :core:repository:testAndroidHostTest :core:model:testAndroidHostTest \
          :core:ui:testAndroidHostTest \
          :core:repository:compileKotlinIosSimulatorArm64 \
          :shared:compileKotlinIosSimulatorArm64 \
          :androidApp:assembleRelease
→ BUILD SUCCESSFUL in 1m 3s
```

集約 `test` タスクは KMP モジュールの host test を含まないため、`testAndroidHostTest` を明示的に並べている（下記の発見事項を参照）。

### テスト（75 件 / failures 0 / errors 0）

| module | 件数 |
| --- | --- |
| `core/repository` | 43 |
| `core/ui` | 16 |
| `core/model` | 16 |

このうち本 PR が追加したのは 5 件である。

| tasks | テスト名 | 何を防ぐか |
| --- | --- | --- |
| 5.2 | `BookmarkPersistenceCompatibilityTest.storedBookmarkJsonIsReadableAsAppOwnedPost` | 保存済み JSON が読めなくなること |
| 5.3 | `BookmarkPersistenceCompatibilityTest.writingBackAnAppOwnedPostKeepsTheStoredJsonFormat` | 書き戻した JSON の形が変わること |
| 5.4 | `BookmarkPersistenceCompatibilityTest.storedBlockedCreatorsAreReadableAsAppOwnedIds` | ブロック設定が読めなくなること |
| 5.5 | `NavTypesTest.postIdNavTypeEncodesTheRawValue` / `creatorIdNavTypeEncodesTheRawValue` | 既存リンクが解決できなくなること |

5.3 は**保存済み JSON の文字列リテラルと、往復後に再符号化した JSON が完全一致する**ことを確認している。手書きのリテラルが一発で一致したことが、保存形式が変わっていないことの直接の証拠になる。

## 置き換えの方法

型名の対応が機械的（`FanboxPost` → `Post`）なので、識別子と package を一括置換したうえでコンパイラに残りを潰させた。

`core/repository/mapper/`、`core/repository` の変換テスト、`core/datastore` は置換の対象から除外している。

### 型の差し替え以外に手を入れた 1 箇所

`bookmarkedPostsIds` と `blockedCreators` は、置き換え前は datastore の `SharedFlow` をそのまま公開していた。

```kotlin
override val bookmarkedPostsIds: SharedFlow<List<FanboxPostId>> = bookmarkDataStore.data
```

要素の型を変えるには `map` が要り、`map` は `Flow` を返すので `SharedFlow` へ戻す必要がある。

```kotlin
override val bookmarkedPostsIds: SharedFlow<List<PostId>> = bookmarkDataStore.data
    .map { ids -> ids.map { it.toPostId() } }
    .shareIn(scope, SharingStarted.Eagerly, replay = 1)
```

`bookmarkDataStore.data` は `MutableSharedFlow(replay = 1)` なので、`replay = 1` の `shareIn` で購読側の見え方は変わらない。`scope` は既存の `CoroutineScope(SupervisorJob() + ioDispatcher)` である。

これは型変更に伴う必然だが、「ロジックには触れていない」という当初の記述が正確ではなかったため明記する。

## #152 へ差し戻した修正

置き換えの途中で、#152 のモデル定義に欠落が 1 件見つかった。**下段の branch（#152）で直して、この branch を追随させている。**

### アプリ所有の ID に `@Serializable` が無かった

`Destination`（navigation の route）は `@Serializable` で `PostId` / `CreatorId` を保持するため、value class 側に serializer が要る。fankt の ID はすべて `@Serializable` を持っており、写しから漏れていた。7 種すべてに付けた（#152 の commit `c5eda413`）。

コンパイルエラーとして出るため実行時には至らないが、`core/model` のコンパイル時点で止まる。

## レビューで閉じた指摘

独立レビューで must-fix は 0 件だった。should が 2 件出て、うち 1 件は下段（#152）の担当なのでそちらで閉じている。

### 翻訳ヘルパの名前が実装と食い違っていた（should）

`toFanboxPostDetail` / `toFanboxComments` は、置き換え後はアプリ所有の `PostDetail` / `PageOffsetInfo<Comment>` を受けて同じ型を返す。fankt 型は関わらない。**この PR の変更によって名前が嘘になった**ため、`toTranslatedPostDetail` / `toTranslatedComments` へ改名した。

`toPostDetail` にはしていない。`core/repository/mapper` の `FanboxPostDetail.toPostDetail()` と受け手だけが違う同名関数になり、読み手が取り違えるため。

### 変換のテストが 4 本しか無かった（should、#152 で対応）

分岐やループを持つ 4 本（`Bell` / `Comment` / `MetaData` / `CreatorPlanDetail`）にテストを追加した。加えて、真偽値が 6 つ並ぶ `MetaData` については値を並べる形では入れ替えを検出できないことが分かり、1 つだけ立てて確認する形へ変えている。詳細は #152 を参照。

## レビューで閉じた指摘（2 巡目）

### README が残存する fankt 境界を正確に書いていなかった（P2）

指摘は妥当だった。「`core/datastore` is the one other place that holds fankt types」は現 HEAD と一致しない。`core/model/FanboxErrorKind.kt` と `feature/welcome/WebViewCookieConverter.kt` も fankt 型を参照し続ける。

datastore は永続化の境界であることだけを述べ、モデルでない契約（例外・cookie と session・エントリポイント）は必要な場所でそのまま fankt から来ることを別段落にした。画面層から fankt が完全に消えたようには読めない形にしている。

同根の誤りが delta spec の Requirement 1 にもあり、そちらは #151 で直した。

## 人間に確認してほしいこと

| # | 帰属 | 内容 |
| --- | --- | --- |
| 1 | agent 仮決め | `FanboxDownloadItems.RequestType.Post` を `WholePost` へ改名した。`val post: Post?` を持つため、app 型を `Post` にすると入れ子クラス自身へ解決されてフィールドの型が書けない |
| 2 | agent 仮決め | 一括置換 + コンパイラでの検出という方法を採った。型名が一意（`FanboxPost` と `Post`）なので取り違えはコンパイルで止まるが、**ロジックの意図的な変更が無いことは diff のレビューに依っている** |
| 3 | 高リスク・要人間確認 | **画面の実機動作は未確認である。** 68 件のテストと両プラットフォームのコンパイル、リリースビルドまでは通っているが、投稿一覧・投稿詳細・クリエイター詳細が実際に描画されることは確認していない。93 ファイルの置換であり、`@Immutable` の付与による recomposition の挙動変化も含みうる |
| 4 | agent 仮決め | `core/model` は `FanboxException` のために fankt を参照し続けるため、`build.gradle.kts` の `api(libs.fankt.fanbox)` は残した（下記の発見事項も参照） |

## 発見事項（この PR では修正していない）

いずれも受け入れ条件にも設計決定にも紐付かないため触っていない。

1. **集約 `test` タスクが KMP モジュールの `testAndroidHostTest` を含まない。** `./gradlew test` の結果に `core/model` のテスト 16 件が現れず、`:core:model:testAndroidHostTest` を明示的に実行して初めて走った。CI は detekt のみを回すため、これらのテストは現状ローカル実行に依っている
2. **`core/model` の fankt 依存は `implementation` で足りる。** `FanboxErrorKind.kt` の `FanboxException` は関数本体と KDoc でのみ使われ、public シグネチャには現れない。`api` から下げられるが、他モジュールが推移的な公開に依存している可能性があるため本 PR では触っていない
3. **`detekt --auto-correct` がこのプロジェクトで有効に働く。** 一括置換で崩れた import 順 73 件はこれで解消した。Gradle 設定の `autoCorrect` は既定 false だが、CLI オプションは効く
