### PR TITLE
Fill in archived spec purposes and narrow core:model's fankt dependency

### DIFF
--- a/core/model/build.gradle.kts
+++ b/core/model/build.gradle.kts
@@ -22,7 +22,7 @@ kotlin {
             implementation(compose.components.resources)
             implementation(libs.ktor.core)
 
-            api(libs.fankt.fanbox)
+            implementation(libs.fankt.fanbox)
         }
 
         commonTest.dependencies {

--- a/openspec/specs/fanbox-error-classification/spec.md
+++ b/openspec/specs/fanbox-error-classification/spec.md
@@ -1,7 +1,7 @@
 # fanbox-error-classification Specification
 
 ## Purpose
-TBD - created by archiving change classify-fanbox-errors. Update Purpose after archive.
+画面のエラー状態へ変換される FANBOX API の失敗の分類を規定する。認証切れからその他までの 8 種別への振り分け、種別ごとの表示文言、および分類を持たない従来のエラー表示が変わらず成立することを扱う。
 ## Requirements
 ### Requirement: 画面のエラー状態に変換される FANBOX API の失敗を種別ごとに分類する
 

--- a/openspec/specs/fanbox-guest-route/spec.md
+++ b/openspec/specs/fanbox-guest-route/spec.md
@@ -1,7 +1,7 @@
 # fanbox-guest-route Specification
 
 ## Purpose
-TBD - created by archiving change enable-zipline-guest-route. Update Purpose after archive.
+配信された Zipline guest bundle で投稿詳細の取得を処理する経路を規定する。配信先と信頼する公開鍵を fankt へ渡す条件、developer mode による配信チャンネルの選択、配信先へ到達できない場合に直接経路へ退避すること、Remote Config から guest の実行を遠隔で停止できること、および遠隔から解析処理を取得する旨の README への記載を扱う。
 ## Requirements
 ### Requirement: 投稿詳細の取得に配信済み guest を使う
 

--- a/openspec/specs/fanbox-list-tolerance/spec.md
+++ b/openspec/specs/fanbox-list-tolerance/spec.md
@@ -1,7 +1,7 @@
 # fanbox-list-tolerance Specification
 
 ## Purpose
-TBD - created by archiving change adopt-tolerant-list-callbacks. Update Purpose after archive.
+FANBOX の list API の応答が一部の項目だけスキーマに一致しない場合の扱いを規定する。デコードできた項目を成功として返し全体を失敗させないこと、およびスキップの発生を画面に表示しないことを扱う。
 ## Requirements
 ### Requirement: 支援プラン一覧は部分的なスキーマ不一致で全体が失敗しない
 

--- a/openspec/specs/fanbox-schema-diagnostics/spec.md
+++ b/openspec/specs/fanbox-schema-diagnostics/spec.md
@@ -1,7 +1,7 @@
 # fanbox-schema-diagnostics Specification
 
 ## Purpose
-TBD - created by archiving change adopt-tolerant-list-callbacks. Update Purpose after archive.
+スキーマ不一致でスキップされた項目を観測する手段を規定する。ログとクラッシュレポート基盤への記録、送る内容をエンドポイント識別子と項目位置に限ること、およびリリースビルドで応答本文の断片を出力しないことを扱う。
 ## Requirements
 ### Requirement: スキーマ不一致の発生を観測できる
 

--- a/openspec/specs/fanbox-session-recovery/spec.md
+++ b/openspec/specs/fanbox-session-recovery/spec.md
@@ -1,7 +1,7 @@
 # fanbox-session-recovery Specification
 
 ## Purpose
-TBD - created by archiving change classify-fanbox-errors. Update Purpose after archive.
+FANBOX API の認証切れからの復帰を規定する。ログイン済み状態を解除して再ログイン画面へ導くこと、認証切れ以外の失敗では導かないこと、および同時に複数の認証切れを受け取っても遷移が重複しないことを扱う。
 ## Requirements
 ### Requirement: 認証切れを検知したら再ログインへ導く
 


### PR DESCRIPTION
#137（PR #151 / #155 / #153 / #154）の follow-up。受け入れ条件に紐付かなかったため本体から外した 2 件を回収する。

ドキュメント影響: なし（README は fankt との境界を説明しているが、module の依存可視性には触れていないため更新不要）

## 1. archive 済み spec の Purpose を書く

`openspec archive` が生成する `TBD - created by archiving change <name>. Update Purpose after archive.` が 5 spec に残っていた。何を扱う capability なのかを知るには Requirement を全部読む必要があり、`openspec/specs/` を index として使えない。

#154 のレビューで `app-owned-fanbox-models` の Purpose を書いた際に、既存 5 件も同根であることを報告していた分。

| spec | Purpose の要旨 |
| --- | --- |
| `fanbox-guest-route` | 配信された guest bundle で投稿詳細を取得する経路。鍵の受け渡し、チャンネル選択、直接経路への退避、遠隔停止、README への記載 |
| `fanbox-list-tolerance` | list API の一部の項目がスキーマ不一致な場合の扱い |
| `fanbox-error-classification` | 画面のエラー状態へ変換される失敗の 8 種別への分類と文言 |
| `fanbox-schema-diagnostics` | スキップされた項目の観測手段と、送る内容の制限 |
| `fanbox-session-recovery` | 認証切れからの復帰と、遷移の重複防止 |

Requirement / Scenario は 1 文字も変えていない。差分は各ファイル 1 行。

## 2. `core:model` の fankt 依存を `implementation` へ

`core/model` は `api(libs.fankt.fanbox)` を宣言していたが、fankt の参照は `FanboxErrorKind.kt` の 1 ファイルだけで、しかも `toFanboxErrorKind()` の本体（`is FanboxException.SchemaMismatch` などの分岐）と KDoc にしか現れない。`Throwable.toFanboxErrorKind(): FanboxErrorKind` の signature に fankt 型は無いため、public contract に載せる理由が無い。

`api` を消すと `core:model` 経由で fankt が透過しなくなる。ビルドは通っており、`core:repository` は `core:datastore` の `api(libs.fankt.fanbox)` から、`feature/welcome` も同じ経路から `FanboxCookieRecord` を解決している。

### これは境界の enforcement ではない

`core:datastore` は `BookmarkDataStore.save(FanboxPost)` などで fankt 型を public API に出しているため `api` が必須で、`core:datastore` に依存する 11 module（`core:billing` / `core:repository` / `core:ui` / `feature/*` 6 つ / `shared`）へ fankt は透過し続ける。

つまり `app-owned-fanbox-models` の「`feature/*` は fankt の domain model を参照してはならない」は、この PR の後も build graph では守られない。この変更の効果は「露出しないものを宣言しない」という依存宣言の正しさに限る。

enforcement が必要なら detekt の禁止 import で静的解析側に置くのが妥当だが、それは #137 の受け入れ条件外の新規提案なので本 PR には含めていない。

## 検証結果

すべて HEAD `ae17fb20` で実施。

```
openspec validate --all --strict
→ 6 passed, 0 failed

./gradlew detekt testAndroidHostTest \
          :core:repository:compileKotlinIosSimulatorArm64 \
          :shared:compileKotlinIosSimulatorArm64 assembleRelease
→ BUILD SUCCESSFUL
```

`testAndroidHostTest` は 184 件 / failures 0 / errors 0。`assembleRelease` を含めたのは、`api` → `implementation` が R8 の到達可能性に影響しないことを確認するため。

最小チェックの追加は無い。1 の差分は Markdown のみ、2 の差分は依存宣言のみで、後者の壊れ方は「コンパイルが通らない」であり上記のビルドが検出する。

## 人間に確認してほしいこと

| # | 帰属 | 内容 |
| --- | --- | --- |
| 1 | agent 仮決め | 2 の効果は依存宣言の正しさに限り、境界の enforcement にはならない（上記）。enforcement を求めるなら別 change が必要 |
| 2 | agent 仮決め | `feature/welcome` は `FanboxCookieRecord` を `core:datastore` の `api` から透過で受け取り続ける。自前で `libs.fankt.fanbox` を宣言する形にはしていない（受け入れ条件外のため） |
| 3 | agent 仮決め | 1 は既存 spec の Purpose を agent の読解で書いたもの。Requirement の要旨として妥当かを確認してほしい |